### PR TITLE
Codex port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "build"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,16 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "build",
+			"type": "npm",
+			"script": "build",
+			"group": "build",
+			"problemMatcher": "$tsc",
+			"presentation": {
+				"reveal": "silent"
+			}
+		},
+		{
             "label": "watch",
             "dependsOn": [
                 "npm: watch:tsc",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A VS Code extension that turns your AI coding agents into animated pixel art characters in a virtual office.
 
-Each Claude Code terminal you open spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
+Each agent terminal you open spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
 
 This is the source code for the free [Pixel Agents extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) — you can install it directly from the marketplace with the full furniture catalog included.
 
@@ -11,7 +11,7 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 
 ## Features
 
-- **One agent, one character** — every Claude Code terminal gets its own animated character
+- **One agent, one character** — every launched agent terminal gets its own animated character
 - **Live activity tracking** — characters animate based on what the agent is actually doing (writing, reading, running commands)
 - **Office layout editor** — design your office with floors, walls, and furniture using a built-in editor
 - **Speech bubbles** — visual indicators when an agent is waiting for input or needs permission
@@ -27,7 +27,7 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 ## Requirements
 
 - VS Code 1.109.0 or later
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- Either [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) or Codex CLI installed and configured
 
 ## Getting Started
 
@@ -48,10 +48,17 @@ Then press **F5** in VS Code to launch the Extension Development Host.
 ### Usage
 
 1. Open the **Pixel Agents** panel (it appears in the bottom panel area alongside your terminal)
-2. Click **+ Agent** to spawn a new Claude Code terminal and its character
-3. Start coding with Claude — watch the character react in real time
+2. Click **+ Agent** to spawn a terminal for the configured CLI provider and its character
+3. Start coding with your selected provider — watch the character react in real time
 4. Click a character to select it, then click a seat to reassign it
 5. Click **Layout** to open the office editor and customize your space
+
+### CLI Provider Settings
+
+- `pixel-agents.cliProvider` — selects transcript/launch provider: `claude` (default) or `codex`
+- `pixel-agents.claudeCommand` — explicit Claude launch command (default `claude`), can be set to `cc`
+
+Pixel Agents does not auto-fallback from `claude` to `cc`, so macOS users avoid accidentally invoking system `cc` (`clang`) unless explicitly configured.
 
 ## Layout Editor
 
@@ -81,7 +88,10 @@ The extension will still work without the tileset — you'll get the default cha
 
 ## How It Works
 
-Pixel Agents watches Claude Code's JSONL transcript files to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to Claude Code are needed — it's purely observational.
+Pixel Agents watches CLI JSONL transcript files to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to Claude Code or Codex are needed — it's purely observational.
+
+- Claude transcripts: `~/.claude/projects/<workspace-hash>/*.jsonl`
+- Codex transcripts: `${CODEX_HOME:-~/.codex}/sessions/YYYY/MM/DD/*.jsonl` (workspace-matched by `session_meta.payload.cwd`)
 
 The webview runs a lightweight game loop with canvas rendering, BFS pathfinding, and a character state machine (idle → walk → type/read). Everything is pixel-perfect at integer zoom levels.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "*"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -46,6 +48,25 @@
           "name": "Pixel Agents"
         }
       ]
+    },
+    "configuration": {
+      "title": "Pixel Agents",
+      "properties": {
+        "pixel-agents.cliProvider": {
+          "type": "string",
+          "enum": [
+            "claude",
+            "codex"
+          ],
+          "default": "claude",
+          "description": "CLI transcript provider used by Pixel Agents. Claude remains the default for backward compatibility."
+        },
+        "pixel-agents.claudeCommand": {
+          "type": "string",
+          "default": "claude",
+          "description": "Command used to launch Claude sessions (for example: claude or cc). Pixel Agents uses this value exactly and does not auto-fallback."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const FILE_WATCHER_POLL_INTERVAL_MS = 2000;
 export const PROJECT_SCAN_INTERVAL_MS = 1000;
 export const TOOL_DONE_DELAY_MS = 300;
 export const PERMISSION_TIMER_DELAY_MS = 7000;
+export const PERMISSION_TIMER_SHELL_DELAY_MS = 15000;
 export const TEXT_IDLE_DELAY_MS = 5000;
 
 // ── Display Truncation ──────────────────────────────────────
@@ -39,4 +40,20 @@ export const COMMAND_EXPORT_DEFAULT_LAYOUT = 'pixel-agents.exportDefaultLayout';
 export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
-export const TERMINAL_NAME_PREFIX = 'Claude Code';
+
+// ── Settings Keys ────────────────────────────────────────────
+export const SETTING_CLI_PROVIDER = 'pixel-agents.cliProvider';
+export const SETTING_CLAUDE_COMMAND = 'pixel-agents.claudeCommand';
+
+// ── Provider Constants ───────────────────────────────────────
+export const CLI_PROVIDER_CLAUDE = 'claude';
+export const CLI_PROVIDER_CODEX = 'codex';
+export const TERMINAL_NAME_PREFIX_CLAUDE = 'Claude Code';
+export const TERMINAL_NAME_PREFIX_CODEX = 'Codex CLI';
+export const TERMINAL_NAME_PREFIX = TERMINAL_NAME_PREFIX_CLAUDE;
+export const CLAUDE_PROJECTS_SUBDIR = '.claude/projects';
+export const CODEX_HOME_SUBDIR = '.codex';
+export const CODEX_SESSIONS_SUBDIR = 'sessions';
+export const CODEX_SCAN_ADJACENT_DAYS = 1;
+export const CODEX_SESSION_META_READ_CHUNK_BYTES = 16384;
+export const CODEX_SESSION_META_READ_MAX_BYTES = 1048576;

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,10 +1,24 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import type { AgentState } from './types.js';
+import type { AgentState, CliProvider } from './types.js';
 import { cancelWaitingTimer, cancelPermissionTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
-import { FILE_WATCHER_POLL_INTERVAL_MS, PROJECT_SCAN_INTERVAL_MS } from './constants.js';
+import {
+	FILE_WATCHER_POLL_INTERVAL_MS,
+	PROJECT_SCAN_INTERVAL_MS,
+	CODEX_SESSION_META_READ_CHUNK_BYTES,
+	CODEX_SESSION_META_READ_MAX_BYTES,
+} from './constants.js';
+import { getCodexDateDirs, getTerminalPrefix } from './providerConfig.js';
+
+export interface ProjectScanConfig {
+	provider: CliProvider;
+	transcriptRoot: string;
+	workspaceRoot: string | null;
+}
+
+const projectScanConfigKeys = new WeakMap<object, string>();
 
 export function startFileWatching(
 	agentId: number,
@@ -16,7 +30,6 @@ export function startFileWatching(
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	webview: vscode.Webview | undefined,
 ): void {
-	// Primary: fs.watch
 	try {
 		const watcher = fs.watch(filePath, () => {
 			readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
@@ -26,9 +39,11 @@ export function startFileWatching(
 		console.log(`[Pixel Agents] fs.watch failed for agent ${agentId}: ${e}`);
 	}
 
-	// Backup: poll every 2s
 	const interval = setInterval(() => {
-		if (!agents.has(agentId)) { clearInterval(interval); return; }
+		if (!agents.has(agentId)) {
+			clearInterval(interval);
+			return;
+		}
 		readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
 	}, FILE_WATCHER_POLL_INTERVAL_MS);
 	pollingTimers.set(agentId, interval);
@@ -57,9 +72,8 @@ export function readNewLines(
 		const lines = text.split('\n');
 		agent.lineBuffer = lines.pop() || '';
 
-		const hasLines = lines.some(l => l.trim());
+		const hasLines = lines.some((l) => l.trim());
 		if (hasLines) {
-			// New data arriving — cancel timers (data flowing means agent is still active)
 			cancelWaitingTimer(agentId, waitingTimers);
 			cancelPermissionTimer(agentId, permissionTimers);
 			if (agent.permissionSent) {
@@ -78,7 +92,7 @@ export function readNewLines(
 }
 
 export function ensureProjectScan(
-	projectDir: string,
+	scanConfig: ProjectScanConfig,
 	knownJsonlFiles: Set<string>,
 	projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
 	activeAgentIdRef: { current: number | null },
@@ -91,28 +105,39 @@ export function ensureProjectScan(
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
 ): void {
-	if (projectScanTimerRef.current) return;
-	// Seed with all existing JSONL files so we only react to truly new ones
-	try {
-		const files = fs.readdirSync(projectDir)
-			.filter(f => f.endsWith('.jsonl'))
-			.map(f => path.join(projectDir, f));
-		for (const f of files) {
-			knownJsonlFiles.add(f);
-		}
-	} catch { /* dir may not exist yet */ }
+	const configKey = makeScanConfigKey(scanConfig);
+	if (projectScanTimerRef.current) {
+		const previousKey = projectScanConfigKeys.get(projectScanTimerRef);
+		if (previousKey === configKey) return;
+
+		clearInterval(projectScanTimerRef.current);
+		projectScanTimerRef.current = null;
+	}
+	projectScanConfigKeys.set(projectScanTimerRef, configKey);
+
+	for (const f of listDiscoverableJsonlFiles(scanConfig)) {
+		knownJsonlFiles.add(f);
+	}
 
 	projectScanTimerRef.current = setInterval(() => {
 		scanForNewJsonlFiles(
-			projectDir, knownJsonlFiles, activeAgentIdRef, nextAgentIdRef,
-			agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-			webview, persistAgents,
+			scanConfig,
+			knownJsonlFiles,
+			activeAgentIdRef,
+			nextAgentIdRef,
+			agents,
+			fileWatchers,
+			pollingTimers,
+			waitingTimers,
+			permissionTimers,
+			webview,
+			persistAgents,
 		);
 	}, PROJECT_SCAN_INTERVAL_MS);
 }
 
 function scanForNewJsonlFiles(
-	projectDir: string,
+	scanConfig: ProjectScanConfig,
 	knownJsonlFiles: Set<string>,
 	activeAgentIdRef: { current: number | null },
 	nextAgentIdRef: { current: number },
@@ -124,51 +149,192 @@ function scanForNewJsonlFiles(
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
 ): void {
-	let files: string[];
-	try {
-		files = fs.readdirSync(projectDir)
-			.filter(f => f.endsWith('.jsonl'))
-			.map(f => path.join(projectDir, f));
-	} catch { return; }
+	const files = listDiscoverableJsonlFiles(scanConfig);
 
 	for (const file of files) {
-		if (!knownJsonlFiles.has(file)) {
-			knownJsonlFiles.add(file);
-			if (activeAgentIdRef.current !== null) {
-				// Active agent focused → /clear reassignment
-				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
-				reassignAgentToFile(
-					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-					webview, persistAgents,
-				);
-			} else {
-				// No active agent → try to adopt the focused terminal
-				const activeTerminal = vscode.window.activeTerminal;
-				if (activeTerminal) {
-					let owned = false;
-					for (const agent of agents.values()) {
-						if (agent.terminalRef === activeTerminal) {
-							owned = true;
-							break;
-						}
-					}
-					if (!owned) {
-						adoptTerminalForFile(
-							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
-							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-							webview, persistAgents,
-						);
-					}
-				}
-			}
+		if (knownJsonlFiles.has(file)) continue;
+		knownJsonlFiles.add(file);
+
+		const terminalForAdoption = findAdoptableTerminal(scanConfig.provider, agents);
+		if (terminalForAdoption) {
+			adoptTerminalForFile(
+				terminalForAdoption,
+				scanConfig.provider,
+				file,
+				scanConfig.transcriptRoot,
+				nextAgentIdRef,
+				agents,
+				activeAgentIdRef,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
+		}
+
+		if (activeAgentIdRef.current !== null) {
+			console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
+			reassignAgentToFile(
+				activeAgentIdRef.current,
+				file,
+				agents,
+				fileWatchers,
+				pollingTimers,
+				waitingTimers,
+				permissionTimers,
+				webview,
+				persistAgents,
+			);
+			continue;
 		}
 	}
 }
 
+function makeScanConfigKey(scanConfig: ProjectScanConfig): string {
+	return `${scanConfig.provider}|${scanConfig.transcriptRoot}|${scanConfig.workspaceRoot || ''}`;
+}
+
+function isTerminalOwnedByAgent(terminal: vscode.Terminal, agents: Map<number, AgentState>): boolean {
+	for (const agent of agents.values()) {
+		if (agent.terminalRef === terminal) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function findAdoptableTerminal(
+	provider: CliProvider,
+	agents: Map<number, AgentState>,
+): vscode.Terminal | null {
+	const expectedPrefix = `${getTerminalPrefix(provider)} #`;
+	const activeTerminal = vscode.window.activeTerminal;
+
+	if (
+		activeTerminal
+		&& activeTerminal.name.startsWith(expectedPrefix)
+		&& !isTerminalOwnedByAgent(activeTerminal, agents)
+	) {
+		return activeTerminal;
+	}
+
+	const terminals = vscode.window.terminals;
+	for (let i = terminals.length - 1; i >= 0; i -= 1) {
+		const terminal = terminals[i];
+		if (!terminal.name.startsWith(expectedPrefix)) continue;
+		if (isTerminalOwnedByAgent(terminal, agents)) continue;
+		return terminal;
+	}
+
+	if (activeTerminal && !isTerminalOwnedByAgent(activeTerminal, agents)) {
+		return activeTerminal;
+	}
+
+	return null;
+}
+
+function listDiscoverableJsonlFiles(scanConfig: ProjectScanConfig): string[] {
+	if (scanConfig.provider === 'codex') {
+		return listCodexWorkspaceJsonlFiles(scanConfig.transcriptRoot, scanConfig.workspaceRoot);
+	}
+	return listFlatJsonlFiles(scanConfig.transcriptRoot);
+}
+
+function listFlatJsonlFiles(projectDir: string): string[] {
+	try {
+		return fs.readdirSync(projectDir)
+			.filter((f) => f.endsWith('.jsonl'))
+			.map((f) => path.join(projectDir, f));
+	} catch {
+		return [];
+	}
+}
+
+function listCodexWorkspaceJsonlFiles(sessionsRoot: string, workspaceRoot: string | null): string[] {
+	if (!workspaceRoot) return [];
+
+	const files: string[] = [];
+	const dateDirs = getCodexDateDirs(sessionsRoot);
+	for (const dir of dateDirs) {
+		let entries: string[];
+		try {
+			entries = fs.readdirSync(dir);
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (!entry.endsWith('.jsonl')) continue;
+			const filePath = path.join(dir, entry);
+			if (codexJsonlMatchesWorkspace(filePath, workspaceRoot)) {
+				files.push(filePath);
+			}
+		}
+	}
+
+	return files;
+}
+
+function codexJsonlMatchesWorkspace(filePath: string, workspaceRoot: string): boolean {
+	const firstLine = readFirstLine(filePath);
+	if (!firstLine) return false;
+
+	try {
+		const record = JSON.parse(firstLine) as { type?: string; payload?: { cwd?: string } };
+		return record.type === 'session_meta' && record.payload?.cwd === workspaceRoot;
+	} catch {
+		return false;
+	}
+}
+
+function readFirstLine(filePath: string): string | null {
+	let fd: number | null = null;
+	const parts: string[] = [];
+	let position = 0;
+	let remainingBytes = CODEX_SESSION_META_READ_MAX_BYTES;
+
+	try {
+		fd = fs.openSync(filePath, 'r');
+		const buffer = Buffer.alloc(CODEX_SESSION_META_READ_CHUNK_BYTES);
+
+		while (remainingBytes > 0) {
+			const bytesToRead = Math.min(buffer.length, remainingBytes);
+			const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead, position);
+			if (bytesRead <= 0) break;
+
+			position += bytesRead;
+			remainingBytes -= bytesRead;
+
+			const chunk = buffer.toString('utf-8', 0, bytesRead);
+			const newlineIdx = chunk.indexOf('\n');
+			if (newlineIdx >= 0) {
+				parts.push(chunk.slice(0, newlineIdx));
+				return parts.join('');
+			}
+			parts.push(chunk);
+		}
+	} catch {
+		return null;
+	} finally {
+		if (fd !== null) {
+			try {
+				fs.closeSync(fd);
+			} catch {
+				// ignore close failures
+			}
+		}
+	}
+
+	if (parts.length === 0) return null;
+	return parts.join('');
+}
+
 function adoptTerminalForFile(
 	terminal: vscode.Terminal,
+	provider: CliProvider,
 	jsonlFile: string,
 	projectDir: string,
 	nextAgentIdRef: { current: number },
@@ -184,6 +350,7 @@ function adoptTerminalForFile(
 	const id = nextAgentIdRef.current++;
 	const agent: AgentState = {
 		id,
+		provider,
 		terminalRef: terminal,
 		projectDir,
 		jsonlFile,
@@ -224,25 +391,23 @@ export function reassignAgentToFile(
 	const agent = agents.get(agentId);
 	if (!agent) return;
 
-	// Stop old file watching
 	fileWatchers.get(agentId)?.close();
 	fileWatchers.delete(agentId);
 	const pt = pollingTimers.get(agentId);
-	if (pt) { clearInterval(pt); }
+	if (pt) {
+		clearInterval(pt);
+	}
 	pollingTimers.delete(agentId);
 
-	// Clear activity
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 	clearAgentActivity(agent, agentId, permissionTimers, webview);
 
-	// Swap to new file
 	agent.jsonlFile = newFilePath;
 	agent.fileOffset = 0;
 	agent.lineBuffer = '';
 	persistAgents();
 
-	// Start watching new file
 	startFileWatching(agentId, newFilePath, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
 	readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
 }

--- a/src/providerConfig.ts
+++ b/src/providerConfig.ts
@@ -1,0 +1,90 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { CliProvider } from './types.js';
+import {
+	SETTING_CLI_PROVIDER,
+	SETTING_CLAUDE_COMMAND,
+	CLI_PROVIDER_CLAUDE,
+	CLI_PROVIDER_CODEX,
+	TERMINAL_NAME_PREFIX_CLAUDE,
+	TERMINAL_NAME_PREFIX_CODEX,
+	CLAUDE_PROJECTS_SUBDIR,
+	CODEX_HOME_SUBDIR,
+	CODEX_SESSIONS_SUBDIR,
+	CODEX_SCAN_ADJACENT_DAYS,
+} from './constants.js';
+
+export function getWorkspaceRoot(cwd?: string): string | null {
+	return cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || null;
+}
+
+export function getActiveProvider(): CliProvider {
+	const configured = vscode.workspace
+		.getConfiguration()
+		.get<string>(SETTING_CLI_PROVIDER, CLI_PROVIDER_CLAUDE);
+	return configured === CLI_PROVIDER_CODEX ? CLI_PROVIDER_CODEX : CLI_PROVIDER_CLAUDE;
+}
+
+export function getClaudeCommand(): string {
+	const configured = vscode.workspace
+		.getConfiguration()
+		.get<string>(SETTING_CLAUDE_COMMAND, 'claude')
+		.trim();
+	return configured || 'claude';
+}
+
+export function getTerminalPrefix(provider: CliProvider): string {
+	return provider === CLI_PROVIDER_CODEX ? TERMINAL_NAME_PREFIX_CODEX : TERMINAL_NAME_PREFIX_CLAUDE;
+}
+
+export function getLaunchCommand(provider: CliProvider, sessionId?: string): string {
+	if (provider === CLI_PROVIDER_CODEX) {
+		return CLI_PROVIDER_CODEX;
+	}
+	const baseCommand = getClaudeCommand();
+	return sessionId ? `${baseCommand} --session-id ${sessionId}` : baseCommand;
+}
+
+export function getClaudeProjectDir(workspaceRoot?: string): string | null {
+	const root = getWorkspaceRoot(workspaceRoot);
+	if (!root) return null;
+	const dirName = root.replace(/[:\\/]/g, '-');
+	return path.join(os.homedir(), CLAUDE_PROJECTS_SUBDIR, dirName);
+}
+
+export function getCodexHome(): string {
+	const envHome = process.env.CODEX_HOME?.trim();
+	if (envHome) {
+		return envHome;
+	}
+	return path.join(os.homedir(), CODEX_HOME_SUBDIR);
+}
+
+export function getCodexSessionsRoot(): string {
+	return path.join(getCodexHome(), CODEX_SESSIONS_SUBDIR);
+}
+
+export function getTranscriptRoot(provider: CliProvider, workspaceRoot?: string): string | null {
+	if (provider === CLI_PROVIDER_CODEX) {
+		return getCodexSessionsRoot();
+	}
+	return getClaudeProjectDir(workspaceRoot);
+}
+
+export function getCodexDateDirs(sessionsRoot: string, fromDate = new Date()): string[] {
+	const base = new Date(fromDate);
+	base.setHours(0, 0, 0, 0);
+
+	const dirs: string[] = [];
+	for (let offset = -CODEX_SCAN_ADJACENT_DAYS; offset <= CODEX_SCAN_ADJACENT_DAYS; offset += 1) {
+		const d = new Date(base);
+		d.setDate(base.getDate() + offset);
+		const year = String(d.getFullYear()).padStart(4, '0');
+		const month = String(d.getMonth() + 1).padStart(2, '0');
+		const day = String(d.getDate()).padStart(2, '0');
+		dirs.push(path.join(sessionsRoot, year, month, day));
+	}
+
+	return dirs;
+}

--- a/src/timerManager.ts
+++ b/src/timerManager.ts
@@ -72,6 +72,7 @@ export function startPermissionTimer(
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	permissionExemptTools: Set<string>,
 	webview: vscode.Webview | undefined,
+	delayMs = PERMISSION_TIMER_DELAY_MS,
 ): void {
 	cancelPermissionTimer(agentId, permissionTimers);
 	const timer = setTimeout(() => {
@@ -117,6 +118,6 @@ export function startPermissionTimer(
 				});
 			}
 		}
-	}, PERMISSION_TIMER_DELAY_MS);
+	}, delayMs);
 	permissionTimers.set(agentId, timer);
 }

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -13,9 +13,30 @@ import {
 	TEXT_IDLE_DELAY_MS,
 	BASH_COMMAND_DISPLAY_MAX_LENGTH,
 	TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+	PERMISSION_TIMER_SHELL_DELAY_MS,
 } from './constants.js';
 
-export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
+const CODEX_SHELL_LIKE_TOOLS = new Set(['exec_command', 'shell', 'shell_command']);
+
+const APPROVAL_SIGNAL_PATTERNS = [
+	/\bapprove\b/i,
+	/\bapproval\b/i,
+	/\ballow\b/i,
+	/\bpermission\b/i,
+	/do you want me to/i,
+	/would you like me to/i,
+	/should i proceed/i,
+	/can i proceed/i,
+	/confirm/i,
+];
+
+export const PERMISSION_EXEMPT_TOOLS = new Set([
+	'Task',
+	'AskUserQuestion',
+	'EnterPlanMode',
+	'update_plan',
+	'request_user_input',
+]);
 
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
 	const base = (p: unknown) => typeof p === 'string' ? path.basename(p) : '';
@@ -25,7 +46,7 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
 		case 'Write': return `Writing ${base(input.file_path)}`;
 		case 'Bash': {
 			const cmd = (input.command as string) || '';
-			return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : cmd}`;
+			return `Running: ${truncateStatusText(cmd, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`;
 		}
 		case 'Glob': return 'Searching files';
 		case 'Grep': return 'Searching code';
@@ -33,13 +54,59 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
 		case 'WebSearch': return 'Searching the web';
 		case 'Task': {
 			const desc = typeof input.description === 'string' ? input.description : '';
-			return desc ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}` : 'Running subtask';
+			return desc ? `Subtask: ${truncateStatusText(desc, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH)}` : 'Running subtask';
 		}
 		case 'AskUserQuestion': return 'Waiting for your answer';
 		case 'EnterPlanMode': return 'Planning';
-		case 'NotebookEdit': return `Editing notebook`;
+		case 'NotebookEdit': return 'Editing notebook';
 		default: return `Using ${toolName}`;
 	}
+}
+
+function formatCodexToolStatus(toolName: string, input: Record<string, unknown>): string {
+	switch (toolName) {
+		case 'exec_command':
+		case 'shell':
+		case 'shell_command': {
+			const command = extractShellCommand(input);
+			return command
+				? `Running: ${truncateStatusText(command, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`
+				: 'Running command';
+		}
+		case 'apply_patch':
+			return 'Editing files';
+		case 'update_plan':
+			return 'Planning';
+		default:
+			if (toolName.toLowerCase().includes('plan')) {
+				return 'Planning';
+			}
+			return `Using ${toolName}`;
+	}
+}
+
+function truncateStatusText(text: string, maxLength: number): string {
+	return text.length > maxLength ? `${text.slice(0, maxLength)}\u2026` : text;
+}
+
+function extractShellCommand(input: Record<string, unknown>): string {
+	const cmd = input.cmd;
+	if (typeof cmd === 'string' && cmd.trim()) {
+		return cmd;
+	}
+
+	const command = input.command;
+	if (typeof command === 'string' && command.trim()) {
+		return command;
+	}
+	if (Array.isArray(command)) {
+		return command
+			.filter((part): part is string => typeof part === 'string')
+			.join(' ')
+			.trim();
+	}
+
+	return '';
 }
 
 export function processTranscriptLine(
@@ -53,13 +120,22 @@ export function processTranscriptLine(
 	const agent = agents.get(agentId);
 	if (!agent) return;
 	try {
-		const record = JSON.parse(line);
+		const record = JSON.parse(line) as Record<string, unknown>;
 
-		if (record.type === 'assistant' && Array.isArray(record.message?.content)) {
-			const blocks = record.message.content as Array<{
-				type: string; id?: string; name?: string; input?: Record<string, unknown>;
+		if (record.type === 'response_item' || record.type === 'event_msg') {
+			processCodexRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
+			return;
+		}
+
+		const message = record.message as { content?: unknown } | undefined;
+		if (record.type === 'assistant' && Array.isArray(message?.content)) {
+			const blocks = message.content as Array<{
+				type: string;
+				id?: string;
+				name?: string;
+				input?: Record<string, unknown>;
 			}>;
-			const hasToolUse = blocks.some(b => b.type === 'tool_use');
+			const hasToolUse = blocks.some((b) => b.type === 'tool_use');
 
 			if (hasToolUse) {
 				cancelWaitingTimer(agentId, waitingTimers);
@@ -89,26 +165,21 @@ export function processTranscriptLine(
 				if (hasNonExemptTool) {
 					startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
 				}
-			} else if (blocks.some(b => b.type === 'text') && !agent.hadToolsInTurn) {
-				// Text-only response in a turn that hasn't used any tools.
-				// turn_duration handles tool-using turns reliably but is never
-				// emitted for text-only turns, so we use a silence-based timer:
-				// if no new JSONL data arrives within TEXT_IDLE_DELAY_MS, mark as waiting.
+			} else if (blocks.some((b) => b.type === 'text') && !agent.hadToolsInTurn) {
 				startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, webview);
 			}
 		} else if (record.type === 'progress') {
 			processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
 		} else if (record.type === 'user') {
-			const content = record.message?.content;
+			const content = message?.content;
 			if (Array.isArray(content)) {
 				const blocks = content as Array<{ type: string; tool_use_id?: string }>;
-				const hasToolResult = blocks.some(b => b.type === 'tool_result');
+				const hasToolResult = blocks.some((b) => b.type === 'tool_result');
 				if (hasToolResult) {
 					for (const block of blocks) {
 						if (block.type === 'tool_result' && block.tool_use_id) {
 							console.log(`[Pixel Agents] Agent ${agentId} tool done: ${block.tool_use_id}`);
 							const completedToolId = block.tool_use_id;
-							// If the completed tool was a Task, clear its subagent tools
 							if (agent.activeToolNames.get(completedToolId) === 'Task') {
 								agent.activeSubagentToolIds.delete(completedToolId);
 								agent.activeSubagentToolNames.delete(completedToolId);
@@ -131,19 +202,15 @@ export function processTranscriptLine(
 							}, TOOL_DONE_DELAY_MS);
 						}
 					}
-					// All tools completed — allow text-idle timer as fallback
-					// for turn-end detection when turn_duration is not emitted
 					if (agent.activeToolIds.size === 0) {
 						agent.hadToolsInTurn = false;
 					}
 				} else {
-					// New user text prompt — new turn starting
 					cancelWaitingTimer(agentId, waitingTimers);
 					clearAgentActivity(agent, agentId, permissionTimers, webview);
 					agent.hadToolsInTurn = false;
 				}
 			} else if (typeof content === 'string' && content.trim()) {
-				// New user text prompt — new turn starting
 				cancelWaitingTimer(agentId, waitingTimers);
 				clearAgentActivity(agent, agentId, permissionTimers, webview);
 				agent.hadToolsInTurn = false;
@@ -152,15 +219,7 @@ export function processTranscriptLine(
 			cancelWaitingTimer(agentId, waitingTimers);
 			cancelPermissionTimer(agentId, permissionTimers);
 
-			// Definitive turn-end: clean up any stale tool state
-			if (agent.activeToolIds.size > 0) {
-				agent.activeToolIds.clear();
-				agent.activeToolStatuses.clear();
-				agent.activeToolNames.clear();
-				agent.activeSubagentToolIds.clear();
-				agent.activeSubagentToolNames.clear();
-				webview?.postMessage({ type: 'agentToolsClear', id: agentId });
-			}
+			clearTrackedToolState(agent, agentId, webview);
 
 			agent.isWaiting = true;
 			agent.permissionSent = false;
@@ -173,6 +232,226 @@ export function processTranscriptLine(
 		}
 	} catch {
 		// Ignore malformed lines
+	}
+}
+
+function processCodexRecord(
+	agentId: number,
+	record: Record<string, unknown>,
+	agents: Map<number, AgentState>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+): void {
+	const agent = agents.get(agentId);
+	if (!agent) return;
+
+	if (record.type === 'response_item') {
+		const payload = record.payload as Record<string, unknown> | undefined;
+		if (!payload) return;
+
+		const payloadType = payload.type;
+		if (payloadType === 'function_call' || payloadType === 'custom_tool_call') {
+			const toolId = typeof payload.call_id === 'string' ? payload.call_id : '';
+			if (!toolId) return;
+
+			const toolName = typeof payload.name === 'string' ? payload.name : '';
+			const input = parseCodexToolInput(payload);
+			const status = formatCodexToolStatus(toolName, input);
+
+			cancelWaitingTimer(agentId, waitingTimers);
+			agent.isWaiting = false;
+			agent.hadToolsInTurn = true;
+			agent.activeToolIds.add(toolId);
+			agent.activeToolStatuses.set(toolId, status);
+			agent.activeToolNames.set(toolId, toolName);
+			webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+			webview?.postMessage({ type: 'agentToolStart', id: agentId, toolId, status });
+
+			if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+				const timerDelay = CODEX_SHELL_LIKE_TOOLS.has(toolName)
+					? PERMISSION_TIMER_SHELL_DELAY_MS
+					: undefined;
+				startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview, timerDelay);
+			}
+			return;
+		}
+
+		if (payloadType === 'function_call_output' || payloadType === 'custom_tool_call_output') {
+			const toolId = typeof payload.call_id === 'string' ? payload.call_id : '';
+			if (!toolId) return;
+
+			agent.activeToolIds.delete(toolId);
+			agent.activeToolStatuses.delete(toolId);
+			agent.activeToolNames.delete(toolId);
+
+			setTimeout(() => {
+				webview?.postMessage({ type: 'agentToolDone', id: agentId, toolId });
+			}, TOOL_DONE_DELAY_MS);
+
+			if (agent.activeToolIds.size === 0) {
+				agent.hadToolsInTurn = false;
+			}
+			return;
+		}
+
+		if (payloadType === 'message' && payload.role === 'assistant') {
+			const assistantText = extractMessageText(payload.content);
+			if (assistantText) {
+				maybeSignalPermissionWait(agentId, assistantText, agents, permissionTimers, webview);
+			}
+		}
+		return;
+	}
+
+	if (record.type === 'event_msg') {
+		const payload = record.payload as Record<string, unknown> | undefined;
+		if (!payload) return;
+
+		const eventType = payload.type;
+		if (eventType === 'task_started') {
+			cancelWaitingTimer(agentId, waitingTimers);
+			agent.isWaiting = false;
+			webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+			return;
+		}
+
+		if (eventType === 'user_message') {
+			cancelWaitingTimer(agentId, waitingTimers);
+			clearAgentActivity(agent, agentId, permissionTimers, webview);
+			agent.hadToolsInTurn = false;
+			return;
+		}
+
+		if (eventType === 'task_complete') {
+			cancelWaitingTimer(agentId, waitingTimers);
+			cancelPermissionTimer(agentId, permissionTimers);
+			clearTrackedToolState(agent, agentId, webview);
+
+			agent.isWaiting = true;
+			agent.permissionSent = false;
+			agent.hadToolsInTurn = false;
+			webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'waiting' });
+			return;
+		}
+
+		if (eventType === 'turn_aborted') {
+			cancelWaitingTimer(agentId, waitingTimers);
+			clearAgentActivity(agent, agentId, permissionTimers, webview);
+			agent.hadToolsInTurn = false;
+			return;
+		}
+
+		if (eventType === 'agent_message' && typeof payload.message === 'string') {
+			maybeSignalPermissionWait(agentId, payload.message, agents, permissionTimers, webview);
+		}
+	}
+}
+
+function parseCodexToolInput(payload: Record<string, unknown>): Record<string, unknown> {
+	const args = payload.arguments;
+	if (typeof args === 'string') {
+		try {
+			const parsed = JSON.parse(args) as unknown;
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed as Record<string, unknown>;
+			}
+		} catch {
+			// ignore parse errors
+		}
+	}
+
+	const input = payload.input;
+	if (input && typeof input === 'object' && !Array.isArray(input)) {
+		return input as Record<string, unknown>;
+	}
+
+	if (typeof input === 'string') {
+		return { input };
+	}
+
+	return {};
+}
+
+function extractMessageText(content: unknown): string {
+	if (!Array.isArray(content)) return '';
+	const chunks: string[] = [];
+	for (const part of content) {
+		if (!part || typeof part !== 'object') continue;
+		const rec = part as { type?: string; text?: string };
+		if (
+			(rec.type === 'output_text' || rec.type === 'input_text' || rec.type === 'text')
+			&& typeof rec.text === 'string'
+		) {
+			chunks.push(rec.text);
+		}
+	}
+	return chunks.join(' ').trim();
+}
+
+function maybeSignalPermissionWait(
+	agentId: number,
+	assistantText: string,
+	agents: Map<number, AgentState>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+): void {
+	if (!looksLikeApprovalPrompt(assistantText)) return;
+	const agent = agents.get(agentId);
+	if (!agent) return;
+	if (!hasNonExemptActiveTools(agent)) return;
+	if (agent.permissionSent) return;
+
+	cancelPermissionTimer(agentId, permissionTimers);
+	agent.permissionSent = true;
+	webview?.postMessage({ type: 'agentToolPermission', id: agentId });
+}
+
+function looksLikeApprovalPrompt(text: string): boolean {
+	const normalized = text.trim();
+	if (!normalized) return false;
+	return APPROVAL_SIGNAL_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function hasNonExemptActiveTools(agent: AgentState): boolean {
+	for (const toolId of agent.activeToolIds) {
+		const toolName = agent.activeToolNames.get(toolId);
+		if (!PERMISSION_EXEMPT_TOOLS.has(toolName || '')) {
+			return true;
+		}
+	}
+
+	for (const [, subToolNames] of agent.activeSubagentToolNames) {
+		for (const [, toolName] of subToolNames) {
+			if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+function clearTrackedToolState(
+	agent: AgentState,
+	agentId: number,
+	webview: vscode.Webview | undefined,
+): void {
+	const hadTrackedState =
+		agent.activeToolIds.size > 0
+		|| agent.activeToolStatuses.size > 0
+		|| agent.activeToolNames.size > 0
+		|| agent.activeSubagentToolIds.size > 0
+		|| agent.activeSubagentToolNames.size > 0;
+
+	agent.activeToolIds.clear();
+	agent.activeToolStatuses.clear();
+	agent.activeToolNames.clear();
+	agent.activeSubagentToolIds.clear();
+	agent.activeSubagentToolNames.clear();
+
+	if (hadTrackedState) {
+		webview?.postMessage({ type: 'agentToolsClear', id: agentId });
 	}
 }
 
@@ -193,8 +472,6 @@ function processProgressRecord(
 	const data = record.data as Record<string, unknown> | undefined;
 	if (!data) return;
 
-	// bash_progress / mcp_progress: tool is actively executing, not stuck on permission.
-	// Restart the permission timer to give the running tool another window.
 	const dataType = data.type as string | undefined;
 	if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
 		if (agent.activeToolIds.has(parentToolId)) {
@@ -203,7 +480,6 @@ function processProgressRecord(
 		return;
 	}
 
-	// Verify parent is an active Task tool (agent_progress handling)
 	if (agent.activeToolNames.get(parentToolId) !== 'Task') return;
 
 	const msg = data.message as Record<string, unknown> | undefined;
@@ -222,7 +498,6 @@ function processProgressRecord(
 				const status = formatToolStatus(toolName, block.input || {});
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool start: ${block.id} ${status} (parent: ${parentToolId})`);
 
-				// Track sub-tool IDs
 				let subTools = agent.activeSubagentToolIds.get(parentToolId);
 				if (!subTools) {
 					subTools = new Set();
@@ -230,7 +505,6 @@ function processProgressRecord(
 				}
 				subTools.add(block.id);
 
-				// Track sub-tool names (for permission checking)
 				let subNames = agent.activeSubagentToolNames.get(parentToolId);
 				if (!subNames) {
 					subNames = new Map();
@@ -259,7 +533,6 @@ function processProgressRecord(
 			if (block.type === 'tool_result' && block.tool_use_id) {
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool done: ${block.tool_use_id} (parent: ${parentToolId})`);
 
-				// Remove from tracking
 				const subTools = agent.activeSubagentToolIds.get(parentToolId);
 				if (subTools) {
 					subTools.delete(block.tool_use_id);
@@ -277,11 +550,10 @@ function processProgressRecord(
 						parentToolId,
 						toolId,
 					});
-				}, 300);
+				}, TOOL_DONE_DELAY_MS);
 			}
 		}
-		// If there are still active non-exempt sub-agent tools, restart the permission timer
-		// (handles the case where one sub-agent completes but another is still stuck)
+
 		let stillHasNonExempt = false;
 		for (const [, subNames] of agent.activeSubagentToolNames) {
 			for (const [, toolName] of subNames) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 import type * as vscode from 'vscode';
 
+export type CliProvider = 'claude' | 'codex';
+
 export interface AgentState {
 	id: number;
+	provider: CliProvider;
 	terminalRef: vscode.Terminal;
 	projectDir: string;
 	jsonlFile: string;
@@ -19,6 +22,7 @@ export interface AgentState {
 
 export interface PersistedAgent {
 	id: number;
+	provider: CliProvider;
 	terminalName: string;
 	jsonlFile: string;
 	projectDir: string;

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1432,7 +1431,6 @@
       "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1443,7 +1441,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1503,7 +1500,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1755,7 +1751,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1861,7 +1856,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2083,7 +2077,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2770,7 +2763,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2832,7 +2824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3038,7 +3029,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3125,7 +3115,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3247,7 +3236,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -225,7 +225,7 @@ function App() {
 
       <BottomToolbar
         isEditMode={editor.isEditMode}
-        onOpenClaude={editor.handleOpenClaude}
+        onOpenAgent={editor.handleOpenAgent}
         onToggleEditMode={editor.handleToggleEditMode}
         isDebugMode={isDebugMode}
         onToggleDebugMode={handleToggleDebugMode}

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -3,7 +3,7 @@ import { SettingsModal } from './SettingsModal.js'
 
 interface BottomToolbarProps {
   isEditMode: boolean
-  onOpenClaude: () => void
+  onOpenAgent: () => void
   onToggleEditMode: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
@@ -43,7 +43,7 @@ const btnActive: React.CSSProperties = {
 
 export function BottomToolbar({
   isEditMode,
-  onOpenClaude,
+  onOpenAgent,
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
@@ -54,7 +54,7 @@ export function BottomToolbar({
   return (
     <div style={panelStyle}>
       <button
-        onClick={onOpenClaude}
+        onClick={onOpenAgent}
         onMouseEnter={() => setHovered('agent')}
         onMouseLeave={() => setHovered(null)}
         style={{

--- a/webview-ui/src/hooks/useEditorActions.ts
+++ b/webview-ui/src/hooks/useEditorActions.ts
@@ -19,7 +19,7 @@ export interface EditorActions {
   panRef: React.MutableRefObject<{ x: number; y: number }>
   saveTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
   setLastSavedLayout: (layout: OfficeLayout) => void
-  handleOpenClaude: () => void
+  handleOpenAgent: () => void
   handleToggleEditMode: () => void
   handleToolChange: (tool: EditToolType) => void
   handleTileTypeChange: (type: TileTypeVal) => void
@@ -78,8 +78,8 @@ export function useEditorActions(
     setEditorTick((n) => n + 1)
   }, [getOfficeState, editorState, saveLayout])
 
-  const handleOpenClaude = useCallback(() => {
-    vscode.postMessage({ type: 'openClaude' })
+  const handleOpenAgent = useCallback(() => {
+    vscode.postMessage({ type: 'openAgent' })
   }, [])
 
   const handleToggleEditMode = useCallback(() => {
@@ -503,7 +503,7 @@ export function useEditorActions(
     panRef,
     saveTimerRef,
     setLastSavedLayout,
-    handleOpenClaude,
+    handleOpenAgent,
     handleToggleEditMode,
     handleToolChange,
     handleTileTypeChange,


### PR DESCRIPTION
## Summary

Adds provider-aware agent support so Pixel Agents can run with Claude Code (default) or Codex CLI.

## Changes

- Added settings:
  - `pixel-agents.cliProvider` (`claude` | `codex`)
  - `pixel-agents.claudeCommand` (explicit Claude command, no auto-fallback)
- Added provider config helpers for launch commands, terminal naming, and transcript roots.
- Updated agent lifecycle/persistence to track provider.
- Extended transcript discovery/parsing for Codex JSONL sessions (workspace-matched via `session_meta.payload.cwd`).
- Renamed webview action to `openAgent` while keeping `openClaude` backward compatible.
- Updated README/CLAUDE docs.

## Validation

- `npm run build` passes.
- Manual run in Extension Development Host confirmed agent flow works locally.
