### PR TITLE
Add first-run welcome overlay for new users

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -14,6 +14,7 @@ import { useEditorKeyboard } from './hooks/useEditorKeyboard.js'
 import { ZoomControls } from './components/ZoomControls.js'
 import { BottomToolbar } from './components/BottomToolbar.js'
 import { DebugView } from './components/DebugView.js'
+import { WelcomeOverlay } from './components/WelcomeOverlay.js'
 
 // Game state lives outside React — updated imperatively by message handlers
 const officeStateRef = { current: null as OfficeState | null }
@@ -222,6 +223,8 @@ function App() {
           zIndex: 40,
         }}
       />
+
+      {agents.length === 0 && !editor.isEditMode && <WelcomeOverlay />}
 
       <BottomToolbar
         isEditMode={editor.isEditMode}

--- a/webview-ui/src/components/WelcomeOverlay.tsx
+++ b/webview-ui/src/components/WelcomeOverlay.tsx
@@ -1,0 +1,123 @@
+import { useState, useCallback } from 'react'
+import { CLAUDE_CODE_INSTALL_CMD } from '../constants.js'
+
+// Shown over the office canvas when no agents exist yet.
+// Guides first-time users through the two-step setup without leaving the panel.
+// Disappears naturally once the first agent is created.
+export function WelcomeOverlay() {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(CLAUDE_CODE_INSTALL_CMD).then(() => {
+      setCopied(true)
+      // Reset copy state after a short delay so the button is reusable
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }, [])
+
+  return (
+    // Outer div fills the canvas but lets pointer events pass through to the
+    // office and toolbar beneath — only the card itself captures interaction
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 60,
+        pointerEvents: 'none',
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--pixel-bg)',
+          border: '2px solid var(--pixel-border)',
+          boxShadow: '4px 4px 0px #0a0a14',
+          padding: '20px 24px',
+          maxWidth: 340,
+          pointerEvents: 'all',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '28px',
+            color: 'var(--pixel-text)',
+            marginBottom: 16,
+            fontWeight: 'bold',
+          }}
+        >
+          Welcome to Pixel Agents
+        </div>
+
+        <div style={{ fontSize: '22px', color: 'var(--pixel-text-dim)', lineHeight: 1.6 }}>
+          {/* Step 1 – install the CLI */}
+          <div style={{ marginBottom: 14 }}>
+            <span style={{ color: 'var(--pixel-accent)' }}>①</span>
+            {' '}Install Claude Code (one-time):
+          </div>
+
+          {/* Install command with one-click copy */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              background: 'rgba(0,0,0,0.3)',
+              border: '2px solid var(--pixel-border)',
+              padding: '6px 8px',
+              marginBottom: 14,
+            }}
+          >
+            <code
+              style={{ fontSize: '18px', color: '#9cdcfe', flex: 1, wordBreak: 'break-all' }}
+            >
+              {CLAUDE_CODE_INSTALL_CMD}
+            </code>
+            <button
+              onClick={handleCopy}
+              title="Copy to clipboard"
+              style={{
+                flexShrink: 0,
+                fontSize: '18px',
+                padding: '2px 8px',
+                background: copied ? 'rgba(90,200,140,0.2)' : 'var(--pixel-btn-bg)',
+                color: copied ? 'var(--pixel-green)' : 'var(--pixel-text-dim)',
+                border: `2px solid ${copied ? 'var(--pixel-green)' : 'transparent'}`,
+                borderRadius: 0,
+                cursor: 'pointer',
+              }}
+            >
+              {copied ? '✓' : 'Copy'}
+            </button>
+          </div>
+
+          {/* Step 2 – authenticate */}
+          <div style={{ marginBottom: 6 }}>
+            <span style={{ color: 'var(--pixel-accent)' }}>②</span>
+            {' '}Run{' '}
+            <code style={{ fontSize: '18px', color: '#9cdcfe' }}>claude</code>
+            {' '}and sign in
+          </div>
+
+          {/* Step 3 – create the first agent */}
+          <div>
+            <span style={{ color: 'var(--pixel-accent)' }}>③</span>
+            {' '}Click{' '}
+            <span
+              style={{
+                color: 'var(--pixel-agent-text)',
+                background: 'rgba(90,200,140,0.15)',
+                padding: '1px 6px',
+                border: '1px solid var(--pixel-agent-border)',
+              }}
+            >
+              + Agent
+            </span>
+            {' '}below
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -96,6 +96,12 @@ export const NOTIFICATION_NOTE_2_START_SEC = 0.1
 export const NOTIFICATION_NOTE_DURATION_SEC = 0.18
 export const NOTIFICATION_VOLUME = 0.14
 
+// ── Welcome Overlay ─────────────────────────────────────────
+// Shell command shown in the first-run overlay to guide users who haven't
+// installed Claude Code yet. Centralised here so it's easy to update if the
+// install URL ever changes.
+export const CLAUDE_CODE_INSTALL_CMD = 'curl -fsSL https://claude.ai/install.sh | bash'
+
 // ── Game Logic ───────────────────────────────────────────────
 export const MAX_DELTA_TIME_SEC = 0.1
 export const WAITING_BUBBLE_DURATION_SEC = 2.0


### PR DESCRIPTION
## What

Adds a `WelcomeOverlay` component that appears over the empty office when no agents exist yet. It walks new users through the three steps required to get started — install Claude Code, sign in, then click **+ Agent** — without leaving the panel.

The overlay disappears automatically as soon as the first agent is created, so it has no impact on regular use.

## Why

Without this, opening the panel for the first time shows an empty office with no indication of what to do next. The only affordance is the **+ Agent** button, but clicking it does nothing useful if Claude Code isn't installed. This makes the first experience confusing, especially for people who aren't already familiar with Claude Code - which is one of the main gains of this extension. 

## Changes

| File | Change |
|------|--------|
| `webview-ui/src/components/WelcomeOverlay.tsx` | New component — three-step setup guide with one-click copy for the install command |
| `webview-ui/src/constants.ts` | `CLAUDE_CODE_INSTALL_CMD` added per project constant conventions |
| `webview-ui/src/App.tsx` | Import + render `<WelcomeOverlay />` when `agents.length === 0 && !isEditMode` |

## Design decisions

- **Pointer events**: the outer wrapper is `pointerEvents: none` so the office canvas, zoom controls, and bottom toolbar remain fully interactive behind the card.
- **Auto-dismiss**: no close/dismiss button. The overlay is a loading state, not a modal — it goes away the moment its condition is no longer true (agent created). No state to manage, no way for it to get stuck.
- **Pixel art aesthetic**: sharp corners, `2px solid` border, hard offset shadow, `--pixel-*` CSS variables — matches all other overlays in the project.
- **Constant in `constants.ts`**: the install URL is centralised so it's easy to update if the URL ever changes, consistent with project rules.

## How to test

1. Run `npm run build` and press **F5** to open the Extension Development Host
2. Open the **Pixel Agents** panel in the bottom bar
3. **Before any agents exist**: the welcome card should appear centred over the office with the three setup steps and a working Copy button
4. Click **+ Agent**: the overlay disappears immediately as the character spawns
5. Close all agents: the overlay returns
6. Switch to **Layout** edit mode: the overlay is hidden (edit mode has its own context)
7. Switch back out of edit mode with no agents: overlay reappears

## Screenshots

_The overlay as seen on first open (no agents):_
<img width="895" height="604" alt="Captura de pantalla 2026-02-24 a las 22 37 26" src="https://github.com/user-attachments/assets/a66ab4eb-2d4c-4057-a6a8-c683a62b9157" />



> Note: the office canvas and all controls remain visible and interactive behind the card.