### PR TITLE
feat: stop typing when inactive

### DIFF
--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -93,9 +93,16 @@ export function updateCharacter(
 
   switch (ch.state) {
     case CharacterState.TYPE: {
-      if (ch.frameTimer >= TYPE_FRAME_DURATION_SEC) {
-        ch.frameTimer -= TYPE_FRAME_DURATION_SEC
-        ch.frame = (ch.frame + 1) % 2
+      // Only animate typing when active — pause animation when waiting for user
+      if (ch.isActive) {
+        if (ch.frameTimer >= TYPE_FRAME_DURATION_SEC) {
+          ch.frameTimer -= TYPE_FRAME_DURATION_SEC
+          ch.frame = (ch.frame + 1) % 2
+        }
+      } else {
+        // Not active — freeze on first frame (hands down, not typing)
+        ch.frame = 0
+        ch.frameTimer = 0
       }
       // If no longer active, stand up and start wandering (after seatTimer expires)
       if (!ch.isActive) {


### PR DESCRIPTION
I added a new feature to this PR that pauses Pixel agents from writing while the real Claude code agent is awaiting a response (e.g., an answer, approval, or other input).