### PR TITLE
Wrap each agent in a tmux session for persistence

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,10 @@ export const LAYOUT_FILE_POLL_INTERVAL_MS = 2000;
 // ── Settings Persistence ────────────────────────────────────
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 
+// ── tmux ─────────────────────────────────────────────────────
+export const TMUX_SESSION_PREFIX = 'pixel-agents-';
+export const TMUX_HEALTH_CHECK_INTERVAL_MS = 5000;
+
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';
 export const COMMAND_SHOW_PANEL = 'pixel-agents.showPanel';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { VIEW_ID, COMMAND_SHOW_PANEL, COMMAND_EXPORT_DEFAULT_LAYOUT } from './co
 let providerInstance: PixelAgentsViewProvider | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
+	console.log('[Pixel Agents] ✅ DEV BUILD activated (tmux support)');
 	const provider = new PixelAgentsViewProvider(context);
 	providerInstance = provider;
 

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -148,7 +148,7 @@ function scanForNewJsonlFiles(
 				if (activeTerminal) {
 					let owned = false;
 					for (const agent of agents.values()) {
-						if (agent.terminalRef === activeTerminal) {
+						if (agent.terminalRef && agent.terminalRef === activeTerminal) {
 							owned = true;
 							break;
 						}
@@ -197,6 +197,8 @@ function adoptTerminalForFile(
 		isWaiting: false,
 		permissionSent: false,
 		hadToolsInTurn: false,
+		tmuxSessionName: null,
+		isDetached: false,
 	};
 
 	agents.set(id, agent);

--- a/src/tmuxManager.ts
+++ b/src/tmuxManager.ts
@@ -1,0 +1,85 @@
+import { execSync } from 'child_process';
+import { TMUX_SESSION_PREFIX } from './constants.js';
+
+let tmuxAvailableCache: boolean | null = null;
+
+/** Check whether tmux is installed and reachable. Result is cached. */
+export function isTmuxAvailable(): boolean {
+	if (tmuxAvailableCache !== null) return tmuxAvailableCache;
+	try {
+		execSync('tmux -V', { stdio: 'pipe', timeout: 3000 });
+		tmuxAvailableCache = true;
+	} catch {
+		tmuxAvailableCache = false;
+	}
+	return tmuxAvailableCache;
+}
+
+/** Build a deterministic tmux session name from agent id and session uuid. */
+export function buildTmuxSessionName(agentId: number, sessionUuid: string): string {
+	return `${TMUX_SESSION_PREFIX}${agentId}-${sessionUuid}`;
+}
+
+/** Extract the session UUID from a tmux session name, or null if not matching. */
+export function parseSessionUuidFromName(name: string): string | null {
+	if (!name.startsWith(TMUX_SESSION_PREFIX)) return null;
+	const rest = name.slice(TMUX_SESSION_PREFIX.length);
+	// Format: {agentId}-{uuid}  —  uuid contains dashes, agentId is numeric
+	const dashIdx = rest.indexOf('-');
+	if (dashIdx < 0) return null;
+	return rest.slice(dashIdx + 1);
+}
+
+/** Parse the agent ID from a tmux session name, or null if not matching. */
+export function parseAgentIdFromName(name: string): number | null {
+	if (!name.startsWith(TMUX_SESSION_PREFIX)) return null;
+	const rest = name.slice(TMUX_SESSION_PREFIX.length);
+	const dashIdx = rest.indexOf('-');
+	if (dashIdx < 0) return null;
+	const idStr = rest.slice(0, dashIdx);
+	const id = parseInt(idStr, 10);
+	return Number.isFinite(id) ? id : null;
+}
+
+/** List all tmux sessions whose name starts with the pixel-agents prefix. */
+export function listPixelAgentsSessions(): string[] {
+	try {
+		const output = execSync("tmux list-sessions -F '#{session_name}'", {
+			stdio: 'pipe',
+			timeout: 3000,
+		}).toString().trim();
+		if (!output) return [];
+		return output.split('\n').filter(name => name.startsWith(TMUX_SESSION_PREFIX));
+	} catch {
+		return [];
+	}
+}
+
+/** Check whether a specific tmux session is still alive. */
+export function isTmuxSessionAlive(sessionName: string): boolean {
+	try {
+		execSync(`tmux has-session -t '${sessionName}'`, { stdio: 'pipe', timeout: 3000 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Kill a tmux session. */
+export function killTmuxSession(sessionName: string): void {
+	try {
+		execSync(`tmux kill-session -t '${sessionName}'`, { stdio: 'pipe', timeout: 3000 });
+	} catch {
+		// Session may already be dead
+	}
+}
+
+/** Build a shell command that creates a new tmux session running claude. */
+export function buildNewSessionCommand(sessionName: string, sessionUuid: string): string {
+	return `tmux new-session -d -s '${sessionName}' 'claude --session-id ${sessionUuid}' && tmux attach-session -t '${sessionName}'`;
+}
+
+/** Build a shell command that attaches to an existing tmux session. */
+export function buildAttachCommand(sessionName: string): string {
+	return `tmux attach-session -t '${sessionName}'`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type * as vscode from 'vscode';
 
 export interface AgentState {
 	id: number;
-	terminalRef: vscode.Terminal;
+	terminalRef: vscode.Terminal | null;
 	projectDir: string;
 	jsonlFile: string;
 	fileOffset: number;
@@ -15,6 +15,8 @@ export interface AgentState {
 	isWaiting: boolean;
 	permissionSent: boolean;
 	hadToolsInTurn: boolean;
+	tmuxSessionName: string | null;
+	isDetached: boolean;
 }
 
 export interface PersistedAgent {
@@ -22,4 +24,5 @@ export interface PersistedAgent {
 	terminalName: string;
 	jsonlFile: string;
 	projectDir: string;
+	tmuxSessionName?: string;
 }

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -96,6 +96,9 @@ export const NOTIFICATION_NOTE_2_START_SEC = 0.1
 export const NOTIFICATION_NOTE_DURATION_SEC = 0.18
 export const NOTIFICATION_VOLUME = 0.14
 
+// ── Detached Agent ───────────────────────────────────────────
+export const DETACHED_CHARACTER_ALPHA = 0.45
+
 // ── Game Logic ───────────────────────────────────────────────
 export const MAX_DELTA_TIME_SEC = 0.1
 export const WAITING_BUBBLE_DURATION_SEC = 2.0

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -155,6 +155,18 @@ export function useExtensionMessages(
           }
           return merged.sort((a, b) => a - b)
         })
+      } else if (msg.type === 'agentDetached') {
+        const id = msg.id as number
+        os.setAgentDetached(id, true)
+      } else if (msg.type === 'agentReattached') {
+        const id = msg.id as number
+        os.setAgentDetached(id, false)
+        setAgentStatuses((prev) => {
+          if (!(id in prev)) return prev
+          const next = { ...prev }
+          delete next[id]
+          return next
+        })
       } else if (msg.type === 'agentToolStart') {
         const id = msg.id as number
         const toolId = msg.toolId as string

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -45,6 +45,7 @@
   /* Status dot colors */
   --pixel-status-permission: var(--vscode-charts-yellow, #cca700);
   --pixel-status-active: var(--vscode-charts-blue, #3794ff);
+  --pixel-status-detached: rgba(120, 130, 160, 0.8);
 
   /* ToolOverlay z-index layers */
   --pixel-overlay-z: 100;

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -100,7 +100,9 @@ export function ToolOverlay({
         // Get activity text
         const subHasPermission = isSub && ch.bubbleType === 'permission'
         let activityText: string
-        if (isSub) {
+        if (ch.isDetached) {
+          activityText = 'Detached'
+        } else if (isSub) {
           if (subHasPermission) {
             activityText = 'Needs approval'
           } else {
@@ -118,7 +120,9 @@ export function ToolOverlay({
         const isActive = ch.isActive
 
         let dotColor: string | null = null
-        if (hasPermission) {
+        if (ch.isDetached) {
+          dotColor = 'var(--pixel-status-detached)'
+        } else if (hasPermission) {
           dotColor = 'var(--pixel-status-permission)'
         } else if (isActive && hasActiveTools) {
           dotColor = 'var(--pixel-status-active)'

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -69,6 +69,7 @@ export function createCharacter(
     wanderCount: 0,
     wanderLimit: randomInt(WANDER_MOVES_BEFORE_REST_MIN, WANDER_MOVES_BEFORE_REST_MAX),
     isActive: true,
+    isDetached: false,
     seatId,
     bubbleType: null,
     bubbleTimer: 0,

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -491,6 +491,19 @@ export class OfficeState {
     return this.subagentIdMap.get(`${parentAgentId}:${parentToolId}`) ?? null
   }
 
+  setAgentDetached(id: number, detached: boolean): void {
+    const ch = this.characters.get(id)
+    if (!ch) return
+    ch.isDetached = detached
+    if (detached) {
+      ch.isActive = false
+      ch.bubbleType = 'detached'
+      ch.bubbleTimer = 0
+    } else {
+      ch.bubbleType = null
+    }
+  }
+
   setAgentActive(id: number, active: boolean): void {
     const ch = this.characters.get(id)
     if (ch) {

--- a/webview-ui/src/office/sprites/spriteData.ts
+++ b/webview-ui/src/office/sprites/spriteData.ts
@@ -318,6 +318,28 @@ export const BUBBLE_WAITING_SPRITE: SpriteData = (() => {
   ]
 })()
 
+/** Detached bubble: gray square with X symbol, and a tail pointer (11x13) */
+export const BUBBLE_DETACHED_SPRITE: SpriteData = (() => {
+  const B = '#555566' // border
+  const F = '#DDDDE8' // fill (slightly muted)
+  const X = '#7888A0' // gray-blue X symbol
+  return [
+    [_, B, B, B, B, B, B, B, B, B, _],
+    [B, F, F, F, F, F, F, F, F, F, B],
+    [B, F, F, F, F, F, F, F, F, F, B],
+    [B, F, F, X, F, F, F, X, F, F, B],
+    [B, F, F, F, X, F, X, F, F, F, B],
+    [B, F, F, F, F, X, F, F, F, F, B],
+    [B, F, F, F, X, F, X, F, F, F, B],
+    [B, F, F, X, F, F, F, X, F, F, B],
+    [B, F, F, F, F, F, F, F, F, F, B],
+    [_, B, B, B, B, B, B, B, B, B, _],
+    [_, _, _, _, B, B, B, _, _, _, _],
+    [_, _, _, _, _, B, _, _, _, _, _],
+    [_, _, _, _, _, _, _, _, _, _, _],
+  ]
+})()
+
 // ── Character Sprites ───────────────────────────────────────────
 // 16x24 characters with palette substitution
 

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -177,8 +177,10 @@ export interface Character {
   isActive: boolean
   /** Assigned seat uid, or null if no seat */
   seatId: string | null
+  /** Whether this agent's terminal is detached (tmux session still alive) */
+  isDetached: boolean
   /** Active speech bubble type, or null if none showing */
-  bubbleType: 'permission' | 'waiting' | null
+  bubbleType: 'permission' | 'waiting' | 'detached' | null
   /** Countdown timer for bubble (waiting: 2→0, permission: unused) */
   bubbleTimer: number
   /** Timer to stay seated while inactive after seat reassignment (counts down to 0) */


### PR DESCRIPTION
## Summary

- Wrap each agent's Claude process in a tmux session so closing a VS Code terminal only detaches -- Claude keeps running
- Detached agents appear semi-transparent with a gray X bubble in the office; clicking reattaches
- On startup, orphaned tmux sessions are auto-discovered and reconnected
- Falls back to current direct-terminal behavior when tmux is unavailable

Closes #34

## Changes

- **New file `src/tmuxManager.ts`**: Pure functions for tmux shell interactions (availability check, session naming, list/check/kill, build commands)
- **Backend**: Launch wraps in tmux; terminal close → detach; focus → reattach; close → kill tmux; 5s health check; orphan discovery; persist/restore detached state
- **Webview**: Detached characters at 45% opacity with gray X bubble sprite, "Detached" status overlay, `--pixel-status-detached` CSS variable

## Test plan

- [ ] Launch agent with tmux installed → verify `tmux ls` shows session
- [ ] Close terminal → character goes semi-transparent with X bubble
- [ ] Click detached character → reattaches via new terminal
- [ ] Close agent via X button → tmux session killed
- [ ] Launch agent without tmux → verify direct-terminal fallback works unchanged
- [ ] Close VS Code → reopen → detached agents restored from persisted tmux sessions
- [ ] Orphaned tmux sessions auto-discovered on startup
- [ ] Manually kill tmux session while detached → agent removed within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)