### PR TITLE
feat: add workspace folder picker for multi-root workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixel-agents",
   "displayName": "Pixel Agents",
   "description": "Pixel art office where your Claude Code agents come to life as animated characters",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "pablodelucca",
   "repository": {
     "type": "git",

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -63,7 +63,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 
 		webviewView.webview.onDidReceiveMessage(async (message) => {
 			if (message.type === 'openClaude') {
-				launchNewTerminal(
+				await launchNewTerminal(
 					this.nextAgentId, this.nextTerminalIndex,
 					this.agents, this.activeAgentId, this.knownJsonlFiles,
 					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -69,6 +69,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 					this.jsonlPollTimers, this.projectScanTimer,
 					this.webview, this.persistAgents,
+					message.folderPath as string | undefined,
 				);
 			} else if (message.type === 'focusAgent') {
 				const agent = this.agents.get(message.id);
@@ -101,6 +102,15 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				// Send persisted settings to webview
 				const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
 				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
+
+				// Send workspace folders to webview (only when multi-root)
+				const wsFolders = vscode.workspace.workspaceFolders;
+				if (wsFolders && wsFolders.length > 1) {
+					this.webview?.postMessage({
+						type: 'workspaceFolders',
+						folders: wsFolders.map(f => ({ name: f.name, path: f.uri.fsPath })),
+					});
+				}
 
 				// Ensure project scan runs even with no restored agents (to adopt external terminals)
 				const projectDir = getProjectDirPath();

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export interface AgentState {
 	isWaiting: boolean;
 	permissionSent: boolean;
 	hadToolsInTurn: boolean;
+	/** Workspace folder name (only set for multi-root workspaces) */
+	folderName?: string;
 }
 
 export interface PersistedAgent {
@@ -22,4 +24,6 @@ export interface PersistedAgent {
 	terminalName: string;
 	jsonlFile: string;
 	projectDir: string;
+	/** Workspace folder name (only set for multi-root workspaces) */
+	folderName?: string;
 }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -121,7 +121,7 @@ function App() {
 
   const isEditDirty = useCallback(() => editor.isEditMode && editor.isDirty, [editor.isEditMode, editor.isDirty])
 
-  const { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
+  const { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets, workspaceFolders } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
 
   const [isDebugMode, setIsDebugMode] = useState(false)
 
@@ -229,6 +229,7 @@ function App() {
         onToggleEditMode={editor.handleToggleEditMode}
         isDebugMode={isDebugMode}
         onToggleDebugMode={handleToggleDebugMode}
+        workspaceFolders={workspaceFolders}
       />
 
       {editor.isEditMode && editor.isDirty && (

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { SettingsModal } from './SettingsModal.js'
+import type { WorkspaceFolder } from '../hooks/useExtensionMessages.js'
+import { vscode } from '../vscodeApi.js'
 
 interface BottomToolbarProps {
   isEditMode: boolean
@@ -7,6 +9,7 @@ interface BottomToolbarProps {
   onToggleEditMode: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
+  workspaceFolders: WorkspaceFolder[]
 }
 
 const panelStyle: React.CSSProperties = {
@@ -47,29 +50,102 @@ export function BottomToolbar({
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
+  workspaceFolders,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isFolderPickerOpen, setIsFolderPickerOpen] = useState(false)
+  const [hoveredFolder, setHoveredFolder] = useState<number | null>(null)
+  const folderPickerRef = useRef<HTMLDivElement>(null)
+
+  // Close folder picker on outside click
+  useEffect(() => {
+    if (!isFolderPickerOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (folderPickerRef.current && !folderPickerRef.current.contains(e.target as Node)) {
+        setIsFolderPickerOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [isFolderPickerOpen])
+
+  const hasMultipleFolders = workspaceFolders.length > 1
+
+  const handleAgentClick = () => {
+    if (hasMultipleFolders) {
+      setIsFolderPickerOpen((v) => !v)
+    } else {
+      onOpenClaude()
+    }
+  }
+
+  const handleFolderSelect = (folder: WorkspaceFolder) => {
+    setIsFolderPickerOpen(false)
+    vscode.postMessage({ type: 'openClaude', folderPath: folder.path })
+  }
 
   return (
     <div style={panelStyle}>
-      <button
-        onClick={onOpenClaude}
-        onMouseEnter={() => setHovered('agent')}
-        onMouseLeave={() => setHovered(null)}
-        style={{
-          ...btnBase,
-          padding: '5px 12px',
-          background:
-            hovered === 'agent'
-              ? 'var(--pixel-agent-hover-bg)'
-              : 'var(--pixel-agent-bg)',
-          border: '2px solid var(--pixel-agent-border)',
-          color: 'var(--pixel-agent-text)',
-        }}
-      >
-        + Agent
-      </button>
+      <div ref={folderPickerRef} style={{ position: 'relative' }}>
+        <button
+          onClick={handleAgentClick}
+          onMouseEnter={() => setHovered('agent')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...btnBase,
+            padding: '5px 12px',
+            background:
+              hovered === 'agent' || isFolderPickerOpen
+                ? 'var(--pixel-agent-hover-bg)'
+                : 'var(--pixel-agent-bg)',
+            border: '2px solid var(--pixel-agent-border)',
+            color: 'var(--pixel-agent-text)',
+          }}
+        >
+          + Agent
+        </button>
+        {isFolderPickerOpen && (
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '100%',
+              left: 0,
+              marginBottom: 4,
+              background: 'var(--pixel-bg)',
+              border: '2px solid var(--pixel-border)',
+              borderRadius: 0,
+              boxShadow: 'var(--pixel-shadow)',
+              minWidth: 160,
+              zIndex: 'var(--pixel-controls-z)',
+            }}
+          >
+            {workspaceFolders.map((folder, i) => (
+              <button
+                key={folder.path}
+                onClick={() => handleFolderSelect(folder)}
+                onMouseEnter={() => setHoveredFolder(i)}
+                onMouseLeave={() => setHoveredFolder(null)}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '6px 10px',
+                  fontSize: '22px',
+                  color: 'var(--pixel-text)',
+                  background: hoveredFolder === i ? 'var(--pixel-btn-hover-bg)' : 'transparent',
+                  border: 'none',
+                  borderRadius: 0,
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {folder.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <button
         onClick={onToggleEditMode}
         onMouseEnter={() => setHovered('edit')}

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -167,17 +167,33 @@ export function ToolOverlay({
                   }}
                 />
               )}
-              <span
-                style={{
-                  fontSize: isSub ? '20px' : '22px',
-                  fontStyle: isSub ? 'italic' : undefined,
-                  color: 'var(--vscode-foreground)',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {activityText}
-              </span>
+              <div style={{ overflow: 'hidden' }}>
+                <span
+                  style={{
+                    fontSize: isSub ? '20px' : '22px',
+                    fontStyle: isSub ? 'italic' : undefined,
+                    color: 'var(--vscode-foreground)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: 'block',
+                  }}
+                >
+                  {activityText}
+                </span>
+                {ch.folderName && (
+                  <span
+                    style={{
+                      fontSize: '16px',
+                      color: 'var(--pixel-text-dim)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: 'block',
+                    }}
+                  >
+                    {ch.folderName}
+                  </span>
+                )}
+              </div>
               {isSelected && !isSub && (
                 <button
                   onClick={(e) => {

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -193,7 +193,7 @@ export class OfficeState {
     return { palette, hueShift }
   }
 
-  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean): void {
+  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean, folderName?: string): void {
     if (this.characters.has(id)) return
 
     let palette: number
@@ -236,6 +236,9 @@ export class OfficeState {
       ch.tileRow = spawn.row
     }
 
+    if (folderName) {
+      ch.folderName = folderName
+    }
     if (!skipSpawnEffect) {
       ch.matrixEffect = 'spawn'
       ch.matrixEffectTimer = 0

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -193,4 +193,6 @@ export interface Character {
   matrixEffectTimer: number
   /** Per-column random seeds (16 values) for staggered rain timing */
   matrixEffectSeeds: number[]
+  /** Workspace folder name (only set for multi-root workspaces) */
+  folderName?: string
 }


### PR DESCRIPTION
## Summary

- In a multi-root workspace, clicking **+ Agent** now shows a QuickPick to select which folder to open Claude Code in
- Single-folder workspaces behave exactly as before (no QuickPick shown)
- Pressing Esc on the QuickPick cancels without creating a terminal or consuming a terminal index

## Motivation

When working with multi-root workspaces (e.g. a monorepo opened via `.code-workspace`), `launchNewTerminal` always used `workspaceFolders[0]` as the `cwd`. This meant Claude Code always started in the first folder, with no way to choose a different one.

## Changes

| File | Change |
|------|--------|
| `src/agentManager.ts` | `launchNewTerminal` → `async`, added `showQuickPick` when `folders.length > 1`, moved `nextTerminalIndexRef.current++` after folder selection |
| `src/PixelAgentsViewProvider.ts` | Added `await` to `launchNewTerminal()` call in `openClaude` handler |

## Test plan

- [ ] Single folder workspace → "+ Agent" opens terminal directly (no QuickPick)
- [ ] Multi-root workspace → "+ Agent" shows folder picker → terminal opens in selected folder
- [ ] Multi-root workspace → "+ Agent" → press Esc → no terminal created
- [ ] `npm run build` passes with no new errors