### PR TITLE
Add agent role labels, task notes, and blocked status

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -14,7 +14,7 @@ import {
 } from './agentManager.js';
 import { ensureProjectScan } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
-import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
+import { WORKSPACE_KEY_AGENT_SEATS, WORKSPACE_KEY_AGENT_ROLES, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
 import { writeLayoutToFile, readLayoutFromFile, watchLayoutFile } from './layoutPersistence.js';
 import type { LayoutWatcher } from './layoutPersistence.js';
 
@@ -84,6 +84,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				// Store seat assignments in a separate key (never touched by persistAgents)
 				console.log(`[Pixel Agents] saveAgentSeats:`, JSON.stringify(message.seats));
 				this.context.workspaceState.update(WORKSPACE_KEY_AGENT_SEATS, message.seats);
+			} else if (message.type === 'saveAgentRoles') {
+				this.context.workspaceState.update(WORKSPACE_KEY_AGENT_ROLES, message.roles);
 			} else if (message.type === 'saveLayout') {
 				this.layoutWatcher?.markOwnWrite();
 				writeLayoutToFile(message.layout as Record<string, unknown>);

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import type { AgentState, PersistedAgent } from './types.js';
 import { cancelWaitingTimer, cancelPermissionTimer } from './timerManager.js';
 import { startFileWatching, readNewLines, ensureProjectScan } from './fileWatcher.js';
-import { JSONL_POLL_INTERVAL_MS, TERMINAL_NAME_PREFIX, WORKSPACE_KEY_AGENTS, WORKSPACE_KEY_AGENT_SEATS } from './constants.js';
+import { JSONL_POLL_INTERVAL_MS, TERMINAL_NAME_PREFIX, WORKSPACE_KEY_AGENTS, WORKSPACE_KEY_AGENT_SEATS, WORKSPACE_KEY_AGENT_ROLES } from './constants.js';
 import { migrateAndLoadLayout } from './layoutPersistence.js';
 
 export function getProjectDirPath(cwd?: string): string | null {
@@ -266,12 +266,14 @@ export function sendExistingAgents(
 
 	// Include persisted palette/seatId from separate key
 	const agentMeta = context.workspaceState.get<Record<string, { palette?: number; seatId?: string }>>(WORKSPACE_KEY_AGENT_SEATS, {});
+	const agentRoles = context.workspaceState.get<Record<string, { role?: string; taskNote?: string; isBlocked?: boolean }>>(WORKSPACE_KEY_AGENT_ROLES, {});
 	console.log(`[Pixel Agents] sendExistingAgents: agents=${JSON.stringify(agentIds)}, meta=${JSON.stringify(agentMeta)}`);
 
 	webview.postMessage({
 		type: 'existingAgents',
 		agents: agentIds,
 		agentMeta,
+		agentRoles,
 	});
 
 	sendCurrentAgentStatuses(agents, webview);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,5 +38,6 @@ export const COMMAND_SHOW_PANEL = 'pixel-agents.showPanel';
 export const COMMAND_EXPORT_DEFAULT_LAYOUT = 'pixel-agents.exportDefaultLayout';
 export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
+export const WORKSPACE_KEY_AGENT_ROLES = 'pixel-agents.agentRoles';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
 export const TERMINAL_NAME_PREFIX = 'Claude Code';

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -121,7 +121,7 @@ function App() {
 
   const isEditDirty = useCallback(() => editor.isEditMode && editor.isDirty, [editor.isEditMode, editor.isDirty])
 
-  const { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
+  const { agents, selectedAgent, agentTools, agentStatuses, subagentTools, subagentCharacters, layoutReady, loadedAssets, onUpdateAgentRole } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty)
 
   const [isDebugMode, setIsDebugMode] = useState(false)
 
@@ -150,8 +150,12 @@ function App() {
     vscode.postMessage({ type: 'closeAgent', id })
   }, [])
 
-  const handleClick = useCallback((agentId: number) => {
-    // If clicked agent is a sub-agent, focus the parent's terminal instead
+  // Click on character only selects it (shows overlay). Focus terminal via the ⌨ button.
+  const handleClick = useCallback((_agentId: number) => {
+    // Selection is handled imperatively by OfficeCanvas
+  }, [])
+
+  const handleFocusAgent = useCallback((agentId: number) => {
     const os = getOfficeState()
     const meta = os.subagentMeta.get(agentId)
     const focusId = meta ? meta.parentAgentId : agentId
@@ -293,6 +297,8 @@ function App() {
         zoom={editor.zoom}
         panRef={editor.panRef}
         onCloseAgent={handleCloseAgent}
+        onFocusAgent={handleFocusAgent}
+        onUpdateAgentRole={onUpdateAgentRole}
       />
 
       {isDebugMode && (

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -193,7 +193,7 @@ export class OfficeState {
     return { palette, hueShift }
   }
 
-  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean): void {
+  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean, role?: string, taskNote?: string, isBlocked?: boolean): void {
     if (this.characters.has(id)) return
 
     let palette: number
@@ -241,7 +241,19 @@ export class OfficeState {
       ch.matrixEffectTimer = 0
       ch.matrixEffectSeeds = matrixEffectSeeds()
     }
+    if (role !== undefined) ch.role = role
+    if (taskNote !== undefined) ch.taskNote = taskNote
+    if (isBlocked !== undefined) ch.isBlocked = isBlocked
     this.characters.set(id, ch)
+  }
+
+  setAgentRole(id: number, role: string, taskNote: string, isBlocked: boolean): void {
+    const ch = this.characters.get(id)
+    if (ch) {
+      ch.role = role
+      ch.taskNote = taskNote
+      ch.isBlocked = isBlocked
+    }
   }
 
   removeAgent(id: number): void {

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -183,6 +183,12 @@ export interface Character {
   bubbleTimer: number
   /** Timer to stay seated while inactive after seat reassignment (counts down to 0) */
   seatTimer: number
+  /** Custom role label for this agent (e.g. "Codex Engineer") */
+  role?: string
+  /** One-line task description */
+  taskNote?: string
+  /** Manual blocked status (coexists with JSONL status) */
+  isBlocked?: boolean
   /** Whether this character represents a sub-agent (spawned by Task tool) */
   isSubagent: boolean
   /** Parent agent ID if this is a sub-agent, null otherwise */


### PR DESCRIPTION
## Summary

- **Role label** — each agent can be assigned a custom name (e.g. "Codex Engineer") shown in the ToolOverlay
- **Task note** — a one-line description shown below the role when the agent is selected
- **Blocked toggle** — manual amber ⊗ status flag that coexists with auto-detected JSONL status (Working/Idle/Waiting)
- **Inline edit UI** — clicking a selected character reveals role/note/blocked fields editable in-place; pencil buttons open input fields, Enter/blur confirms
- **Persistence** — roles stored in `workspaceState` under `pixel-agents.agentRoles`, restored on webview reload and VS Code restart
- **Decoupled click behavior** — clicking a character now only selects it (shows overlay); a new ⌨ button in the overlay header focuses the terminal explicitly, so input fields remain usable

## Test plan

- [ ] Click "+ Agent" to create agents — characters appear in office
- [ ] Click a character → overlay appears without focusing the terminal
- [ ] Type a role name → press Enter → role persists in overlay
- [ ] Add a task note → blur → note persists
- [ ] Click "○ Blocked" → toggles to amber "⊗ Blocked" indicator in overlay header
- [ ] Click ⌨ button → Claude terminal gains focus
- [ ] Reload webview → roles/notes/blocked status all restored correctly
- [ ] Close and reopen VS Code → roles persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)