### PR TITLE
Add Codex compatibility with runtime-agnostic agent/session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A VS Code extension that turns your AI coding agents into animated pixel art characters in a virtual office.
 
-Each Claude Code terminal you open spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
+Each agent terminal you open (Claude Code or Codex) spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
 
 This is the source code for the free [Pixel Agents extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) — you can install it directly from the marketplace with the full furniture catalog included.
 
@@ -11,7 +11,7 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 
 ## Features
 
-- **One agent, one character** — every Claude Code terminal gets its own animated character
+- **One agent, one character** — every supported agent terminal gets its own animated character
 - **Live activity tracking** — characters animate based on what the agent is actually doing (writing, reading, running commands)
 - **Office layout editor** — design your office with floors, walls, and furniture using a built-in editor
 - **Speech bubbles** — visual indicators when an agent is waiting for input or needs permission
@@ -27,7 +27,7 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 ## Requirements
 
 - VS Code 1.109.0 or later
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) and/or Codex CLI installed and configured
 
 ## Getting Started
 
@@ -48,8 +48,8 @@ Then press **F5** in VS Code to launch the Extension Development Host.
 ### Usage
 
 1. Open the **Pixel Agents** panel (it appears in the bottom panel area alongside your terminal)
-2. Click **+ Agent** to spawn a new Claude Code terminal and its character
-3. Start coding with Claude — watch the character react in real time
+2. Click **+ Agent** to spawn a terminal and character (default runtime is configurable in **Settings**)
+3. Start coding with your selected agent runtime — watch the character react in real time
 4. Click a character to select it, then click a seat to reassign it
 5. Click **Layout** to open the office editor and customize your space
 
@@ -81,7 +81,7 @@ The extension will still work without the tileset — you'll get the default cha
 
 ## How It Works
 
-Pixel Agents watches Claude Code's JSONL transcript files to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to Claude Code are needed — it's purely observational.
+Pixel Agents watches local JSONL transcript files to track what each agent is doing. For Claude Code, it watches files under `~/.claude/projects/...`; for Codex, it watches files under `~/.codex/sessions/...`. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly.
 
 The webview runs a lightweight game loop with canvas rendering, BFS pathfinding, and a character state machine (idle → walk → type/read). Everything is pixel-perfect at integer zoom levels.
 
@@ -94,6 +94,7 @@ The webview runs a lightweight game loop with canvas rendering, BFS pathfinding,
 
 - **Agent-terminal sync** — the way agents are connected to Claude Code terminal instances is not super robust and sometimes desyncs, especially when terminals are rapidly opened/closed or restored across sessions.
 - **Heuristic-based status detection** — Claude Code's JSONL transcript format does not provide clear signals for when an agent is waiting for user input or when it has finished its turn. The current detection is based on heuristics (idle timers, turn-duration events) and often misfires — agents may briefly show the wrong status or miss transitions.
+- **Codex support is first-pass** — Codex tool activity and turn-end waiting are supported, but Codex-specific sub-agent/permission heuristics are not yet fully implemented.
 - **Windows-only testing** — the extension has only been tested on Windows 11. It may work on macOS or Linux, but there could be unexpected issues with file watching, paths, or terminal behavior on those platforms.
 
 ## Roadmap

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import type { AgentState } from './types.js';
+import type { AgentRuntime, AgentState } from './types.js';
 import {
 	launchNewTerminal,
 	removeAgent,
@@ -13,8 +13,10 @@ import {
 	getProjectDirPath,
 } from './agentManager.js';
 import { ensureProjectScan } from './fileWatcher.js';
+import type { ProjectScanState } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
-import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
+import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED, GLOBAL_KEY_DEFAULT_RUNTIME } from './constants.js';
+import { DEFAULT_AGENT_RUNTIME, normalizeAgentRuntime } from './runtime.js';
 import { writeLayoutToFile, readLayoutFromFile, watchLayoutFile } from './layoutPersistence.js';
 import type { LayoutWatcher } from './layoutPersistence.js';
 
@@ -31,16 +33,31 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 	jsonlPollTimers = new Map<number, ReturnType<typeof setInterval>>();
 	permissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
-	// /clear detection: project-level scan for new JSONL files
+	// /clear / codex new-session detection
 	activeAgentId = { current: null as number | null };
-	knownJsonlFiles = new Set<string>();
-	projectScanTimer = { current: null as ReturnType<typeof setInterval> | null };
+	knownJsonlFilesByRuntime: Record<AgentRuntime, Set<string>> = {
+		claude: new Set<string>(),
+		codex: new Set<string>(),
+	};
+	projectScanStates: Record<AgentRuntime, ProjectScanState> = {
+		claude: {
+			current: null,
+			runtime: 'claude',
+			projectDir: null,
+		},
+		codex: {
+			current: null,
+			runtime: 'codex',
+			projectDir: null,
+		},
+	};
 
 	// Bundled default layout (loaded from assets/default-layout.json)
 	defaultLayout: Record<string, unknown> | null = null;
 
 	// Cross-window layout sync
 	layoutWatcher: LayoutWatcher | null = null;
+	defaultRuntime: AgentRuntime = DEFAULT_AGENT_RUNTIME;
 
 	constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -62,12 +79,16 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 		webviewView.webview.html = getWebviewContent(webviewView.webview, this.extensionUri);
 
 		webviewView.webview.onDidReceiveMessage(async (message) => {
-			if (message.type === 'openClaude') {
-				await launchNewTerminal(
+			if (message.type === 'openAgent' || message.type === 'openClaude') {
+				const requestedRuntime = message.type === 'openClaude'
+					? 'claude'
+					: normalizeAgentRuntime(message.runtime ?? this.defaultRuntime);
+				launchNewTerminal(
+					requestedRuntime,
 					this.nextAgentId, this.nextTerminalIndex,
-					this.agents, this.activeAgentId, this.knownJsonlFiles,
+					this.agents, this.activeAgentId, this.knownJsonlFilesByRuntime[requestedRuntime],
 					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
-					this.jsonlPollTimers, this.projectScanTimer,
+					this.jsonlPollTimers, this.projectScanStates[requestedRuntime],
 					this.webview, this.persistAgents,
 					message.folderPath as string | undefined,
 				);
@@ -90,18 +111,24 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				writeLayoutToFile(message.layout as Record<string, unknown>);
 			} else if (message.type === 'setSoundEnabled') {
 				this.context.globalState.update(GLOBAL_KEY_SOUND_ENABLED, message.enabled);
+			} else if (message.type === 'setDefaultRuntime') {
+				this.defaultRuntime = normalizeAgentRuntime(message.runtime);
+				this.context.globalState.update(GLOBAL_KEY_DEFAULT_RUNTIME, this.defaultRuntime);
 			} else if (message.type === 'webviewReady') {
+				this.defaultRuntime = normalizeAgentRuntime(
+					this.context.globalState.get<string>(GLOBAL_KEY_DEFAULT_RUNTIME, DEFAULT_AGENT_RUNTIME),
+				);
 				restoreAgents(
 					this.context,
 					this.nextAgentId, this.nextTerminalIndex,
-					this.agents, this.knownJsonlFiles,
+					this.agents, this.knownJsonlFilesByRuntime,
 					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
-					this.jsonlPollTimers, this.projectScanTimer, this.activeAgentId,
+					this.jsonlPollTimers, this.projectScanStates, this.activeAgentId,
 					this.webview, this.persistAgents,
 				);
 				// Send persisted settings to webview
 				const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
-				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
+				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled, defaultRuntime: this.defaultRuntime });
 
 				// Send workspace folders to webview (only when multi-root)
 				const wsFolders = vscode.workspace.workspaceFolders;
@@ -113,13 +140,17 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				}
 
 				// Ensure project scan runs even with no restored agents (to adopt external terminals)
-				const projectDir = getProjectDirPath();
+				const projectDir = getProjectDirPath(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath, this.defaultRuntime);
 				const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 				console.log('[Extension] workspaceRoot:', workspaceRoot);
 				console.log('[Extension] projectDir:', projectDir);
 				if (projectDir) {
 					ensureProjectScan(
-						projectDir, this.knownJsonlFiles, this.projectScanTimer, this.activeAgentId,
+						this.defaultRuntime,
+						projectDir,
+						this.knownJsonlFilesByRuntime[this.defaultRuntime],
+						this.projectScanStates[this.defaultRuntime],
+						this.activeAgentId,
 						this.nextAgentId, this.agents,
 						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 						this.webview, this.persistAgents,
@@ -225,7 +256,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				}
 				sendExistingAgents(this.agents, this.context, this.webview);
 			} else if (message.type === 'openSessionsFolder') {
-				const projectDir = getProjectDirPath();
+				const runtime = normalizeAgentRuntime(message.runtime ?? this.defaultRuntime);
+				const projectDir = getProjectDirPath(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath, runtime);
 				if (projectDir && fs.existsSync(projectDir)) {
 					vscode.env.openExternal(vscode.Uri.file(projectDir));
 				}
@@ -331,9 +363,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				this.jsonlPollTimers, this.persistAgents,
 			);
 		}
-		if (this.projectScanTimer.current) {
-			clearInterval(this.projectScanTimer.current);
-			this.projectScanTimer.current = null;
+		for (const runtime of Object.keys(this.projectScanStates) as AgentRuntime[]) {
+			const state = this.projectScanStates[runtime];
+			if (!state.current) continue;
+			clearInterval(state.current);
+			state.current = null;
+			state.projectDir = null;
 		}
 	}
 }

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -1,23 +1,58 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import * as vscode from 'vscode';
-import type { AgentState, PersistedAgent } from './types.js';
+import type { AgentRuntime, AgentState, PersistedAgent } from './types.js';
 import { cancelWaitingTimer, cancelPermissionTimer } from './timerManager.js';
 import { startFileWatching, readNewLines, ensureProjectScan } from './fileWatcher.js';
-import { JSONL_POLL_INTERVAL_MS, TERMINAL_NAME_PREFIX, WORKSPACE_KEY_AGENTS, WORKSPACE_KEY_AGENT_SEATS } from './constants.js';
+import type { ProjectScanState } from './fileWatcher.js';
+import { JSONL_POLL_INTERVAL_MS, WORKSPACE_KEY_AGENTS, WORKSPACE_KEY_AGENT_SEATS } from './constants.js';
 import { migrateAndLoadLayout } from './layoutPersistence.js';
+import {
+	DEFAULT_AGENT_RUNTIME,
+	normalizeAgentRuntime,
+	getProjectDirPathForRuntime,
+	getClaudeSessionsRootPath,
+	getRuntimeLaunchCommand,
+	getTerminalNamePrefix,
+} from './runtime.js';
 
-export function getProjectDirPath(cwd?: string): string | null {
-	const workspacePath = cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-	if (!workspacePath) return null;
-	const dirName = workspacePath.replace(/[^a-zA-Z0-9-]/g, '-');
-	const projectDir = path.join(os.homedir(), '.claude', 'projects', dirName);
-	console.log(`[Pixel Agents] Project dir: ${workspacePath} → ${dirName}`);
-	return projectDir;
+function createAgentState(
+	id: number,
+	runtime: AgentRuntime,
+	terminalRef: vscode.Terminal,
+	projectDir: string,
+	jsonlFile: string,
+	pendingSessionId?: string,
+	folderName?: string,
+): AgentState {
+	return {
+		id,
+		runtime,
+		pendingSessionId,
+		terminalRef,
+		projectDir,
+		jsonlFile,
+		fileOffset: 0,
+		lineBuffer: '',
+		activeToolIds: new Set(),
+		activeToolStatuses: new Map(),
+		activeToolNames: new Map(),
+		activeToolCallToName: new Map(),
+		activeSubagentToolIds: new Map(),
+		activeSubagentToolNames: new Map(),
+		isWaiting: false,
+		permissionSent: false,
+		hadToolsInTurn: false,
+		folderName,
+	};
 }
 
-export async function launchNewTerminal(
+export function getProjectDirPath(cwd?: string, runtime: AgentRuntime = DEFAULT_AGENT_RUNTIME): string | null {
+	return getProjectDirPathForRuntime(runtime, cwd);
+}
+
+export function launchNewTerminal(
+	runtime: AgentRuntime,
 	nextAgentIdRef: { current: number },
 	nextTerminalIndexRef: { current: number },
 	agents: Map<number, AgentState>,
@@ -28,78 +63,87 @@ export async function launchNewTerminal(
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
-	projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
+	projectScanStateRef: ProjectScanState,
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
 	folderPath?: string,
-): Promise<void> {
+): void {
 	const folders = vscode.workspace.workspaceFolders;
 	const cwd = folderPath || folders?.[0]?.uri.fsPath;
 	const isMultiRoot = !!(folders && folders.length > 1);
 	const idx = nextTerminalIndexRef.current++;
 	const terminal = vscode.window.createTerminal({
-		name: `${TERMINAL_NAME_PREFIX} #${idx}`,
+		name: `${getTerminalNamePrefix(runtime)} #${idx}`,
 		cwd,
 	});
 	terminal.show();
 
 	const sessionId = crypto.randomUUID();
-	terminal.sendText(`claude --session-id ${sessionId}`);
+	terminal.sendText(getRuntimeLaunchCommand(runtime, cwd, sessionId));
 
-	const projectDir = getProjectDirPath(cwd);
+	const projectDir = getProjectDirPath(cwd, runtime) ?? (runtime === 'claude' ? getClaudeSessionsRootPath() : null);
 	if (!projectDir) {
-		console.log(`[Pixel Agents] No project dir, cannot track agent`);
+		console.log(`[Pixel Agents] No project dir for runtime ${runtime}, cannot track agent`);
 		return;
 	}
 
-	// Pre-register expected JSONL file so project scan won't treat it as a /clear file
-	const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);
-	knownJsonlFiles.add(expectedFile);
+	let jsonlFile = '';
+	if (runtime === 'claude' && cwd) {
+		// Pre-register expected JSONL file so project scan won't treat it as a /clear file.
+		jsonlFile = path.join(projectDir, `${sessionId}.jsonl`);
+		knownJsonlFiles.add(jsonlFile);
+	}
 
-	// Create agent immediately (before JSONL file exists)
 	const id = nextAgentIdRef.current++;
 	const folderName = isMultiRoot && cwd ? path.basename(cwd) : undefined;
-	const agent: AgentState = {
+	const agent = createAgentState(
 		id,
-		terminalRef: terminal,
+		runtime,
+		terminal,
 		projectDir,
-		jsonlFile: expectedFile,
-		fileOffset: 0,
-		lineBuffer: '',
-		activeToolIds: new Set(),
-		activeToolStatuses: new Map(),
-		activeToolNames: new Map(),
-		activeSubagentToolIds: new Map(),
-		activeSubagentToolNames: new Map(),
-		isWaiting: false,
-		permissionSent: false,
-		hadToolsInTurn: false,
+		jsonlFile,
+		runtime === 'claude' ? sessionId : undefined,
 		folderName,
-	};
-
+	);
 	agents.set(id, agent);
 	activeAgentIdRef.current = id;
 	persistAgents();
-	console.log(`[Pixel Agents] Agent ${id}: created for terminal ${terminal.name}`);
+	console.log(`[Pixel Agents] Agent ${id}: created for terminal ${terminal.name} (runtime=${runtime})`);
 	webview?.postMessage({ type: 'agentCreated', id, folderName });
 
 	ensureProjectScan(
-		projectDir, knownJsonlFiles, projectScanTimerRef, activeAgentIdRef,
-		nextAgentIdRef, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-		webview, persistAgents,
+		runtime,
+		projectDir,
+		knownJsonlFiles,
+		projectScanStateRef,
+		activeAgentIdRef,
+		nextAgentIdRef,
+		agents,
+		fileWatchers,
+		pollingTimers,
+		waitingTimers,
+		permissionTimers,
+		webview,
+		persistAgents,
 	);
 
-	// Poll for the specific JSONL file to appear
+	if (runtime !== 'claude' || !agent.jsonlFile) {
+		return;
+	}
+
+	// Claude only: poll for the specific JSONL file to appear.
 	const pollTimer = setInterval(() => {
 		try {
-			if (fs.existsSync(agent.jsonlFile)) {
+			if (agent.jsonlFile && fs.existsSync(agent.jsonlFile)) {
 				console.log(`[Pixel Agents] Agent ${id}: found JSONL file ${path.basename(agent.jsonlFile)}`);
 				clearInterval(pollTimer);
 				jsonlPollTimers.delete(id);
 				startFileWatching(id, agent.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
 				readNewLines(id, agents, waitingTimers, permissionTimers, webview);
 			}
-		} catch { /* file may not exist yet */ }
+		} catch {
+			// File may not exist yet.
+		}
 	}, JSONL_POLL_INTERVAL_MS);
 	jsonlPollTimers.set(id, pollTimer);
 }
@@ -117,24 +161,24 @@ export function removeAgent(
 	const agent = agents.get(agentId);
 	if (!agent) return;
 
-	// Stop JSONL poll timer
 	const jpTimer = jsonlPollTimers.get(agentId);
-	if (jpTimer) { clearInterval(jpTimer); }
+	if (jpTimer) {
+		clearInterval(jpTimer);
+	}
 	jsonlPollTimers.delete(agentId);
 
-	// Stop file watching
 	fileWatchers.get(agentId)?.close();
 	fileWatchers.delete(agentId);
 	const pt = pollingTimers.get(agentId);
-	if (pt) { clearInterval(pt); }
+	if (pt) {
+		clearInterval(pt);
+	}
 	pollingTimers.delete(agentId);
 	try { fs.unwatchFile(agent.jsonlFile); } catch { /* ignore */ }
 
-	// Cancel timers
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 
-	// Remove from maps
 	agents.delete(agentId);
 	persistAgents();
 }
@@ -147,6 +191,7 @@ export function persistAgents(
 	for (const agent of agents.values()) {
 		persisted.push({
 			id: agent.id,
+			runtime: agent.runtime,
 			terminalName: agent.terminalRef.name,
 			jsonlFile: agent.jsonlFile,
 			projectDir: agent.projectDir,
@@ -161,13 +206,13 @@ export function restoreAgents(
 	nextAgentIdRef: { current: number },
 	nextTerminalIndexRef: { current: number },
 	agents: Map<number, AgentState>,
-	knownJsonlFiles: Set<string>,
+	knownJsonlFilesByRuntime: Record<AgentRuntime, Set<string>>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
-	projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
+	projectScanStateRefs: Record<AgentRuntime, ProjectScanState>,
 	activeAgentIdRef: { current: number | null },
 	webview: vscode.Webview | undefined,
 	doPersist: () => void,
@@ -178,55 +223,39 @@ export function restoreAgents(
 	const liveTerminals = vscode.window.terminals;
 	let maxId = 0;
 	let maxIdx = 0;
-	let restoredProjectDir: string | null = null;
+	const scanTargets = new Map<AgentRuntime, string>();
 
 	for (const p of persisted) {
-		const terminal = liveTerminals.find(t => t.name === p.terminalName);
+		const terminal = liveTerminals.find((t) => t.name === p.terminalName);
 		if (!terminal) continue;
 
-		const agent: AgentState = {
-			id: p.id,
-			terminalRef: terminal,
-			projectDir: p.projectDir,
-			jsonlFile: p.jsonlFile,
-			fileOffset: 0,
-			lineBuffer: '',
-			activeToolIds: new Set(),
-			activeToolStatuses: new Map(),
-			activeToolNames: new Map(),
-			activeSubagentToolIds: new Map(),
-			activeSubagentToolNames: new Map(),
-			isWaiting: false,
-			permissionSent: false,
-			hadToolsInTurn: false,
-			folderName: p.folderName,
-		};
-
+		const runtime = normalizeAgentRuntime(p.runtime);
+		const knownJsonlFiles = knownJsonlFilesByRuntime[runtime];
+		const initialJsonl = runtime === 'codex' ? (p.jsonlFile || '') : p.jsonlFile;
+		const agent = createAgentState(p.id, runtime, terminal, p.projectDir, initialJsonl, undefined, p.folderName);
 		agents.set(p.id, agent);
-		knownJsonlFiles.add(p.jsonlFile);
-		console.log(`[Pixel Agents] Restored agent ${p.id} → terminal "${p.terminalName}"`);
+		if (agent.jsonlFile) {
+			knownJsonlFiles.add(agent.jsonlFile);
+		}
+		console.log(`[Pixel Agents] Restored agent ${p.id} → terminal "${p.terminalName}" (runtime=${runtime})`);
 
 		if (p.id > maxId) maxId = p.id;
-		// Extract terminal index from name like "Claude Code #3"
 		const match = p.terminalName.match(/#(\d+)$/);
 		if (match) {
 			const idx = parseInt(match[1], 10);
 			if (idx > maxIdx) maxIdx = idx;
 		}
+		scanTargets.set(runtime, p.projectDir);
 
-		restoredProjectDir = p.projectDir;
-
-		// Start file watching if JSONL exists, skipping to end of file
 		try {
-			if (fs.existsSync(p.jsonlFile)) {
-				const stat = fs.statSync(p.jsonlFile);
+			if (agent.jsonlFile && fs.existsSync(agent.jsonlFile)) {
+				const stat = fs.statSync(agent.jsonlFile);
 				agent.fileOffset = stat.size;
-				startFileWatching(p.id, p.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
-			} else {
-				// Poll for the file to appear
+				startFileWatching(p.id, agent.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
+			} else if (runtime === 'claude' && agent.jsonlFile) {
 				const pollTimer = setInterval(() => {
 					try {
-						if (fs.existsSync(agent.jsonlFile)) {
+						if (agent.jsonlFile && fs.existsSync(agent.jsonlFile)) {
 							console.log(`[Pixel Agents] Restored agent ${p.id}: found JSONL file`);
 							clearInterval(pollTimer);
 							jsonlPollTimers.delete(p.id);
@@ -234,14 +263,19 @@ export function restoreAgents(
 							agent.fileOffset = stat.size;
 							startFileWatching(p.id, agent.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
 						}
-					} catch { /* file may not exist yet */ }
+					} catch {
+						// File may not exist yet.
+					}
 				}, JSONL_POLL_INTERVAL_MS);
 				jsonlPollTimers.set(p.id, pollTimer);
+			} else if (runtime === 'codex') {
+				agent.jsonlFile = '';
 			}
-		} catch { /* ignore errors during restore */ }
+		} catch {
+			// Ignore errors during restore.
+		}
 	}
 
-	// Advance counters past restored IDs
 	if (maxId >= nextAgentIdRef.current) {
 		nextAgentIdRef.current = maxId + 1;
 	}
@@ -249,15 +283,23 @@ export function restoreAgents(
 		nextTerminalIndexRef.current = maxIdx + 1;
 	}
 
-	// Re-persist cleaned-up list (removes entries whose terminals are gone)
 	doPersist();
 
-	// Start project scan for /clear detection
-	if (restoredProjectDir) {
+	for (const [runtime, projectDir] of scanTargets) {
 		ensureProjectScan(
-			restoredProjectDir, knownJsonlFiles, projectScanTimerRef, activeAgentIdRef,
-			nextAgentIdRef, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-			webview, doPersist,
+			runtime,
+			projectDir,
+			knownJsonlFilesByRuntime[runtime],
+			projectScanStateRefs[runtime],
+			activeAgentIdRef,
+			nextAgentIdRef,
+			agents,
+			fileWatchers,
+			pollingTimers,
+			waitingTimers,
+			permissionTimers,
+			webview,
+			doPersist,
 		);
 	}
 }
@@ -274,7 +316,6 @@ export function sendExistingAgents(
 	}
 	agentIds.sort((a, b) => a - b);
 
-	// Include persisted palette/seatId from separate key
 	const agentMeta = context.workspaceState.get<Record<string, { palette?: number; seatId?: string }>>(WORKSPACE_KEY_AGENT_SEATS, {});
 
 	// Include folderName per agent
@@ -302,7 +343,6 @@ export function sendCurrentAgentStatuses(
 ): void {
 	if (!webview) return;
 	for (const [agentId, agent] of agents) {
-		// Re-send active tools
 		for (const [toolId, status] of agent.activeToolStatuses) {
 			webview.postMessage({
 				type: 'agentToolStart',
@@ -311,7 +351,6 @@ export function sendCurrentAgentStatuses(
 				status,
 			});
 		}
-		// Re-send waiting status
 		if (agent.isWaiting) {
 			webview.postMessage({
 				type: 'agentStatus',

--- a/src/codex/session.ts
+++ b/src/codex/session.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentState } from '../types.js';
+import { CODEX_FIRST_LINE_READ_CHUNK_BYTES, CODEX_FIRST_LINE_READ_MAX_BYTES } from '../constants.js';
+import { listJsonlFilesRecursive } from '../sessionFiles.js';
+
+export function listCodexJsonlFiles(projectDir: string): string[] {
+	return listJsonlFilesRecursive(projectDir);
+}
+
+export function matchesWorkspaceCodexSession(filePath: string, workspaceRoot: string | undefined): boolean {
+	if (!workspaceRoot) return true;
+	const cwd = readCodexSessionCwd(filePath);
+	if (!cwd) return false;
+	return path.resolve(cwd) === path.resolve(workspaceRoot);
+}
+
+export function findPendingCodexAgent(
+	agents: Map<number, AgentState>,
+): AgentState | undefined {
+	return [...agents.values()]
+		.filter((agent) => agent.runtime === 'codex' && !agent.jsonlFile)
+		.sort((a, b) => b.id - a.id)[0];
+}
+
+export function findNewestUnassignedMatchingCodexFile(
+	files: string[],
+	agents: Map<number, AgentState>,
+	workspaceRoot: string | undefined,
+): string | undefined {
+	const assignedFiles = new Set<string>();
+	for (const agent of agents.values()) {
+		if (agent.jsonlFile) {
+			assignedFiles.add(agent.jsonlFile);
+		}
+	}
+
+	let newestFile = '';
+	let newestMtime = -1;
+	for (const file of files) {
+		if (assignedFiles.has(file)) continue;
+		if (!matchesWorkspaceCodexSession(file, workspaceRoot)) continue;
+		try {
+			const stat = fs.statSync(file);
+			if (stat.mtimeMs > newestMtime) {
+				newestMtime = stat.mtimeMs;
+				newestFile = file;
+			}
+		} catch {
+			// Ignore stat failures for transient files.
+		}
+	}
+	return newestFile || undefined;
+}
+
+function readCodexSessionCwd(filePath: string): string | null {
+	let fd: number | undefined;
+	try {
+		fd = fs.openSync(filePath, 'r');
+		let readOffset = 0;
+		let firstLine = '';
+		while (readOffset < CODEX_FIRST_LINE_READ_MAX_BYTES && !firstLine.includes('\n')) {
+			const chunk = Buffer.alloc(CODEX_FIRST_LINE_READ_CHUNK_BYTES);
+			const bytesRead = fs.readSync(fd, chunk, 0, chunk.length, readOffset);
+			if (bytesRead <= 0) break;
+			firstLine += chunk.toString('utf-8', 0, bytesRead);
+			readOffset += bytesRead;
+		}
+		const line = firstLine.split('\n')[0];
+		if (!line.trim()) return null;
+		const record = JSON.parse(line) as { type?: string; payload?: { cwd?: unknown } };
+		if (record.type !== 'session_meta') return null;
+		const cwd = record.payload?.cwd;
+		return typeof cwd === 'string' ? cwd : null;
+	} catch {
+		return null;
+	} finally {
+		if (fd !== undefined) {
+			try {
+				fs.closeSync(fd);
+			} catch {
+				// Ignore close errors.
+			}
+		}
+	}
+}

--- a/src/codex/transcript.ts
+++ b/src/codex/transcript.ts
@@ -1,0 +1,130 @@
+import type * as vscode from 'vscode';
+import type { AgentState } from '../types.js';
+import { TOOL_DONE_DELAY_MS, BASH_COMMAND_DISPLAY_MAX_LENGTH } from '../constants.js';
+import { cancelWaitingTimer, clearAgentActivity } from '../timerManager.js';
+
+export function processCodexRecord(
+	agentId: number,
+	agent: AgentState,
+	record: Record<string, unknown>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+	markAgentWaiting: (
+		agentId: number,
+		agent: AgentState,
+		waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+		permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+		webview: vscode.Webview | undefined,
+	) => void,
+): void {
+	if (record.type === 'response_item') {
+		const payload = record.payload as Record<string, unknown> | undefined;
+		if (!payload) return;
+		const payloadType = payload.type;
+
+		if (payloadType === 'function_call') {
+			const callId = payload.call_id;
+			const toolName = payload.name;
+			if (typeof callId !== 'string' || typeof toolName !== 'string') return;
+
+			const status = formatCodexToolStatus(toolName, payload.arguments);
+			cancelWaitingTimer(agentId, waitingTimers);
+			agent.isWaiting = false;
+			agent.hadToolsInTurn = true;
+			webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+
+			agent.activeToolIds.add(callId);
+			agent.activeToolStatuses.set(callId, status);
+			agent.activeToolNames.set(callId, toolName);
+			agent.activeToolCallToName.set(callId, toolName);
+			webview?.postMessage({
+				type: 'agentToolStart',
+				id: agentId,
+				toolId: callId,
+				status,
+			});
+			return;
+		}
+
+		if (payloadType === 'function_call_output') {
+			const callId = payload.call_id;
+			if (typeof callId !== 'string') return;
+			agent.activeToolIds.delete(callId);
+			agent.activeToolStatuses.delete(callId);
+			agent.activeToolNames.delete(callId);
+			agent.activeToolCallToName.delete(callId);
+			setTimeout(() => {
+				webview?.postMessage({
+					type: 'agentToolDone',
+					id: agentId,
+					toolId: callId,
+				});
+			}, TOOL_DONE_DELAY_MS);
+			if (agent.activeToolIds.size === 0) {
+				agent.hadToolsInTurn = false;
+			}
+			return;
+		}
+
+		if (payloadType === 'message') {
+			const role = payload.role;
+			if (role === 'user') {
+				cancelWaitingTimer(agentId, waitingTimers);
+				clearAgentActivity(agent, agentId, permissionTimers, webview);
+				agent.hadToolsInTurn = false;
+				return;
+			}
+			if (role === 'assistant' && payload.phase === 'final_answer') {
+				markAgentWaiting(agentId, agent, waitingTimers, permissionTimers, webview);
+				return;
+			}
+		}
+		return;
+	}
+
+	if (record.type === 'event_msg') {
+		const payload = record.payload as Record<string, unknown> | undefined;
+		if (!payload) return;
+		if (payload.type === 'task_complete') {
+			markAgentWaiting(agentId, agent, waitingTimers, permissionTimers, webview);
+		}
+	}
+}
+
+function formatCodexToolStatus(toolName: string, rawArguments: unknown): string {
+	if (toolName === 'exec_command') {
+		let cmd = '';
+		if (typeof rawArguments === 'string') {
+			try {
+				const parsed = JSON.parse(rawArguments) as { cmd?: unknown };
+				if (typeof parsed.cmd === 'string') {
+					cmd = parsed.cmd;
+				}
+			} catch {
+				// Ignore parse errors.
+			}
+		}
+		if (!cmd && typeof rawArguments === 'object' && rawArguments !== null) {
+			const argObj = rawArguments as { cmd?: unknown };
+			if (typeof argObj.cmd === 'string') {
+				cmd = argObj.cmd;
+			}
+		}
+		if (cmd) {
+			return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : cmd}`;
+		}
+		return 'Running command';
+	}
+
+	if (toolName === 'parallel') {
+		return 'Running parallel tools';
+	}
+
+	if (toolName.startsWith('mcp__')) {
+		const normalized = toolName.replace(/^mcp__/, '').replace(/__/g, ':');
+		return `Using ${normalized}`;
+	}
+
+	return `Using ${toolName}`;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const PROJECT_SCAN_INTERVAL_MS = 1000;
 export const TOOL_DONE_DELAY_MS = 300;
 export const PERMISSION_TIMER_DELAY_MS = 7000;
 export const TEXT_IDLE_DELAY_MS = 5000;
+export const CODEX_FIRST_LINE_READ_CHUNK_BYTES = 8192;
+export const CODEX_FIRST_LINE_READ_MAX_BYTES = 2 * 1024 * 1024;
 
 // ── Display Truncation ──────────────────────────────────────
 export const BASH_COMMAND_DISPLAY_MAX_LENGTH = 30;
@@ -31,6 +33,7 @@ export const LAYOUT_FILE_POLL_INTERVAL_MS = 2000;
 
 // ── Settings Persistence ────────────────────────────────────
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
+export const GLOBAL_KEY_DEFAULT_RUNTIME = 'pixel-agents.defaultRuntime';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';
@@ -39,4 +42,5 @@ export const COMMAND_EXPORT_DEFAULT_LAYOUT = 'pixel-agents.exportDefaultLayout';
 export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
-export const TERMINAL_NAME_PREFIX = 'Claude Code';
+export const TERMINAL_NAME_PREFIX_CLAUDE = 'Claude Code';
+export const TERMINAL_NAME_PREFIX_CODEX = 'Codex';

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,10 +1,24 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import type { AgentState } from './types.js';
+import type { AgentRuntime, AgentState } from './types.js';
 import { cancelWaitingTimer, cancelPermissionTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
 import { FILE_WATCHER_POLL_INTERVAL_MS, PROJECT_SCAN_INTERVAL_MS } from './constants.js';
+import { getClaudeSessionsRootPath } from './runtime.js';
+import { listJsonlFilesRecursive } from './sessionFiles.js';
+import {
+	findNewestUnassignedMatchingCodexFile,
+	findPendingCodexAgent,
+	listCodexJsonlFiles,
+	matchesWorkspaceCodexSession,
+} from './codex/session.js';
+
+export interface ProjectScanState {
+	current: ReturnType<typeof setInterval> | null;
+	runtime: AgentRuntime | null;
+	projectDir: string | null;
+}
 
 export function startFileWatching(
 	agentId: number,
@@ -55,7 +69,7 @@ export function readNewLines(
 	webview: vscode.Webview | undefined,
 ): void {
 	const agent = agents.get(agentId);
-	if (!agent) return;
+	if (!agent || !agent.jsonlFile) return;
 	try {
 		const stat = fs.statSync(agent.jsonlFile);
 		if (stat.size <= agent.fileOffset) return;
@@ -70,9 +84,8 @@ export function readNewLines(
 		const lines = text.split('\n');
 		agent.lineBuffer = lines.pop() || '';
 
-		const hasLines = lines.some(l => l.trim());
+		const hasLines = lines.some((l) => l.trim());
 		if (hasLines) {
-			// New data arriving — cancel timers (data flowing means agent is still active)
 			cancelWaitingTimer(agentId, waitingTimers);
 			cancelPermissionTimer(agentId, permissionTimers);
 			if (agent.permissionSent) {
@@ -91,9 +104,10 @@ export function readNewLines(
 }
 
 export function ensureProjectScan(
+	runtime: AgentRuntime,
 	projectDir: string,
 	knownJsonlFiles: Set<string>,
-	projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
+	projectScanStateRef: ProjectScanState,
 	activeAgentIdRef: { current: number | null },
 	nextAgentIdRef: { current: number },
 	agents: Map<number, AgentState>,
@@ -104,27 +118,107 @@ export function ensureProjectScan(
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
 ): void {
-	if (projectScanTimerRef.current) return;
-	// Seed with all existing JSONL files so we only react to truly new ones
-	try {
-		const files = fs.readdirSync(projectDir)
-			.filter(f => f.endsWith('.jsonl'))
-			.map(f => path.join(projectDir, f));
-		for (const f of files) {
-			knownJsonlFiles.add(f);
-		}
-	} catch { /* dir may not exist yet */ }
+	if (
+		projectScanStateRef.current &&
+		projectScanStateRef.runtime === runtime &&
+		projectScanStateRef.projectDir === projectDir
+	) {
+		return;
+	}
 
-	projectScanTimerRef.current = setInterval(() => {
+	if (projectScanStateRef.current) {
+		clearInterval(projectScanStateRef.current);
+	}
+	projectScanStateRef.current = null;
+	projectScanStateRef.runtime = runtime;
+	projectScanStateRef.projectDir = projectDir;
+
+	seedKnownJsonlFiles(runtime, projectDir, knownJsonlFiles);
+
+	projectScanStateRef.current = setInterval(() => {
 		scanForNewJsonlFiles(
-			projectDir, knownJsonlFiles, activeAgentIdRef, nextAgentIdRef,
-			agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-			webview, persistAgents,
+			runtime,
+			projectDir,
+			knownJsonlFiles,
+			activeAgentIdRef,
+			nextAgentIdRef,
+			agents,
+			fileWatchers,
+			pollingTimers,
+			waitingTimers,
+			permissionTimers,
+			webview,
+			persistAgents,
 		);
 	}, PROJECT_SCAN_INTERVAL_MS);
 }
 
+function seedKnownJsonlFiles(
+	runtime: AgentRuntime,
+	projectDir: string,
+	knownJsonlFiles: Set<string>,
+): void {
+	try {
+		const files = runtime === 'codex' || path.resolve(projectDir) === path.resolve(getClaudeSessionsRootPath())
+			? listJsonlFilesRecursive(projectDir)
+			: fs.readdirSync(projectDir)
+				.filter((f) => f.endsWith('.jsonl'))
+				.map((f) => path.join(projectDir, f));
+		for (const file of files) {
+			knownJsonlFiles.add(file);
+		}
+	} catch {
+		// Directory may not exist yet.
+	}
+}
+
 function scanForNewJsonlFiles(
+	runtime: AgentRuntime,
+	projectDir: string,
+	knownJsonlFiles: Set<string>,
+	activeAgentIdRef: { current: number | null },
+	nextAgentIdRef: { current: number },
+	agents: Map<number, AgentState>,
+	fileWatchers: Map<number, fs.FSWatcher>,
+	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+	persistAgents: () => void,
+): void {
+	if (runtime === 'codex') {
+		scanForNewCodexJsonlFiles(
+			projectDir,
+			knownJsonlFiles,
+			activeAgentIdRef,
+			nextAgentIdRef,
+			agents,
+			fileWatchers,
+			pollingTimers,
+			waitingTimers,
+			permissionTimers,
+			webview,
+			persistAgents,
+		);
+		return;
+	}
+
+	scanForNewClaudeJsonlFiles(
+		projectDir,
+		knownJsonlFiles,
+		activeAgentIdRef,
+		nextAgentIdRef,
+		agents,
+		fileWatchers,
+		pollingTimers,
+		waitingTimers,
+		permissionTimers,
+		webview,
+		persistAgents,
+	);
+}
+
+function scanForNewClaudeJsonlFiles(
 	projectDir: string,
 	knownJsonlFiles: Set<string>,
 	activeAgentIdRef: { current: number | null },
@@ -139,48 +233,200 @@ function scanForNewJsonlFiles(
 ): void {
 	let files: string[];
 	try {
-		files = fs.readdirSync(projectDir)
-			.filter(f => f.endsWith('.jsonl'))
-			.map(f => path.join(projectDir, f));
-	} catch { return; }
+		files = listCodexJsonlFiles(projectDir);
+	} catch {
+		return;
+	}
+	const isGlobalClaudeRoot = path.resolve(projectDir) === path.resolve(getClaudeSessionsRootPath());
 
 	for (const file of files) {
-		if (!knownJsonlFiles.has(file)) {
-			knownJsonlFiles.add(file);
-			if (activeAgentIdRef.current !== null) {
-				// Active agent focused → /clear reassignment
-				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
-				reassignAgentToFile(
-					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-					webview, persistAgents,
-				);
-			} else {
-				// No active agent → try to adopt the focused terminal
-				const activeTerminal = vscode.window.activeTerminal;
-				if (activeTerminal) {
-					let owned = false;
-					for (const agent of agents.values()) {
-						if (agent.terminalRef === activeTerminal) {
-							owned = true;
-							break;
-						}
-					}
-					if (!owned) {
-						adoptTerminalForFile(
-							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
-							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-							webview, persistAgents,
-						);
-					}
-				}
+		if (knownJsonlFiles.has(file)) continue;
+		knownJsonlFiles.add(file);
+
+		const pendingMatch = findPendingClaudeAgentForFile(agents, file);
+		if (pendingMatch) {
+			reassignAgentToFile(
+				pendingMatch.id,
+				file,
+				agents,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
+		}
+
+		// When scanning the global Claude sessions root (no workspace cwd available),
+		// do not run /clear/adoption heuristics on unrelated files.
+		if (isGlobalClaudeRoot) continue;
+
+		if (activeAgentIdRef.current !== null) {
+			console.log(`[Pixel Agents] New Claude JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
+			reassignAgentToFile(
+				activeAgentIdRef.current,
+				file,
+				agents,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
+		}
+
+		const activeTerminal = vscode.window.activeTerminal;
+		if (!activeTerminal) continue;
+		let owned = false;
+		for (const agent of agents.values()) {
+			if (agent.terminalRef === activeTerminal) {
+				owned = true;
+				break;
 			}
+		}
+		if (!owned) {
+			adoptTerminalForFile(
+				'claude',
+				activeTerminal,
+				file,
+				projectDir,
+				nextAgentIdRef,
+				agents,
+				activeAgentIdRef,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
 		}
 	}
 }
 
+function findPendingClaudeAgentForFile(
+	agents: Map<number, AgentState>,
+	filePath: string,
+): AgentState | undefined {
+	const sessionId = path.basename(filePath, '.jsonl');
+	return [...agents.values()]
+		.filter((agent) => agent.runtime === 'claude' && !agent.jsonlFile && agent.pendingSessionId === sessionId)
+		.sort((a, b) => b.id - a.id)[0];
+}
+
+function scanForNewCodexJsonlFiles(
+	projectDir: string,
+	knownJsonlFiles: Set<string>,
+	activeAgentIdRef: { current: number | null },
+	nextAgentIdRef: { current: number },
+	agents: Map<number, AgentState>,
+	fileWatchers: Map<number, fs.FSWatcher>,
+	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+	persistAgents: () => void,
+): void {
+	let files: string[];
+	try {
+		files = listJsonlFilesRecursive(projectDir);
+	} catch {
+		return;
+	}
+
+	const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+	for (const file of files) {
+		if (knownJsonlFiles.has(file)) continue;
+		knownJsonlFiles.add(file);
+		if (!matchesWorkspaceCodexSession(file, workspaceRoot)) continue;
+
+		const activeAgent = activeAgentIdRef.current !== null ? agents.get(activeAgentIdRef.current) : undefined;
+		if (activeAgent && activeAgent.runtime === 'codex' && !activeAgent.jsonlFile) {
+			reassignAgentToFile(
+				activeAgent.id,
+				file,
+				agents,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
+		}
+
+		const pendingAgent = findPendingCodexAgent(agents);
+		if (pendingAgent) {
+			reassignAgentToFile(
+				pendingAgent.id,
+				file,
+				agents,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
+		}
+
+		const activeTerminal = vscode.window.activeTerminal;
+		if (!activeTerminal) continue;
+		let owned = false;
+		for (const agent of agents.values()) {
+			if (agent.terminalRef === activeTerminal) {
+				owned = true;
+				break;
+			}
+		}
+		if (!owned) {
+			adoptTerminalForFile(
+				'codex',
+				activeTerminal,
+				file,
+				projectDir,
+				nextAgentIdRef,
+				agents,
+				activeAgentIdRef,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+		}
+	}
+
+	// Handle a race where the new file already existed during seedKnownJsonlFiles.
+	// If a Codex agent is still pending, attach it to the newest unassigned matching session.
+	const pendingAgent = findPendingCodexAgent(agents);
+	if (!pendingAgent) return;
+
+	const newestFile = findNewestUnassignedMatchingCodexFile(files, agents, workspaceRoot);
+	if (!newestFile) return;
+
+	reassignAgentToFile(
+		pendingAgent.id,
+		newestFile,
+		agents,
+		fileWatchers,
+		pollingTimers,
+		waitingTimers,
+		permissionTimers,
+		webview,
+		persistAgents,
+	);
+}
+
 function adoptTerminalForFile(
+	runtime: AgentRuntime,
 	terminal: vscode.Terminal,
 	jsonlFile: string,
 	projectDir: string,
@@ -197,6 +443,7 @@ function adoptTerminalForFile(
 	const id = nextAgentIdRef.current++;
 	const agent: AgentState = {
 		id,
+		runtime,
 		terminalRef: terminal,
 		projectDir,
 		jsonlFile,
@@ -205,6 +452,7 @@ function adoptTerminalForFile(
 		activeToolIds: new Set(),
 		activeToolStatuses: new Map(),
 		activeToolNames: new Map(),
+		activeToolCallToName: new Map(),
 		activeSubagentToolIds: new Map(),
 		activeSubagentToolNames: new Map(),
 		isWaiting: false,
@@ -216,7 +464,7 @@ function adoptTerminalForFile(
 	activeAgentIdRef.current = id;
 	persistAgents();
 
-	console.log(`[Pixel Agents] Agent ${id}: adopted terminal "${terminal.name}" for ${path.basename(jsonlFile)}`);
+	console.log(`[Pixel Agents] Agent ${id}: adopted terminal "${terminal.name}" for ${path.basename(jsonlFile)} (runtime=${runtime})`);
 	webview?.postMessage({ type: 'agentCreated', id });
 
 	startFileWatching(id, jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
@@ -237,26 +485,25 @@ export function reassignAgentToFile(
 	const agent = agents.get(agentId);
 	if (!agent) return;
 
-	// Stop old file watching
 	fileWatchers.get(agentId)?.close();
 	fileWatchers.delete(agentId);
 	const pt = pollingTimers.get(agentId);
-	if (pt) { clearInterval(pt); }
+	if (pt) {
+		clearInterval(pt);
+	}
 	pollingTimers.delete(agentId);
 	try { fs.unwatchFile(agent.jsonlFile); } catch { /* ignore */ }
 
-	// Clear activity
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 	clearAgentActivity(agent, agentId, permissionTimers, webview);
 
-	// Swap to new file
 	agent.jsonlFile = newFilePath;
+	agent.pendingSessionId = undefined;
 	agent.fileOffset = 0;
 	agent.lineBuffer = '';
 	persistAgents();
 
-	// Start watching new file
 	startFileWatching(agentId, newFilePath, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
 	readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,47 @@
+import * as os from 'os';
+import * as path from 'path';
+import type { AgentRuntime } from './types.js';
+import { TERMINAL_NAME_PREFIX_CLAUDE, TERMINAL_NAME_PREFIX_CODEX } from './constants.js';
+
+export const DEFAULT_AGENT_RUNTIME: AgentRuntime = 'claude';
+
+export function normalizeAgentRuntime(value: unknown): AgentRuntime {
+	return value === 'codex' ? 'codex' : 'claude';
+}
+
+export function getTerminalNamePrefix(runtime: AgentRuntime): string {
+	return runtime === 'codex' ? TERMINAL_NAME_PREFIX_CODEX : TERMINAL_NAME_PREFIX_CLAUDE;
+}
+
+export function getClaudeProjectDirPath(cwd?: string): string | null {
+	const workspacePath = cwd;
+	if (!workspacePath) return null;
+	const dirName = workspacePath.replace(/[:\\/]/g, '-');
+	return path.join(getClaudeSessionsRootPath(), dirName);
+}
+
+export function getClaudeSessionsRootPath(): string {
+	return path.join(os.homedir(), '.claude', 'projects');
+}
+
+export function getCodexProjectDirPath(): string {
+	return path.join(os.homedir(), '.codex', 'sessions');
+}
+
+export function getProjectDirPathForRuntime(runtime: AgentRuntime, cwd?: string): string | null {
+	if (runtime === 'codex') {
+		return getCodexProjectDirPath();
+	}
+	return getClaudeProjectDirPath(cwd);
+}
+
+function shellEscape(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function getRuntimeLaunchCommand(runtime: AgentRuntime, cwd: string | undefined, sessionId: string): string {
+	if (runtime === 'codex') {
+		return cwd ? `codex -C ${shellEscape(cwd)}` : 'codex';
+	}
+	return `claude --session-id ${sessionId}`;
+}

--- a/src/sessionFiles.ts
+++ b/src/sessionFiles.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function listJsonlFilesRecursive(rootDir: string): string[] {
+	const files: string[] = [];
+	const stack = [rootDir];
+	while (stack.length > 0) {
+		const dir = stack.pop();
+		if (!dir) continue;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(fullPath);
+			} else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+				files.push(fullPath);
+			}
+		}
+	}
+	return files;
+}

--- a/src/timerManager.ts
+++ b/src/timerManager.ts
@@ -12,6 +12,7 @@ export function clearAgentActivity(
 	agent.activeToolIds.clear();
 	agent.activeToolStatuses.clear();
 	agent.activeToolNames.clear();
+	agent.activeToolCallToName.clear();
 	agent.activeSubagentToolIds.clear();
 	agent.activeSubagentToolNames.clear();
 	agent.isWaiting = false;

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -14,31 +14,45 @@ import {
 	BASH_COMMAND_DISPLAY_MAX_LENGTH,
 	TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
 } from './constants.js';
+import { processCodexRecord } from './codex/transcript.js';
 
 export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
 
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
-	const base = (p: unknown) => typeof p === 'string' ? path.basename(p) : '';
+	const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
 	switch (toolName) {
-		case 'Read': return `Reading ${base(input.file_path)}`;
-		case 'Edit': return `Editing ${base(input.file_path)}`;
-		case 'Write': return `Writing ${base(input.file_path)}`;
+		case 'Read':
+			return `Reading ${base(input.file_path)}`;
+		case 'Edit':
+			return `Editing ${base(input.file_path)}`;
+		case 'Write':
+			return `Writing ${base(input.file_path)}`;
 		case 'Bash': {
 			const cmd = (input.command as string) || '';
 			return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : cmd}`;
 		}
-		case 'Glob': return 'Searching files';
-		case 'Grep': return 'Searching code';
-		case 'WebFetch': return 'Fetching web content';
-		case 'WebSearch': return 'Searching the web';
+		case 'Glob':
+			return 'Searching files';
+		case 'Grep':
+			return 'Searching code';
+		case 'WebFetch':
+			return 'Fetching web content';
+		case 'WebSearch':
+			return 'Searching the web';
 		case 'Task': {
 			const desc = typeof input.description === 'string' ? input.description : '';
-			return desc ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}` : 'Running subtask';
+			return desc
+				? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}`
+				: 'Running subtask';
 		}
-		case 'AskUserQuestion': return 'Waiting for your answer';
-		case 'EnterPlanMode': return 'Planning';
-		case 'NotebookEdit': return `Editing notebook`;
-		default: return `Using ${toolName}`;
+		case 'AskUserQuestion':
+			return 'Waiting for your answer';
+		case 'EnterPlanMode':
+			return 'Planning';
+		case 'NotebookEdit':
+			return 'Editing notebook';
+		default:
+			return `Using ${toolName}`;
 	}
 }
 
@@ -52,128 +66,153 @@ export function processTranscriptLine(
 ): void {
 	const agent = agents.get(agentId);
 	if (!agent) return;
+
 	try {
-		const record = JSON.parse(line);
+		const record = JSON.parse(line) as Record<string, unknown>;
+		if (agent.runtime === 'codex') {
+			processCodexRecord(
+				agentId,
+				agent,
+				record,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				markAgentWaiting,
+			);
+			return;
+		}
+		processClaudeRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
+	} catch {
+		// Ignore malformed lines.
+	}
+}
 
-		if (record.type === 'assistant' && Array.isArray(record.message?.content)) {
-			const blocks = record.message.content as Array<{
-				type: string; id?: string; name?: string; input?: Record<string, unknown>;
-			}>;
-			const hasToolUse = blocks.some(b => b.type === 'tool_use');
+function processClaudeRecord(
+	agentId: number,
+	record: Record<string, unknown>,
+	agents: Map<number, AgentState>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+): void {
+	const agent = agents.get(agentId);
+	if (!agent) return;
 
-			if (hasToolUse) {
-				cancelWaitingTimer(agentId, waitingTimers);
-				agent.isWaiting = false;
-				agent.hadToolsInTurn = true;
-				webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
-				let hasNonExemptTool = false;
-				for (const block of blocks) {
-					if (block.type === 'tool_use' && block.id) {
-						const toolName = block.name || '';
-						const status = formatToolStatus(toolName, block.input || {});
-						console.log(`[Pixel Agents] Agent ${agentId} tool start: ${block.id} ${status}`);
-						agent.activeToolIds.add(block.id);
-						agent.activeToolStatuses.set(block.id, status);
-						agent.activeToolNames.set(block.id, toolName);
-						if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
-							hasNonExemptTool = true;
-						}
-						webview?.postMessage({
-							type: 'agentToolStart',
-							id: agentId,
-							toolId: block.id,
-							status,
-						});
+	if (record.type === 'assistant' && Array.isArray((record.message as { content?: unknown } | undefined)?.content)) {
+		const blocks = (record.message as { content: Array<{ type: string; id?: string; name?: string; input?: Record<string, unknown> }> }).content;
+		const hasToolUse = blocks.some((b) => b.type === 'tool_use');
+
+		if (hasToolUse) {
+			cancelWaitingTimer(agentId, waitingTimers);
+			agent.isWaiting = false;
+			agent.hadToolsInTurn = true;
+			webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+			let hasNonExemptTool = false;
+			for (const block of blocks) {
+				if (block.type === 'tool_use' && block.id) {
+					const toolName = block.name || '';
+					const status = formatToolStatus(toolName, block.input || {});
+					console.log(`[Pixel Agents] Agent ${agentId} tool start: ${block.id} ${status}`);
+					agent.activeToolIds.add(block.id);
+					agent.activeToolStatuses.set(block.id, status);
+					agent.activeToolNames.set(block.id, toolName);
+					if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+						hasNonExemptTool = true;
 					}
+					webview?.postMessage({
+						type: 'agentToolStart',
+						id: agentId,
+						toolId: block.id,
+						status,
+					});
 				}
-				if (hasNonExemptTool) {
-					startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
-				}
-			} else if (blocks.some(b => b.type === 'text') && !agent.hadToolsInTurn) {
-				// Text-only response in a turn that hasn't used any tools.
-				// turn_duration handles tool-using turns reliably but is never
-				// emitted for text-only turns, so we use a silence-based timer:
-				// if no new JSONL data arrives within TEXT_IDLE_DELAY_MS, mark as waiting.
-				startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, webview);
 			}
-		} else if (record.type === 'progress') {
-			processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
-		} else if (record.type === 'user') {
-			const content = record.message?.content;
-			if (Array.isArray(content)) {
-				const blocks = content as Array<{ type: string; tool_use_id?: string }>;
-				const hasToolResult = blocks.some(b => b.type === 'tool_result');
-				if (hasToolResult) {
-					for (const block of blocks) {
-						if (block.type === 'tool_result' && block.tool_use_id) {
-							console.log(`[Pixel Agents] Agent ${agentId} tool done: ${block.tool_use_id}`);
-							const completedToolId = block.tool_use_id;
-							// If the completed tool was a Task, clear its subagent tools
-							if (agent.activeToolNames.get(completedToolId) === 'Task') {
-								agent.activeSubagentToolIds.delete(completedToolId);
-								agent.activeSubagentToolNames.delete(completedToolId);
-								webview?.postMessage({
-									type: 'subagentClear',
-									id: agentId,
-									parentToolId: completedToolId,
-								});
-							}
-							agent.activeToolIds.delete(completedToolId);
-							agent.activeToolStatuses.delete(completedToolId);
-							agent.activeToolNames.delete(completedToolId);
-							const toolId = completedToolId;
-							setTimeout(() => {
-								webview?.postMessage({
-									type: 'agentToolDone',
-									id: agentId,
-									toolId,
-								});
-							}, TOOL_DONE_DELAY_MS);
+			if (hasNonExemptTool) {
+				startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
+			}
+		} else if (blocks.some((b) => b.type === 'text') && !agent.hadToolsInTurn) {
+			startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, webview);
+		}
+	} else if (record.type === 'progress') {
+		processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
+	} else if (record.type === 'user') {
+		const content = (record.message as { content?: unknown } | undefined)?.content;
+		if (Array.isArray(content)) {
+			const blocks = content as Array<{ type: string; tool_use_id?: string }>;
+			const hasToolResult = blocks.some((b) => b.type === 'tool_result');
+			if (hasToolResult) {
+				for (const block of blocks) {
+					if (block.type === 'tool_result' && block.tool_use_id) {
+						console.log(`[Pixel Agents] Agent ${agentId} tool done: ${block.tool_use_id}`);
+						const completedToolId = block.tool_use_id;
+						if (agent.activeToolNames.get(completedToolId) === 'Task') {
+							agent.activeSubagentToolIds.delete(completedToolId);
+							agent.activeSubagentToolNames.delete(completedToolId);
+							webview?.postMessage({
+								type: 'subagentClear',
+								id: agentId,
+								parentToolId: completedToolId,
+							});
 						}
+						agent.activeToolIds.delete(completedToolId);
+						agent.activeToolStatuses.delete(completedToolId);
+						agent.activeToolNames.delete(completedToolId);
+						const toolId = completedToolId;
+						setTimeout(() => {
+							webview?.postMessage({
+								type: 'agentToolDone',
+								id: agentId,
+								toolId,
+							});
+						}, TOOL_DONE_DELAY_MS);
 					}
-					// All tools completed — allow text-idle timer as fallback
-					// for turn-end detection when turn_duration is not emitted
-					if (agent.activeToolIds.size === 0) {
-						agent.hadToolsInTurn = false;
-					}
-				} else {
-					// New user text prompt — new turn starting
-					cancelWaitingTimer(agentId, waitingTimers);
-					clearAgentActivity(agent, agentId, permissionTimers, webview);
+				}
+				if (agent.activeToolIds.size === 0) {
 					agent.hadToolsInTurn = false;
 				}
-			} else if (typeof content === 'string' && content.trim()) {
-				// New user text prompt — new turn starting
+			} else {
 				cancelWaitingTimer(agentId, waitingTimers);
 				clearAgentActivity(agent, agentId, permissionTimers, webview);
 				agent.hadToolsInTurn = false;
 			}
-		} else if (record.type === 'system' && record.subtype === 'turn_duration') {
+		} else if (typeof content === 'string' && content.trim()) {
 			cancelWaitingTimer(agentId, waitingTimers);
-			cancelPermissionTimer(agentId, permissionTimers);
-
-			// Definitive turn-end: clean up any stale tool state
-			if (agent.activeToolIds.size > 0) {
-				agent.activeToolIds.clear();
-				agent.activeToolStatuses.clear();
-				agent.activeToolNames.clear();
-				agent.activeSubagentToolIds.clear();
-				agent.activeSubagentToolNames.clear();
-				webview?.postMessage({ type: 'agentToolsClear', id: agentId });
-			}
-
-			agent.isWaiting = true;
-			agent.permissionSent = false;
+			clearAgentActivity(agent, agentId, permissionTimers, webview);
 			agent.hadToolsInTurn = false;
-			webview?.postMessage({
-				type: 'agentStatus',
-				id: agentId,
-				status: 'waiting',
-			});
 		}
-	} catch {
-		// Ignore malformed lines
+	} else if (record.type === 'system' && record.subtype === 'turn_duration') {
+		markAgentWaiting(agentId, agent, waitingTimers, permissionTimers, webview);
 	}
+}
+
+function markAgentWaiting(
+	agentId: number,
+	agent: AgentState,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+): void {
+	cancelWaitingTimer(agentId, waitingTimers);
+	cancelPermissionTimer(agentId, permissionTimers);
+
+	if (agent.activeToolIds.size > 0) {
+		agent.activeToolIds.clear();
+		agent.activeToolStatuses.clear();
+		agent.activeToolNames.clear();
+		agent.activeToolCallToName.clear();
+		agent.activeSubagentToolIds.clear();
+		agent.activeSubagentToolNames.clear();
+		webview?.postMessage({ type: 'agentToolsClear', id: agentId });
+	}
+
+	agent.isWaiting = true;
+	agent.permissionSent = false;
+	agent.hadToolsInTurn = false;
+	webview?.postMessage({
+		type: 'agentStatus',
+		id: agentId,
+		status: 'waiting',
+	});
 }
 
 function processProgressRecord(
@@ -193,8 +232,6 @@ function processProgressRecord(
 	const data = record.data as Record<string, unknown> | undefined;
 	if (!data) return;
 
-	// bash_progress / mcp_progress: tool is actively executing, not stuck on permission.
-	// Restart the permission timer to give the running tool another window.
 	const dataType = data.type as string | undefined;
 	if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
 		if (agent.activeToolIds.has(parentToolId)) {
@@ -203,7 +240,6 @@ function processProgressRecord(
 		return;
 	}
 
-	// Verify parent is an active Task tool (agent_progress handling)
 	if (agent.activeToolNames.get(parentToolId) !== 'Task') return;
 
 	const msg = data.message as Record<string, unknown> | undefined;
@@ -222,7 +258,6 @@ function processProgressRecord(
 				const status = formatToolStatus(toolName, block.input || {});
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool start: ${block.id} ${status} (parent: ${parentToolId})`);
 
-				// Track sub-tool IDs
 				let subTools = agent.activeSubagentToolIds.get(parentToolId);
 				if (!subTools) {
 					subTools = new Set();
@@ -230,7 +265,6 @@ function processProgressRecord(
 				}
 				subTools.add(block.id);
 
-				// Track sub-tool names (for permission checking)
 				let subNames = agent.activeSubagentToolNames.get(parentToolId);
 				if (!subNames) {
 					subNames = new Map();
@@ -259,7 +293,6 @@ function processProgressRecord(
 			if (block.type === 'tool_result' && block.tool_use_id) {
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool done: ${block.tool_use_id} (parent: ${parentToolId})`);
 
-				// Remove from tracking
 				const subTools = agent.activeSubagentToolIds.get(parentToolId);
 				if (subTools) {
 					subTools.delete(block.tool_use_id);
@@ -277,11 +310,10 @@ function processProgressRecord(
 						parentToolId,
 						toolId,
 					});
-				}, 300);
+				}, TOOL_DONE_DELAY_MS);
 			}
 		}
-		// If there are still active non-exempt sub-agent tools, restart the permission timer
-		// (handles the case where one sub-agent completes but another is still stuck)
+
 		let stillHasNonExempt = false;
 		for (const [, subNames] of agent.activeSubagentToolNames) {
 			for (const [, toolName] of subNames) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,11 @@
 import type * as vscode from 'vscode';
 
+export type AgentRuntime = 'claude' | 'codex';
+
 export interface AgentState {
 	id: number;
+	runtime: AgentRuntime;
+	pendingSessionId?: string; // waiting for runtime transcript file discovery
 	terminalRef: vscode.Terminal;
 	projectDir: string;
 	jsonlFile: string;
@@ -10,6 +14,7 @@ export interface AgentState {
 	activeToolIds: Set<string>;
 	activeToolStatuses: Map<string, string>;
 	activeToolNames: Map<string, string>;
+	activeToolCallToName: Map<string, string>; // codex callId -> toolName
 	activeSubagentToolIds: Map<string, Set<string>>; // parentToolId → active sub-tool IDs
 	activeSubagentToolNames: Map<string, Map<string, string>>; // parentToolId → (subToolId → toolName)
 	isWaiting: boolean;
@@ -21,6 +26,7 @@ export interface AgentState {
 
 export interface PersistedAgent {
 	id: number;
+	runtime?: AgentRuntime;
 	terminalName: string;
 	jsonlFile: string;
 	projectDir: string;

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -121,7 +121,19 @@ function App() {
 
   const isEditDirty = useCallback(() => editor.isEditMode && editor.isDirty, [editor.isEditMode, editor.isDirty])
 
-  const { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets, workspaceFolders } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
+  const {
+    agents,
+    selectedAgent,
+    agentTools,
+    agentStatuses,
+    subagentTools,
+    subagentCharacters,
+    layoutReady,
+    defaultRuntime,
+    setDefaultRuntime,
+    loadedAssets,
+    workspaceFolders,
+  } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
 
   const [isDebugMode, setIsDebugMode] = useState(false)
 
@@ -225,10 +237,12 @@ function App() {
 
       <BottomToolbar
         isEditMode={editor.isEditMode}
-        onOpenClaude={editor.handleOpenClaude}
+        onOpenAgent={editor.handleOpenAgent}
         onToggleEditMode={editor.handleToggleEditMode}
         isDebugMode={isDebugMode}
         onToggleDebugMode={handleToggleDebugMode}
+        defaultRuntime={defaultRuntime}
+        onSetDefaultRuntime={setDefaultRuntime}
         workspaceFolders={workspaceFolders}
       />
 

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -5,11 +5,13 @@ import { vscode } from '../vscodeApi.js'
 
 interface BottomToolbarProps {
   isEditMode: boolean
-  onOpenClaude: () => void
+  onOpenAgent: () => void
   onToggleEditMode: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
   workspaceFolders: WorkspaceFolder[]
+  defaultRuntime: 'claude' | 'codex'
+  onSetDefaultRuntime: (runtime: 'claude' | 'codex') => void
 }
 
 const panelStyle: React.CSSProperties = {
@@ -46,11 +48,13 @@ const btnActive: React.CSSProperties = {
 
 export function BottomToolbar({
   isEditMode,
-  onOpenClaude,
+  onOpenAgent,
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
   workspaceFolders,
+  defaultRuntime,
+  onSetDefaultRuntime,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
@@ -76,13 +80,13 @@ export function BottomToolbar({
     if (hasMultipleFolders) {
       setIsFolderPickerOpen((v) => !v)
     } else {
-      onOpenClaude()
+      onOpenAgent()
     }
   }
 
   const handleFolderSelect = (folder: WorkspaceFolder) => {
     setIsFolderPickerOpen(false)
-    vscode.postMessage({ type: 'openClaude', folderPath: folder.path })
+    vscode.postMessage({ type: 'openAgent', runtime: defaultRuntime, folderPath: folder.path })
   }
 
   return (
@@ -184,6 +188,8 @@ export function BottomToolbar({
           onClose={() => setIsSettingsOpen(false)}
           isDebugMode={isDebugMode}
           onToggleDebugMode={onToggleDebugMode}
+          defaultRuntime={defaultRuntime}
+          onSetDefaultRuntime={onSetDefaultRuntime}
         />
       </div>
     </div>

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -7,6 +7,8 @@ interface SettingsModalProps {
   onClose: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
+  defaultRuntime: 'claude' | 'codex'
+  onSetDefaultRuntime: (runtime: 'claude' | 'codex') => void
 }
 
 const menuItemBase: React.CSSProperties = {
@@ -14,6 +16,7 @@ const menuItemBase: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'space-between',
   width: '100%',
+  boxSizing: 'border-box',
   padding: '6px 10px',
   fontSize: '24px',
   color: 'rgba(255, 255, 255, 0.8)',
@@ -24,7 +27,24 @@ const menuItemBase: React.CSSProperties = {
   textAlign: 'left',
 }
 
-export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode }: SettingsModalProps) {
+const runtimeBtnBase: React.CSSProperties = {
+  border: '2px solid rgba(255, 255, 255, 0.4)',
+  borderRadius: 0,
+  background: 'transparent',
+  color: 'rgba(255, 255, 255, 0.8)',
+  fontSize: '20px',
+  padding: '3px 8px',
+  cursor: 'pointer',
+}
+
+export function SettingsModal({
+  isOpen,
+  onClose,
+  isDebugMode,
+  onToggleDebugMode,
+  defaultRuntime,
+  onSetDefaultRuntime,
+}: SettingsModalProps) {
   const [hovered, setHovered] = useState<string | null>(null)
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled)
 
@@ -58,7 +78,7 @@ export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode 
           borderRadius: 0,
           padding: '4px',
           boxShadow: 'var(--pixel-shadow)',
-          minWidth: 200,
+          minWidth: 300,
         }}
       >
         {/* Header with title and X button */}
@@ -94,7 +114,7 @@ export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode 
         {/* Menu items */}
         <button
           onClick={() => {
-            vscode.postMessage({ type: 'openSessionsFolder' })
+            vscode.postMessage({ type: 'openSessionsFolder', runtime: defaultRuntime })
             onClose()
           }}
           onMouseEnter={() => setHovered('sessions')}
@@ -134,6 +154,59 @@ export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode 
         >
           Import Layout
         </button>
+        <div
+          onMouseEnter={() => setHovered('runtime')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...menuItemBase,
+            cursor: 'default',
+            background: hovered === 'runtime' ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+        >
+          <span>Default Runtime</span>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              style={{
+                ...runtimeBtnBase,
+                borderColor: defaultRuntime === 'claude' ? 'var(--pixel-accent)' : runtimeBtnBase.borderColor,
+                background:
+                  defaultRuntime === 'claude'
+                    ? 'rgba(90, 140, 255, 0.3)'
+                    : hovered === 'runtime-claude'
+                      ? 'rgba(255, 255, 255, 0.08)'
+                      : runtimeBtnBase.background,
+              }}
+              onMouseEnter={() => setHovered('runtime-claude')}
+              onMouseLeave={() => setHovered('runtime')}
+              onClick={() => {
+                onSetDefaultRuntime('claude')
+                vscode.postMessage({ type: 'setDefaultRuntime', runtime: 'claude' })
+              }}
+            >
+              Claude
+            </button>
+            <button
+              style={{
+                ...runtimeBtnBase,
+                borderColor: defaultRuntime === 'codex' ? 'var(--pixel-accent)' : runtimeBtnBase.borderColor,
+                background:
+                  defaultRuntime === 'codex'
+                    ? 'rgba(90, 140, 255, 0.3)'
+                    : hovered === 'runtime-codex'
+                      ? 'rgba(255, 255, 255, 0.08)'
+                      : runtimeBtnBase.background,
+              }}
+              onMouseEnter={() => setHovered('runtime-codex')}
+              onMouseLeave={() => setHovered('runtime')}
+              onClick={() => {
+                onSetDefaultRuntime('codex')
+                vscode.postMessage({ type: 'setDefaultRuntime', runtime: 'codex' })
+              }}
+            >
+              Codex
+            </button>
+          </div>
+        </div>
         <button
           onClick={() => {
             const newVal = !isSoundEnabled()

--- a/webview-ui/src/hooks/useEditorActions.ts
+++ b/webview-ui/src/hooks/useEditorActions.ts
@@ -19,7 +19,7 @@ export interface EditorActions {
   panRef: React.MutableRefObject<{ x: number; y: number }>
   saveTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
   setLastSavedLayout: (layout: OfficeLayout) => void
-  handleOpenClaude: () => void
+  handleOpenAgent: () => void
   handleToggleEditMode: () => void
   handleToolChange: (tool: EditToolType) => void
   handleTileTypeChange: (type: TileTypeVal) => void
@@ -78,8 +78,8 @@ export function useEditorActions(
     setEditorTick((n) => n + 1)
   }, [getOfficeState, editorState, saveLayout])
 
-  const handleOpenClaude = useCallback(() => {
-    vscode.postMessage({ type: 'openClaude' })
+  const handleOpenAgent = useCallback(() => {
+    vscode.postMessage({ type: 'openAgent' })
   }, [])
 
   const handleToggleEditMode = useCallback(() => {
@@ -503,7 +503,7 @@ export function useEditorActions(
     panRef,
     saveTimerRef,
     setLastSavedLayout,
-    handleOpenClaude,
+    handleOpenAgent,
     handleToggleEditMode,
     handleToolChange,
     handleTileTypeChange,

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -48,6 +48,8 @@ export interface ExtensionMessageState {
   subagentTools: Record<number, Record<string, ToolActivity[]>>
   subagentCharacters: SubagentCharacter[]
   layoutReady: boolean
+  defaultRuntime: 'claude' | 'codex'
+  setDefaultRuntime: (runtime: 'claude' | 'codex') => void
   loadedAssets?: { catalog: FurnitureAsset[]; sprites: Record<string, string[][]> }
   workspaceFolders: WorkspaceFolder[]
 }
@@ -73,6 +75,7 @@ export function useExtensionMessages(
   const [subagentTools, setSubagentTools] = useState<Record<number, Record<string, ToolActivity[]>>>({})
   const [subagentCharacters, setSubagentCharacters] = useState<SubagentCharacter[]>([])
   const [layoutReady, setLayoutReady] = useState(false)
+  const [defaultRuntime, setDefaultRuntime] = useState<'claude' | 'codex'>('claude')
   const [loadedAssets, setLoadedAssets] = useState<{ catalog: FurnitureAsset[]; sprites: Record<string, string[][]> } | undefined>()
   const [workspaceFolders, setWorkspaceFolders] = useState<WorkspaceFolder[]>([])
 
@@ -342,6 +345,8 @@ export function useExtensionMessages(
       } else if (msg.type === 'settingsLoaded') {
         const soundOn = msg.soundEnabled as boolean
         setSoundEnabled(soundOn)
+        const runtime = msg.defaultRuntime === 'codex' ? 'codex' : 'claude'
+        setDefaultRuntime(runtime)
       } else if (msg.type === 'furnitureAssetsLoaded') {
         try {
           const catalog = msg.catalog as FurnitureAsset[]
@@ -360,5 +365,17 @@ export function useExtensionMessages(
     return () => window.removeEventListener('message', handler)
   }, [getOfficeState])
 
-  return { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets, workspaceFolders }
+  return {
+    agents,
+    selectedAgent,
+    agentTools,
+    agentStatuses,
+    subagentTools,
+    subagentCharacters,
+    layoutReady,
+    defaultRuntime,
+    setDefaultRuntime,
+    loadedAssets,
+    workspaceFolders,
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds first-pass Codex compatibility and refactors agent/session handling to be runtime-agnostic (Claude + Codex), while keeping existing Claude behavior intact.

## What Changed

  - Added runtime abstraction (`claude | codex`) for:
    - terminal launch command
    - session root resolution
    - terminal naming
  - Made agent lifecycle/runtime state explicit (`runtime`, pending session linking).
  - Added Codex session discovery/linking from `~/.codex/sessions/**/*.jsonl` using `session_meta.payload.cwd`.
  - Added Codex transcript parsing:
    - `function_call` -> tool start
    - `function_call_output` -> tool done
    - `final_answer` / `task_complete` -> waiting
  - Isolated Codex-specific logic into:
    - `src/codex/session.ts`
    - `src/codex/transcript.ts`
  - Added shared JSONL file utility:
    - `src/sessionFiles.ts`
  - Added Settings support for default runtime (Claude/Codex) + persistence.
    - <img width="454" height="389" alt="image" src="https://github.com/user-attachments/assets/a9b9781c-2b0d-4e37-a02b-245ab5ba2b3d" />
 
  - Updated `CLAUDE.md` to reflect the new architecture and message flow.

  ## Why

  Claude and Codex have fundamentally different session/transcript behaviors. This change introduces a clean runtime split so both can be supported safely without embedding Codex-specific logic across the core flow.

  ## Validation

  - Manual smoke test in Extension Development Host:
    - `+ Agent` works for both Claude and Codex
    - tool/waiting status updates are emitted correctly
    - runtime setting persists and affects new launches