### PR TITLE
Add tmux integration and external agent detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -12,9 +12,11 @@ import {
 	sendLayout,
 	getProjectDirPath,
 } from './agentManager.js';
-import { ensureProjectScan } from './fileWatcher.js';
+import { ensureProjectScan, startFileWatching, readNewLines } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
-import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
+import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED, GLOBAL_KEY_EXTERNAL_AGENTS_ENABLED, GLOBAL_KEY_USE_TMUX, TMUX_TERMINAL_NAME_PREFIX, TMUX_SESSION_NAME } from './constants.js';
+import { startExternalAgentScanning, startStaleExternalAgentCheck } from './externalAgentScanner.js';
+import { isTmuxAvailable, resolveTmuxSession, tmuxSessionExists, createTmuxSession, createTmuxWindow, tmuxSendKeys, killTmuxWindow } from './tmuxResolver.js';
 import { writeLayoutToFile, readLayoutFromFile, watchLayoutFile } from './layoutPersistence.js';
 import type { LayoutWatcher } from './layoutPersistence.js';
 
@@ -35,6 +37,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 	activeAgentId = { current: null as number | null };
 	knownJsonlFiles = new Set<string>();
 	projectScanTimer = { current: null as ReturnType<typeof setInterval> | null };
+
+	// External agent scanning
+	externalScanTimer: ReturnType<typeof setInterval> | null = null;
+	staleCheckTimer: ReturnType<typeof setInterval> | null = null;
 
 	// Bundled default layout (loaded from assets/default-layout.json)
 	defaultLayout: Record<string, unknown> | null = null;
@@ -63,23 +69,57 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 
 		webviewView.webview.onDidReceiveMessage(async (message) => {
 			if (message.type === 'openClaude') {
-				launchNewTerminal(
-					this.nextAgentId, this.nextTerminalIndex,
-					this.agents, this.activeAgentId, this.knownJsonlFiles,
-					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
-					this.jsonlPollTimers, this.projectScanTimer,
-					this.webview, this.persistAgents,
-				);
+				const useTmux = this.context.globalState.get<boolean>(GLOBAL_KEY_USE_TMUX, false);
+				if (useTmux && isTmuxAvailable()) {
+					this.launchTmuxAgent();
+				} else {
+					launchNewTerminal(
+						this.nextAgentId, this.nextTerminalIndex,
+						this.agents, this.activeAgentId, this.knownJsonlFiles,
+						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+						this.jsonlPollTimers, this.projectScanTimer,
+						this.webview, this.persistAgents,
+					);
+				}
 			} else if (message.type === 'focusAgent') {
 				const agent = this.agents.get(message.id);
-				if (agent) {
+				if (!agent) return;
+				console.log(`[Pixel Agents] focusAgent ${agent.id}: terminalRef=${!!agent.terminalRef} isExternal=${agent.isExternal} isTmux=${agent.isTmux}`);
+				if (agent.terminalRef) {
 					agent.terminalRef.show();
+				} else if (agent.isExternal) {
+					this.attachExternalAgent(agent);
+				} else if (agent.isTmux && agent.tmuxSessionName && agent.tmuxWindowName) {
+					this.reattachTmuxAgent(agent);
 				}
 			} else if (message.type === 'closeAgent') {
 				const agent = this.agents.get(message.id);
-				if (agent) {
+				if (!agent) return;
+				// Kill tmux window if applicable
+				if (agent.tmuxSessionName && agent.tmuxWindowName) {
+					killTmuxWindow(agent.tmuxSessionName, agent.tmuxWindowName);
+				} else if (agent.isExternal) {
+					// Try to resolve and kill the tmux session for external agents
+					const sessionName = resolveTmuxSession(agent.projectDir);
+					if (sessionName) {
+						try {
+							// Kill the whole tmux session since we don't track the window
+							const { execFileSync } = require('child_process') as typeof import('child_process');
+							execFileSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'pipe' });
+						} catch { /* session may be gone */ }
+					}
+				}
+				// Dispose VS Code terminal if any
+				if (agent.terminalRef) {
 					agent.terminalRef.dispose();
 				}
+				// Remove agent directly (onDidCloseTerminal will be a no-op since agent is gone)
+				removeAgent(
+					message.id as number, this.agents,
+					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+					this.jsonlPollTimers, this.persistAgents,
+				);
+				webviewView.webview.postMessage({ type: 'agentClosed', id: message.id });
 			} else if (message.type === 'saveAgentSeats') {
 				// Store seat assignments in a separate key (never touched by persistAgents)
 				console.log(`[Pixel Agents] saveAgentSeats:`, JSON.stringify(message.seats));
@@ -89,6 +129,16 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				writeLayoutToFile(message.layout as Record<string, unknown>);
 			} else if (message.type === 'setSoundEnabled') {
 				this.context.globalState.update(GLOBAL_KEY_SOUND_ENABLED, message.enabled);
+			} else if (message.type === 'setUseTmux') {
+				this.context.globalState.update(GLOBAL_KEY_USE_TMUX, message.enabled);
+			} else if (message.type === 'setExternalAgentsEnabled') {
+				const enabled = message.enabled as boolean;
+				this.context.globalState.update(GLOBAL_KEY_EXTERNAL_AGENTS_ENABLED, enabled);
+				if (enabled) {
+					this.startExternalScanning();
+				} else {
+					this.stopExternalScanning();
+				}
 			} else if (message.type === 'webviewReady') {
 				restoreAgents(
 					this.context,
@@ -100,7 +150,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				);
 				// Send persisted settings to webview
 				const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
-				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
+				const externalAgentsEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_EXTERNAL_AGENTS_ENABLED, true);
+				const useTmux = this.context.globalState.get<boolean>(GLOBAL_KEY_USE_TMUX, false);
+				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled, externalAgentsEnabled, useTmux });
 
 				// Ensure project scan runs even with no restored agents (to adopt external terminals)
 				const projectDir = getProjectDirPath();
@@ -214,6 +266,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 					})();
 				}
 				sendExistingAgents(this.agents, this.context, this.webview);
+
+				// Start external agent scanning if enabled
+				const extEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_EXTERNAL_AGENTS_ENABLED, true);
+				if (extEnabled) {
+					this.startExternalScanning();
+				}
 			} else if (message.type === 'openSessionsFolder') {
 				const projectDir = getProjectDirPath();
 				if (projectDir && fs.existsSync(projectDir)) {
@@ -270,16 +328,22 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 
 		vscode.window.onDidCloseTerminal((closed) => {
 			for (const [id, agent] of this.agents) {
-				if (agent.terminalRef === closed) {
+				if (agent.terminalRef && agent.terminalRef === closed) {
 					if (this.activeAgentId.current === id) {
 						this.activeAgentId.current = null;
 					}
-					removeAgent(
-						id, this.agents,
-						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
-						this.jsonlPollTimers, this.persistAgents,
-					);
-					webviewView.webview.postMessage({ type: 'agentClosed', id });
+					if (agent.isExternal || agent.isTmux) {
+						// Detach terminal — character stays, can re-attach on next click
+						agent.terminalRef = null;
+						this.persistAgents();
+					} else {
+						removeAgent(
+							id, this.agents,
+							this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+							this.jsonlPollTimers, this.persistAgents,
+						);
+						webviewView.webview.postMessage({ type: 'agentClosed', id });
+					}
 				}
 			}
 		});
@@ -303,6 +367,168 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 		vscode.window.showInformationMessage(`Pixel Agents: Default layout exported to ${targetPath}`);
 	}
 
+	private launchTmuxAgent(): void {
+		const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+		const projectDir = getProjectDirPath(cwd);
+		if (!projectDir || !cwd) {
+			vscode.window.showWarningMessage('Pixel Agents: No workspace folder found.');
+			return;
+		}
+
+		const idx = this.nextTerminalIndex.current++;
+		const windowName = `agent-${idx}`;
+		const sessionId = crypto.randomUUID();
+
+		// Ensure tmux session exists
+		if (!tmuxSessionExists(TMUX_SESSION_NAME)) {
+			createTmuxSession(TMUX_SESSION_NAME, windowName, cwd);
+		} else {
+			createTmuxWindow(TMUX_SESSION_NAME, windowName, cwd);
+		}
+
+		// Run claude in the tmux window
+		tmuxSendKeys(TMUX_SESSION_NAME, windowName, `claude --session-id ${sessionId}`);
+
+		// Create VS Code terminal attached to the tmux window
+		const terminal = vscode.window.createTerminal({
+			name: `${TMUX_TERMINAL_NAME_PREFIX} #${idx}`,
+		});
+		terminal.sendText(`tmux attach -t ${TMUX_SESSION_NAME}:${windowName}`);
+		terminal.show();
+
+		// Pre-register expected JSONL file
+		const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);
+		this.knownJsonlFiles.add(expectedFile);
+
+		// Create agent
+		const id = this.nextAgentId.current++;
+		const agent: AgentState = {
+			id,
+			terminalRef: terminal,
+			projectDir,
+			jsonlFile: expectedFile,
+			fileOffset: 0,
+			lineBuffer: '',
+			activeToolIds: new Set(),
+			activeToolStatuses: new Map(),
+			activeToolNames: new Map(),
+			activeSubagentToolIds: new Map(),
+			activeSubagentToolNames: new Map(),
+			isWaiting: false,
+			permissionSent: false,
+			hadToolsInTurn: false,
+			isExternal: false,
+			isTmux: true,
+			tmuxSessionName: TMUX_SESSION_NAME,
+			tmuxWindowName: windowName,
+			lastDataTimestamp: Date.now(),
+		};
+
+		this.agents.set(id, agent);
+		this.activeAgentId.current = id;
+		this.persistAgents();
+		console.log(`[Pixel Agents] Tmux agent ${id}: created window ${TMUX_SESSION_NAME}:${windowName}`);
+		this.webview?.postMessage({ type: 'agentCreated', id });
+
+		ensureProjectScan(
+			projectDir, this.knownJsonlFiles, this.projectScanTimer, this.activeAgentId,
+			this.nextAgentId, this.agents,
+			this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+			this.webview, this.persistAgents,
+		);
+
+		// Poll for the JSONL file to appear
+		const pollTimer = setInterval(() => {
+			try {
+				if (fs.existsSync(agent.jsonlFile)) {
+					console.log(`[Pixel Agents] Tmux agent ${id}: found JSONL file`);
+					clearInterval(pollTimer);
+					this.jsonlPollTimers.delete(id);
+					startFileWatching(id, agent.jsonlFile, this.agents, this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers, this.webview);
+					readNewLines(id, this.agents, this.waitingTimers, this.permissionTimers, this.webview);
+				}
+			} catch { /* file may not exist yet */ }
+		}, 1000);
+		this.jsonlPollTimers.set(id, pollTimer);
+	}
+
+	private reattachTmuxAgent(agent: AgentState): void {
+		const idx = this.nextTerminalIndex.current++;
+		const terminal = vscode.window.createTerminal({
+			name: `${TMUX_TERMINAL_NAME_PREFIX} #${idx}`,
+		});
+		terminal.sendText(`tmux attach -t ${agent.tmuxSessionName}:${agent.tmuxWindowName}`);
+		terminal.show();
+		agent.terminalRef = terminal;
+		this.persistAgents();
+		console.log(`[Pixel Agents] Re-attached tmux agent ${agent.id} to ${agent.tmuxSessionName}:${agent.tmuxWindowName}`);
+	}
+
+	private attachExternalAgent(agent: AgentState): void {
+		if (!isTmuxAvailable()) {
+			vscode.window.showInformationMessage('Pixel Agents: tmux is not installed. Cannot attach to external session.');
+			return;
+		}
+
+		const sessionName = resolveTmuxSession(agent.projectDir);
+		if (!sessionName) {
+			vscode.window.showInformationMessage('Pixel Agents: Could not find a tmux session for this agent.');
+			return;
+		}
+
+		const idx = this.nextTerminalIndex.current++;
+		const terminal = vscode.window.createTerminal({
+			name: `${TMUX_TERMINAL_NAME_PREFIX} #${idx}`,
+		});
+		terminal.sendText(`tmux attach -t ${sessionName}`);
+		terminal.show();
+
+		agent.terminalRef = terminal;
+		this.persistAgents();
+		console.log(`[Pixel Agents] Attached external agent ${agent.id} to tmux session "${sessionName}"`);
+	}
+
+	private startExternalScanning(): void {
+		if (this.externalScanTimer) return;
+		const projectDir = getProjectDirPath();
+		if (!projectDir) return;
+
+		this.externalScanTimer = startExternalAgentScanning(
+			projectDir, this.nextAgentId, this.agents,
+			this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+			this.webview, this.persistAgents,
+		);
+		this.staleCheckTimer = startStaleExternalAgentCheck(
+			this.agents,
+			this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+			this.jsonlPollTimers, this.webview, this.persistAgents,
+		);
+		console.log('[Pixel Agents] External agent scanning started');
+	}
+
+	private stopExternalScanning(): void {
+		if (this.externalScanTimer) {
+			clearInterval(this.externalScanTimer);
+			this.externalScanTimer = null;
+		}
+		if (this.staleCheckTimer) {
+			clearInterval(this.staleCheckTimer);
+			this.staleCheckTimer = null;
+		}
+		// Remove all currently tracked external agents
+		for (const [id, agent] of this.agents) {
+			if (agent.isExternal) {
+				removeAgent(
+					id, this.agents,
+					this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+					this.jsonlPollTimers, this.persistAgents,
+				);
+				this.webview?.postMessage({ type: 'agentClosed', id });
+			}
+		}
+		console.log('[Pixel Agents] External agent scanning stopped');
+	}
+
 	private startLayoutWatcher(): void {
 		if (this.layoutWatcher) return;
 		this.layoutWatcher = watchLayoutFile((layout) => {
@@ -314,6 +540,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 	dispose() {
 		this.layoutWatcher?.dispose();
 		this.layoutWatcher = null;
+		this.stopExternalScanning();
 		for (const id of [...this.agents.keys()]) {
 			removeAgent(
 				id, this.agents,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,8 +29,15 @@ export const LAYOUT_FILE_DIR = '.pixel-agents';
 export const LAYOUT_FILE_NAME = 'layout.json';
 export const LAYOUT_FILE_POLL_INTERVAL_MS = 2000;
 
+// ── External Agent Scanning ─────────────────────────────────
+export const EXTERNAL_SCAN_INTERVAL_MS = 5000;
+export const EXTERNAL_STALE_TIMEOUT_MS = 120_000;
+export const EXTERNAL_ACTIVE_THRESHOLD_MS = 30_000;
+export const EXTERNAL_STALE_CHECK_INTERVAL_MS = 15_000;
+
 // ── Settings Persistence ────────────────────────────────────
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
+export const GLOBAL_KEY_EXTERNAL_AGENTS_ENABLED = 'pixel-agents.externalAgentsEnabled';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';
@@ -40,3 +47,9 @@ export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
 export const TERMINAL_NAME_PREFIX = 'Claude Code';
+export const TMUX_TERMINAL_NAME_PREFIX = 'Claude (tmux)';
+export const TMUX_SESSION_NAME = 'pixel-agents';
+
+// ── Settings Persistence ────────────────────────────────────
+// (additional keys)
+export const GLOBAL_KEY_USE_TMUX = 'pixel-agents.useTmux';

--- a/src/externalAgentScanner.ts
+++ b/src/externalAgentScanner.ts
@@ -1,0 +1,152 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+import type { AgentState } from './types.js';
+import { startFileWatching, readNewLines } from './fileWatcher.js';
+import {
+	EXTERNAL_SCAN_INTERVAL_MS,
+	EXTERNAL_STALE_TIMEOUT_MS,
+	EXTERNAL_ACTIVE_THRESHOLD_MS,
+	EXTERNAL_STALE_CHECK_INTERVAL_MS,
+} from './constants.js';
+import { removeAgent } from './agentManager.js';
+
+/** Check if a JSONL file is already tracked by any agent */
+function isFileTracked(filePath: string, agents: Map<number, AgentState>): boolean {
+	for (const agent of agents.values()) {
+		if (agent.jsonlFile === filePath) return true;
+	}
+	return false;
+}
+
+export function startExternalAgentScanning(
+	projectDir: string,
+	nextAgentIdRef: { current: number },
+	agents: Map<number, AgentState>,
+	fileWatchers: Map<number, fs.FSWatcher>,
+	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+	persistAgents: () => void,
+): ReturnType<typeof setInterval> {
+	return setInterval(() => {
+		scanForExternalJsonlFiles(
+			projectDir, nextAgentIdRef, agents,
+			fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+			webview, persistAgents,
+		);
+	}, EXTERNAL_SCAN_INTERVAL_MS);
+}
+
+function scanForExternalJsonlFiles(
+	projectDir: string,
+	nextAgentIdRef: { current: number },
+	agents: Map<number, AgentState>,
+	fileWatchers: Map<number, fs.FSWatcher>,
+	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	webview: vscode.Webview | undefined,
+	persistAgents: () => void,
+): void {
+	let files: string[];
+	try {
+		files = fs.readdirSync(projectDir)
+			.filter(f => f.endsWith('.jsonl'))
+			.map(f => path.join(projectDir, f));
+	} catch { return; }
+
+	const now = Date.now();
+
+	for (const file of files) {
+		if (isFileTracked(file, agents)) continue;
+
+		// Check if the file was recently modified (active session)
+		try {
+			const stat = fs.statSync(file);
+			if (now - stat.mtimeMs > EXTERNAL_ACTIVE_THRESHOLD_MS) continue;
+		} catch { continue; }
+
+		// Create external agent
+		const id = nextAgentIdRef.current++;
+		const agent: AgentState = {
+			id,
+			terminalRef: null,
+			projectDir,
+			jsonlFile: file,
+			fileOffset: 0,
+			lineBuffer: '',
+			activeToolIds: new Set(),
+			activeToolStatuses: new Map(),
+			activeToolNames: new Map(),
+			activeSubagentToolIds: new Map(),
+			activeSubagentToolNames: new Map(),
+			isWaiting: false,
+			permissionSent: false,
+			hadToolsInTurn: false,
+			isExternal: true,
+			isTmux: false,
+			tmuxSessionName: null,
+			tmuxWindowName: null,
+			lastDataTimestamp: now,
+		};
+
+		agents.set(id, agent);
+		persistAgents();
+
+		console.log(`[Pixel Agents] External agent ${id}: detected ${path.basename(file)}`);
+		webview?.postMessage({ type: 'agentCreated', id, isExternal: true });
+
+		// Start file watching — reads from offset 0 to reconstruct full tool state
+		startFileWatching(id, file, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
+		readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+	}
+}
+
+export function startStaleExternalAgentCheck(
+	agents: Map<number, AgentState>,
+	fileWatchers: Map<number, fs.FSWatcher>,
+	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+	jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
+	webview: vscode.Webview | undefined,
+	persistAgents: () => void,
+): ReturnType<typeof setInterval> {
+	return setInterval(() => {
+		const now = Date.now();
+		const toRemove: number[] = [];
+
+		for (const [id, agent] of agents) {
+			if (!agent.isExternal) continue;
+
+			// Check if file still exists
+			let fileExists = false;
+			let fileMtime = 0;
+			try {
+				const stat = fs.statSync(agent.jsonlFile);
+				fileExists = true;
+				fileMtime = stat.mtimeMs;
+			} catch { /* file deleted */ }
+
+			if (!fileExists) {
+				toRemove.push(id);
+				continue;
+			}
+
+			// Stale if both file mtime and last data timestamp are older than threshold
+			const fileAge = now - fileMtime;
+			const dataAge = now - agent.lastDataTimestamp;
+			if (fileAge > EXTERNAL_STALE_TIMEOUT_MS && dataAge > EXTERNAL_STALE_TIMEOUT_MS) {
+				toRemove.push(id);
+			}
+		}
+
+		for (const id of toRemove) {
+			console.log(`[Pixel Agents] Removing stale external agent ${id}`);
+			removeAgent(id, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, jsonlPollTimers, persistAgents);
+			webview?.postMessage({ type: 'agentClosed', id });
+		}
+	}, EXTERNAL_STALE_CHECK_INTERVAL_MS);
+}

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -59,6 +59,7 @@ export function readNewLines(
 
 		const hasLines = lines.some(l => l.trim());
 		if (hasLines) {
+			agent.lastDataTimestamp = Date.now();
 			// New data arriving — cancel timers (data flowing means agent is still active)
 			cancelWaitingTimer(agentId, waitingTimers);
 			cancelPermissionTimer(agentId, permissionTimers);
@@ -197,6 +198,11 @@ function adoptTerminalForFile(
 		isWaiting: false,
 		permissionSent: false,
 		hadToolsInTurn: false,
+		isExternal: false,
+		isTmux: false,
+		tmuxSessionName: null,
+		tmuxWindowName: null,
+		lastDataTimestamp: Date.now(),
 	};
 
 	agents.set(id, agent);

--- a/src/tmuxResolver.ts
+++ b/src/tmuxResolver.ts
@@ -1,0 +1,171 @@
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+const MAX_TREE_WALK_DEPTH = 10;
+
+/** Check if tmux is available on the system */
+export function isTmuxAvailable(): boolean {
+	try {
+		execFileSync('which', ['tmux'], { stdio: 'pipe' });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Hash a workspace path the same way Claude does: replace :/\/ with - */
+function hashWorkspacePath(wsPath: string): string {
+	return wsPath.replace(/[:\\/]/g, '-');
+}
+
+/** Find PIDs of `claude` processes whose cwd matches the project dir hash */
+export function findClaudePidsForProject(projectDir: string): number[] {
+	// Extract the hash from the project dir path (last component)
+	const expectedHash = path.basename(projectDir);
+
+	try {
+		const output = execFileSync('pgrep', ['-x', 'claude'], {
+			stdio: 'pipe',
+			encoding: 'utf-8',
+		}).trim();
+		if (!output) return [];
+
+		const pids = output.split('\n').map(s => parseInt(s, 10)).filter(n => !isNaN(n));
+		const matches: number[] = [];
+
+		for (const pid of pids) {
+			try {
+				const lsofOutput = execFileSync('lsof', ['-p', String(pid), '-Fn'], {
+					stdio: 'pipe',
+					encoding: 'utf-8',
+				});
+				// lsof -Fn outputs lines like "fcwd\nn/path/to/dir"
+				const lines = lsofOutput.split('\n');
+				for (let i = 0; i < lines.length; i++) {
+					if (lines[i] === 'fcwd' && i + 1 < lines.length && lines[i + 1].startsWith('n')) {
+						const cwd = lines[i + 1].slice(1);
+						if (hashWorkspacePath(cwd) === expectedHash) {
+							matches.push(pid);
+						}
+						break;
+					}
+				}
+			} catch {
+				// Process may have exited
+			}
+		}
+		return matches;
+	} catch {
+		return [];
+	}
+}
+
+/** Get the parent PID of a given process */
+export function getParentPid(pid: number): number | null {
+	try {
+		const output = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
+			stdio: 'pipe',
+			encoding: 'utf-8',
+		}).trim();
+		const ppid = parseInt(output, 10);
+		return isNaN(ppid) || ppid <= 1 ? null : ppid;
+	} catch {
+		return null;
+	}
+}
+
+/** Parse `tmux list-panes` output into a Map of pane_pid → session_name */
+export function getTmuxPanePids(): Map<number, string> {
+	const result = new Map<number, string>();
+	try {
+		const output = execFileSync('tmux', ['list-panes', '-a', '-F', '#{pane_pid} #{session_name}'], {
+			stdio: 'pipe',
+			encoding: 'utf-8',
+		}).trim();
+		if (!output) return result;
+		for (const line of output.split('\n')) {
+			const spaceIdx = line.indexOf(' ');
+			if (spaceIdx === -1) continue;
+			const pid = parseInt(line.slice(0, spaceIdx), 10);
+			const sessionName = line.slice(spaceIdx + 1);
+			if (!isNaN(pid) && sessionName) {
+				result.set(pid, sessionName);
+			}
+		}
+	} catch {
+		// tmux not running or no sessions
+	}
+	return result;
+}
+
+/** Walk the process tree upward from `pid` looking for a tmux pane PID */
+export function findTmuxSessionForPid(pid: number, panePids: Map<number, string>): string | null {
+	let current: number | null = pid;
+	for (let i = 0; i < MAX_TREE_WALK_DEPTH && current !== null; i++) {
+		const session = panePids.get(current);
+		if (session) return session;
+		current = getParentPid(current);
+	}
+	return null;
+}
+
+// ── Tmux session/window management ─────────────────────────
+
+/** Check if a tmux session exists */
+export function tmuxSessionExists(sessionName: string): boolean {
+	try {
+		execFileSync('tmux', ['has-session', '-t', sessionName], { stdio: 'pipe' });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Create a new tmux session (detached) with an initial window */
+export function createTmuxSession(sessionName: string, windowName: string, cwd: string): void {
+	execFileSync('tmux', ['new-session', '-d', '-s', sessionName, '-n', windowName, '-c', cwd], {
+		stdio: 'pipe',
+	});
+}
+
+/** Create a new window in an existing tmux session */
+export function createTmuxWindow(sessionName: string, windowName: string, cwd: string): void {
+	execFileSync('tmux', ['new-window', '-t', sessionName, '-n', windowName, '-c', cwd], {
+		stdio: 'pipe',
+	});
+}
+
+/** Send keys to a tmux window */
+export function tmuxSendKeys(sessionName: string, windowName: string, keys: string): void {
+	execFileSync('tmux', ['send-keys', '-t', `${sessionName}:${windowName}`, keys, 'Enter'], {
+		stdio: 'pipe',
+	});
+}
+
+/** Kill a tmux window */
+export function killTmuxWindow(sessionName: string, windowName: string): void {
+	try {
+		execFileSync('tmux', ['kill-window', '-t', `${sessionName}:${windowName}`], {
+			stdio: 'pipe',
+		});
+	} catch {
+		// Window may already be gone
+	}
+}
+
+/** Orchestrate: agent project dir → tmux session name (or null) */
+export function resolveTmuxSession(projectDir: string): string | null {
+	const claudePids = findClaudePidsForProject(projectDir);
+	if (claudePids.length === 0) return null;
+
+	const panePids = getTmuxPanePids();
+	if (panePids.size === 0) return null;
+
+	// Try each Claude PID — first one that matches a tmux session wins
+	for (const claudePid of claudePids) {
+		const session = findTmuxSessionForPid(claudePid, panePids);
+		if (session) return session;
+	}
+
+	return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type * as vscode from 'vscode';
 
 export interface AgentState {
 	id: number;
-	terminalRef: vscode.Terminal;
+	terminalRef: vscode.Terminal | null;
 	projectDir: string;
 	jsonlFile: string;
 	fileOffset: number;
@@ -15,6 +15,11 @@ export interface AgentState {
 	isWaiting: boolean;
 	permissionSent: boolean;
 	hadToolsInTurn: boolean;
+	isExternal: boolean;
+	isTmux: boolean;
+	tmuxSessionName: string | null;
+	tmuxWindowName: string | null;
+	lastDataTimestamp: number;
 }
 
 export interface PersistedAgent {
@@ -22,4 +27,8 @@ export interface PersistedAgent {
 	terminalName: string;
 	jsonlFile: string;
 	projectDir: string;
+	isExternal?: boolean;
+	isTmux?: boolean;
+	tmuxSessionName?: string;
+	tmuxWindowName?: string;
 }

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1432,7 +1431,6 @@
       "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1443,7 +1441,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1503,7 +1500,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1755,7 +1751,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1861,7 +1856,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2083,7 +2077,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2770,7 +2763,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2832,7 +2824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3038,7 +3029,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3125,7 +3115,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3247,7 +3236,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webview-ui/src/components/AgentContextMenu.tsx
+++ b/webview-ui/src/components/AgentContextMenu.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react'
+
+export interface ContextMenuAction {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+interface AgentContextMenuProps {
+  x: number
+  y: number
+  actions: ContextMenuAction[]
+  onClose: () => void
+}
+
+const menuStyle: React.CSSProperties = {
+  position: 'fixed',
+  zIndex: 9999,
+  background: 'var(--pixel-bg)',
+  border: '2px solid var(--pixel-border)',
+  borderRadius: 0,
+  boxShadow: 'var(--pixel-shadow)',
+  padding: '4px 0',
+  minWidth: 140,
+}
+
+const itemStyle: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  padding: '6px 14px',
+  fontSize: '22px',
+  background: 'none',
+  border: 'none',
+  borderRadius: 0,
+  color: 'var(--vscode-foreground)',
+  textAlign: 'left',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+}
+
+const itemDisabledStyle: React.CSSProperties = {
+  ...itemStyle,
+  opacity: 0.4,
+  cursor: 'default',
+}
+
+export function AgentContextMenu({ x, y, actions, onClose }: AgentContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    // Delay to avoid the same right-click closing the menu
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handler)
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', handler)
+    }
+  }, [onClose])
+
+  return (
+    <div ref={ref} style={{ ...menuStyle, left: x, top: y }}>
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          style={action.disabled ? itemDisabledStyle : itemStyle}
+          onClick={() => {
+            if (!action.disabled) {
+              action.onClick()
+              onClose()
+            }
+          }}
+          onMouseEnter={(e) => {
+            if (!action.disabled) {
+              (e.currentTarget as HTMLElement).style.background = 'var(--pixel-btn-bg)'
+            }
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLElement).style.background = 'none'
+          }}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -7,6 +7,10 @@ interface BottomToolbarProps {
   onToggleEditMode: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
+  externalAgentsEnabled: boolean
+  onToggleExternalAgents: () => void
+  useTmux: boolean
+  onToggleUseTmux: () => void
 }
 
 const panelStyle: React.CSSProperties = {
@@ -47,6 +51,10 @@ export function BottomToolbar({
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
+  externalAgentsEnabled,
+  onToggleExternalAgents,
+  useTmux,
+  onToggleUseTmux,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
@@ -108,6 +116,10 @@ export function BottomToolbar({
           onClose={() => setIsSettingsOpen(false)}
           isDebugMode={isDebugMode}
           onToggleDebugMode={onToggleDebugMode}
+          externalAgentsEnabled={externalAgentsEnabled}
+          onToggleExternalAgents={onToggleExternalAgents}
+          useTmux={useTmux}
+          onToggleUseTmux={onToggleUseTmux}
         />
       </div>
     </div>

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -7,6 +7,10 @@ interface SettingsModalProps {
   onClose: () => void
   isDebugMode: boolean
   onToggleDebugMode: () => void
+  externalAgentsEnabled: boolean
+  onToggleExternalAgents: () => void
+  useTmux: boolean
+  onToggleUseTmux: () => void
 }
 
 const menuItemBase: React.CSSProperties = {
@@ -24,7 +28,7 @@ const menuItemBase: React.CSSProperties = {
   textAlign: 'left',
 }
 
-export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode }: SettingsModalProps) {
+export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode, externalAgentsEnabled, onToggleExternalAgents, useTmux, onToggleUseTmux }: SettingsModalProps) {
   const [hovered, setHovered] = useState<string | null>(null)
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled)
 
@@ -166,6 +170,64 @@ export function SettingsModal({ isOpen, onClose, isDebugMode, onToggleDebugMode 
             }}
           >
             {soundLocal ? 'X' : ''}
+          </span>
+        </button>
+        <button
+          onClick={onToggleExternalAgents}
+          onMouseEnter={() => setHovered('external')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...menuItemBase,
+            background: hovered === 'external' ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+        >
+          <span>External Sessions</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              border: '2px solid rgba(255, 255, 255, 0.5)',
+              borderRadius: 0,
+              background: externalAgentsEnabled ? 'rgba(90, 140, 255, 0.8)' : 'transparent',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '12px',
+              lineHeight: 1,
+              color: '#fff',
+            }}
+          >
+            {externalAgentsEnabled ? 'X' : ''}
+          </span>
+        </button>
+        <button
+          onClick={onToggleUseTmux}
+          onMouseEnter={() => setHovered('tmux')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...menuItemBase,
+            background: hovered === 'tmux' ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+        >
+          <span>Use tmux</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              border: '2px solid rgba(255, 255, 255, 0.5)',
+              borderRadius: 0,
+              background: useTmux ? 'rgba(90, 140, 255, 0.8)' : 'transparent',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '12px',
+              lineHeight: 1,
+              color: '#fff',
+            }}
+          >
+            {useTmux ? 'X' : ''}
           </span>
         </button>
         <button

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -96,6 +96,9 @@ export const NOTIFICATION_NOTE_2_START_SEC = 0.1
 export const NOTIFICATION_NOTE_DURATION_SEC = 0.18
 export const NOTIFICATION_VOLUME = 0.14
 
+// ── External Agents ─────────────────────────────────────────
+export const EXTERNAL_AGENT_LABEL_PREFIX = '[ext] '
+
 // ── Game Logic ───────────────────────────────────────────────
 export const MAX_DELTA_TIME_SEC = 0.1
 export const WAITING_BUBBLE_DURATION_SEC = 2.0

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -3,13 +3,14 @@ import type { ToolActivity } from '../types.js'
 import type { OfficeState } from '../engine/officeState.js'
 import type { SubagentCharacter } from '../../hooks/useExtensionMessages.js'
 import { TILE_SIZE, CharacterState } from '../types.js'
-import { TOOL_OVERLAY_VERTICAL_OFFSET, CHARACTER_SITTING_OFFSET_PX } from '../../constants.js'
+import { TOOL_OVERLAY_VERTICAL_OFFSET, CHARACTER_SITTING_OFFSET_PX, EXTERNAL_AGENT_LABEL_PREFIX } from '../../constants.js'
 
 interface ToolOverlayProps {
   officeState: OfficeState
   agents: number[]
   agentTools: Record<number, ToolActivity[]>
   subagentCharacters: SubagentCharacter[]
+  externalAgentIds: Set<number>
   containerRef: React.RefObject<HTMLDivElement | null>
   zoom: number
   panRef: React.RefObject<{ x: number; y: number }>
@@ -45,6 +46,7 @@ export function ToolOverlay({
   agents,
   agentTools,
   subagentCharacters,
+  externalAgentIds,
   containerRef,
   zoom,
   panRef,
@@ -88,6 +90,7 @@ export function ToolOverlay({
         const isSelected = selectedId === id
         const isHovered = hoveredId === id
         const isSub = ch.isSubagent
+        const isExt = externalAgentIds.has(id)
 
         // Only show for hovered or selected agents
         if (!isSelected && !isHovered) return null
@@ -109,6 +112,9 @@ export function ToolOverlay({
           }
         } else {
           activityText = getActivityText(id, agentTools, ch.isActive)
+        }
+        if (isExt) {
+          activityText = EXTERNAL_AGENT_LABEL_PREFIX + activityText
         }
 
         // Determine dot color

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -73,6 +73,7 @@ export function createCharacter(
     bubbleType: null,
     bubbleTimer: 0,
     seatTimer: 0,
+    isExternal: false,
     isSubagent: false,
     parentAgentId: null,
     matrixEffect: null,

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -193,7 +193,7 @@ export class OfficeState {
     return { palette, hueShift }
   }
 
-  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean): void {
+  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean, isExternal?: boolean): void {
     if (this.characters.has(id)) return
 
     let palette: number
@@ -236,6 +236,9 @@ export class OfficeState {
       ch.tileRow = spawn.row
     }
 
+    if (isExternal) {
+      ch.isExternal = true
+    }
     if (!skipSpawnEffect) {
       ch.matrixEffect = 'spawn'
       ch.matrixEffectTimer = 0

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -183,6 +183,8 @@ export interface Character {
   bubbleTimer: number
   /** Timer to stay seated while inactive after seat reassignment (counts down to 0) */
   seatTimer: number
+  /** Whether this character represents an external Claude session (not from VS Code terminal) */
+  isExternal: boolean
   /** Whether this character represents a sub-agent (spawned by Task tool) */
   isSubagent: boolean
   /** Parent agent ID if this is a sub-agent, null otherwise */


### PR DESCRIPTION
## Summary

- Add automatic detection of Claude Code sessions running outside VS Code (e.g. in tmux or standalone terminals) — they appear as `[ext]` characters in the office
- Add "Use tmux" mode: `+ Agent` creates tmux windows inside a shared `pixel-agents` session instead of VS Code terminals, so agents survive editor restarts
- Add right-click context menu on characters with type-aware actions (attach, focus, close, kill)
- Closing a VS Code terminal tab for tmux/external agents only detaches — the character stays and re-attaches on next click

## What changed

### New files

| File | What it does |
|------|-------------|
| `src/tmuxResolver.ts` | Pure functions for tmux integration: find Claude PIDs via `pgrep`+`lsof`, walk process tree to resolve tmux sessions, create/kill tmux windows |
| `src/externalAgentScanner.ts` | Polls project JSONL dir every 5s for session files not owned by any VS Code terminal; creates external agent characters, removes stale ones after 2min |
| `webview-ui/src/components/AgentContextMenu.tsx` | Pixel-art right-click context menu component |

### Backend changes

| File | Changes |
|------|---------|
| `src/types.ts` | `terminalRef` now nullable; added `isExternal`, `isTmux`, `tmuxSessionName`, `tmuxWindowName`, `lastDataTimestamp` |
| `src/constants.ts` | External scanning intervals, tmux constants, new settings keys |
| `src/PixelAgentsViewProvider.ts` | `openClaude` checks "Use tmux" setting; `focusAgent` re-attaches tmux/external agents; `closeAgent` kills tmux windows; `onDidCloseTerminal` detaches instead of removing for tmux/external; new methods: `launchTmuxAgent()`, `reattachTmuxAgent()`, `attachExternalAgent()`, external scanning lifecycle |
| `src/agentManager.ts` | Initialize/persist/restore new fields; `sendExistingAgents` includes `externalIds` |
| `src/fileWatcher.ts` | Tracks `lastDataTimestamp` on new JSONL data; adopted agents initialize new fields |

### Webview changes

| File | Changes |
|------|---------|
| `webview-ui/src/App.tsx` | Context menu state + rendering with type-aware actions; click on external agent sends `focusAgent`; wires tmux/external settings toggles |
| `webview-ui/src/hooks/useExtensionMessages.ts` | Tracks `externalAgentIds`, `externalAgentsEnabled`, `useTmux` state |
| `webview-ui/src/components/SettingsModal.tsx` | "External Sessions" and "Use tmux" toggle checkboxes |
| `webview-ui/src/components/BottomToolbar.tsx` | Pass-through for new settings props |
| `webview-ui/src/office/components/ToolOverlay.tsx` | `[ext]` label prefix; close button visible for external agents |
| `webview-ui/src/office/components/OfficeCanvas.tsx` | Right-click on character opens context menu |
| `webview-ui/src/office/engine/officeState.ts` | `addAgent()` accepts `isExternal` param |
| `webview-ui/src/office/engine/characters.ts` | `createCharacter` initializes `isExternal` |
| `webview-ui/src/office/types.ts` | `isExternal` field on `Character` |

## How tmux resolution works

1. `pgrep -x claude` finds all Claude process PIDs
2. `lsof -p <pid> -Fn` gets each process's cwd
3. cwd is hashed (replace `:/\` with `-`) and compared against project dir hash
4. For matching PIDs, walk the process tree upward (`ps -o ppid=`) up to 10 levels
5. Check each ancestor against `tmux list-panes -a -F '#{pane_pid} #{session_name}'`
6. First match → resolved tmux session name

## How "Use tmux" agents work

1. User clicks `+ Agent` with setting enabled
2. Extension ensures `pixel-agents` tmux session exists (creates if needed)
3. Creates a named tmux window (`agent-N`) with workspace cwd
4. Sends `claude --session-id <uuid>` into the tmux window
5. Opens a VS Code terminal running `tmux attach -t pixel-agents:agent-N`
6. Polls for `<uuid>.jsonl` to appear, then starts file watching
7. If terminal tab is closed → character stays; click re-attaches

## Test plan

- [ ] Enable "External Sessions" in settings, run `claude` in a tmux session with the same workspace → character appears as `[ext]`
- [ ] Click external character → VS Code terminal opens attached to tmux session
- [ ] Click again → terminal is focused (no duplicate)
- [ ] Close terminal tab → character stays; click re-attaches
- [ ] Right-click external character → "Attach tmux" / "Kill session" menu
- [ ] "Kill session" removes the character and kills tmux session
- [ ] Enable "Use tmux", click `+ Agent` → tmux window created, VS Code terminal attached
- [ ] Close tmux agent terminal tab → character stays; click re-attaches
- [ ] Right-click normal agent → "Focus terminal" / "Close agent" menu
- [ ] Right-click sub-agent → "Focus parent" menu
- [ ] Disable "External Sessions" → all `[ext]` characters removed
- [ ] tmux not installed → info message on attach attempt, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)