### PR TITLE
chore: lower VS Code engine requirement to ^1.107.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "icon": "icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.107.0"
   },
   "categories": [
     "Other"
@@ -65,7 +65,7 @@
     "@anthropic-ai/sdk": "^0.74.0",
     "@types/node": "22.x",
     "@types/pngjs": "^6.0.5",
-    "@types/vscode": "^1.109.0",
+    "@types/vscode": "^1.107.0",
     "esbuild": "^0.27.2",
     "eslint": "^9.39.2",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Summary

- Lower `engines.vscode` from `^1.109.0` to `^1.107.0`
- Lower `@types/vscode` devDependency accordingly

## Motivation

The extension doesn't use any API introduced in VS Code 1.109+. The newest API used is `WebviewViewProvider` (v1.64). Lowering the requirement broadens compatibility with older VS Code versions and compatible forks (e.g. Antigravity, Cursor) without any code changes.

## API audit

All VS Code APIs used in `src/`:

| API | Available since |
|-----|----------------|
| `WebviewViewProvider` | v1.64 |
| `window.createTerminal` | v1.6 |
| `window.showQuickPick` | v1.9 |
| `workspace.workspaceFolders` | v1.19 |
| `env.openExternal` | v1.25 |

No APIs from v1.109+ (`lm.tools`, `LanguageModelToolResult`, etc.) are present.

## Test plan

- [ ] `npm run build` passes
- [ ] Extension loads and functions normally in VS Code 1.107+