### PR TITLE
Add Codex-first provider support and compatibility workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Added first-class Codex CLI support with configurable provider selection (`pixel-agents.cliProvider`), command overrides, and Codex session tracking from `~/.codex/sessions`.
+- Added dual transcript parsing paths (Claude + Codex) so tool activity, waiting status, and terminal sync work across both runtimes.
+- Lowered VS Code engine floor to `^1.99.0` for better Cursor compatibility.
+
 ## v1.0.2
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A VS Code extension that turns your AI coding agents into animated pixel art characters in a virtual office.
 
-Each Claude Code terminal you open spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
+Each agent terminal you open (Codex CLI or Claude Code) spawns a character that walks around, sits at desks, and visually reflects what the agent is doing — typing when writing code, reading when searching files, waiting when it needs your attention.
 
 This is the source code for the free [Pixel Agents extension for VS Code](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) — you can install it directly from the marketplace with the full furniture catalog included.
 
@@ -11,7 +11,7 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 
 ## Features
 
-- **One agent, one character** — every Claude Code terminal gets its own animated character
+- **One agent, one character** — every Codex/Claude terminal gets its own animated character
 - **Live activity tracking** — characters animate based on what the agent is actually doing (writing, reading, running commands)
 - **Office layout editor** — design your office with floors, walls, and furniture using a built-in editor
 - **Speech bubbles** — visual indicators when an agent is waiting for input or needs permission
@@ -26,8 +26,9 @@ This is the source code for the free [Pixel Agents extension for VS Code](https:
 
 ## Requirements
 
-- VS Code 1.109.0 or later
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- VS Code 1.99.0 or later
+- [Codex CLI](https://github.com/openai/codex) or [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- Set `pixel-agents.cliProvider` in VS Code settings (`codex` by default, `claude` supported)
 
 ## Getting Started
 
@@ -45,11 +46,19 @@ npm run build
 
 Then press **F5** in VS Code to launch the Extension Development Host.
 
+### Build + Install VSIX (Codex-friendly)
+
+```bash
+./scripts/build-codex-vsix.sh
+```
+
+This packages a local VSIX and installs it into your current editor profile.
+
 ### Usage
 
 1. Open the **Pixel Agents** panel (it appears in the bottom panel area alongside your terminal)
-2. Click **+ Agent** to spawn a new Claude Code terminal and its character
-3. Start coding with Claude — watch the character react in real time
+2. Click **+ Agent** to spawn a new agent terminal and its character
+3. Start coding with your configured CLI — watch the character react in real time
 4. Click a character to select it, then click a seat to reassign it
 5. Click **Layout** to open the office editor and customize your space
 
@@ -81,7 +90,7 @@ The extension will still work without the tileset — you'll get the default cha
 
 ## How It Works
 
-Pixel Agents watches Claude Code's JSONL transcript files to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to Claude Code are needed — it's purely observational.
+Pixel Agents watches CLI transcript files (Codex or Claude, depending on configuration) to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No CLI modifications are needed — it's purely observational.
 
 The webview runs a lightweight game loop with canvas rendering, BFS pathfinding, and a character state machine (idle → walk → type/read). Everything is pixel-perfect at integer zoom levels.
 
@@ -92,20 +101,20 @@ The webview runs a lightweight game loop with canvas rendering, BFS pathfinding,
 
 ## Known Limitations
 
-- **Agent-terminal sync** — the way agents are connected to Claude Code terminal instances is not super robust and sometimes desyncs, especially when terminals are rapidly opened/closed or restored across sessions.
-- **Heuristic-based status detection** — Claude Code's JSONL transcript format does not provide clear signals for when an agent is waiting for user input or when it has finished its turn. The current detection is based on heuristics (idle timers, turn-duration events) and often misfires — agents may briefly show the wrong status or miss transitions.
+- **Agent-terminal sync** — the way agents are connected to terminal instances is not super robust and sometimes desyncs, especially when terminals are rapidly opened/closed or restored across sessions.
+- **Heuristic-based status detection** — transcript formats do not always provide explicit waiting/done signals. The current detection still relies on heuristics in some paths and may briefly misclassify states.
 - **Windows-only testing** — the extension has only been tested on Windows 11. It may work on macOS or Linux, but there could be unexpected issues with file watching, paths, or terminal behavior on those platforms.
 
 ## Roadmap
 
 There are several areas where contributions would be very welcome:
 
-- **Improve agent-terminal reliability** — more robust connection and sync between characters and Claude Code instances
+- **Improve agent-terminal reliability** — more robust connection and sync between characters and CLI instances
 - **Better status detection** — find or propose clearer signals for agent state transitions (waiting, done, permission needed)
 - **Community assets** — freely usable pixel art tilesets or characters that anyone can use without purchasing third-party assets
 - **Agent creation and definition** — define agents with custom skills, system prompts, names, and skins before launching them
 - **Desks as directories** — click on a desk to select a working directory, drag and drop agents or click-to-assign to move them to specific desks/projects
-- **Claude Code agent teams** — native support for [agent teams](https://code.claude.com/docs/en/agent-teams), visualizing multi-agent coordination and communication
+- **Agent teams** — native support for multi-agent coordination and communication
 - **Git worktree support** — agents working in different worktrees to avoid conflict from parallel work on the same files
 - **Support for other agentic frameworks** — [OpenCode](https://github.com/nichochar/opencode), or really any kind of agentic experiment you'd want to run inside a pixel art interface (see [simile.ai](https://simile.ai/) for inspiration)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.2",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
         "@types/pngjs": "^6.0.5",
-        "@types/vscode": "^1.109.0",
+        "@types/vscode": "^1.99.0",
         "esbuild": "^0.27.2",
         "eslint": "^9.39.2",
         "npm-run-all": "^4.1.5",
@@ -21,7 +22,7 @@
         "typescript-eslint": "^8.54.0"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.99.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-agents",
   "displayName": "Pixel Agents",
-  "description": "Pixel art office where your Claude Code agents come to life as animated characters",
+  "description": "Pixel art office where your Codex or Claude agents come to life as animated characters",
   "version": "1.0.2",
   "publisher": "pablodelucca",
   "repository": {
@@ -11,7 +11,7 @@
   "icon": "icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.107.0"
+    "vscode": "^1.99.0"
   },
   "categories": [
     "Other"
@@ -46,6 +46,30 @@
           "name": "Pixel Agents"
         }
       ]
+    },
+    "configuration": {
+      "title": "Pixel Agents",
+      "properties": {
+        "pixel-agents.cliProvider": {
+          "type": "string",
+          "enum": [
+            "codex",
+            "claude"
+          ],
+          "default": "codex",
+          "description": "Select which CLI runtime Pixel Agents launches and tracks."
+        },
+        "pixel-agents.codexCommand": {
+          "type": "string",
+          "default": "codex",
+          "description": "Command used to start Codex sessions."
+        },
+        "pixel-agents.claudeCommand": {
+          "type": "string",
+          "default": "claude",
+          "description": "Command used to start Claude Code sessions."
+        }
+      }
     }
   },
   "scripts": {
@@ -57,6 +81,7 @@
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "package": "npm run check-types && npm run lint && node esbuild.js --production && npm run build:webview",
+    "package:codex": "./scripts/build-codex-vsix.sh",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
     "import-tileset": "tsx scripts/import-tileset-cli.ts"
@@ -65,7 +90,7 @@
     "@anthropic-ai/sdk": "^0.74.0",
     "@types/node": "22.x",
     "@types/pngjs": "^6.0.5",
-    "@types/vscode": "^1.107.0",
+    "@types/vscode": "^1.99.0",
     "esbuild": "^0.27.2",
     "eslint": "^9.39.2",
     "npm-run-all": "^4.1.5",

--- a/scripts/build-codex-vsix.sh
+++ b/scripts/build-codex-vsix.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_VSIX="${ROOT_DIR}/pixel-agents-codex-1.0.2.vsix"
+
+cd "${ROOT_DIR}"
+npm install
+
+cd "${ROOT_DIR}/webview-ui"
+npm install
+
+cd "${ROOT_DIR}"
+npx @vscode/vsce package -o "${OUT_VSIX}"
+code --install-extension "${OUT_VSIX}" --force
+
+echo "Installed: ${OUT_VSIX}"

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -11,6 +11,7 @@ import {
 	sendExistingAgents,
 	sendLayout,
 	getProjectDirPath,
+	getSessionsFolderPathForProvider,
 } from './agentManager.js';
 import { ensureProjectScan } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
@@ -225,9 +226,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				}
 				sendExistingAgents(this.agents, this.context, this.webview);
 			} else if (message.type === 'openSessionsFolder') {
-				const projectDir = getProjectDirPath();
-				if (projectDir && fs.existsSync(projectDir)) {
-					vscode.env.openExternal(vscode.Uri.file(projectDir));
+				const sessionsDir = getSessionsFolderPathForProvider();
+				if (sessionsDir && fs.existsSync(sessionsDir)) {
+					vscode.env.openExternal(vscode.Uri.file(sessionsDir));
 				}
 			} else if (message.type === 'exportLayout') {
 				const layout = readLayoutFromFile();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,4 +39,9 @@ export const COMMAND_EXPORT_DEFAULT_LAYOUT = 'pixel-agents.exportDefaultLayout';
 export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
-export const TERMINAL_NAME_PREFIX = 'Claude Code';
+
+// ── Provider Settings ───────────────────────────────────────
+export const CONFIG_SECTION = 'pixel-agents';
+export const CONFIG_KEY_CLI_PROVIDER = 'cliProvider';
+export const CONFIG_KEY_CODEX_COMMAND = 'codexCommand';
+export const CONFIG_KEY_CLAUDE_COMMAND = 'claudeCommand';

--- a/src/providerConfig.ts
+++ b/src/providerConfig.ts
@@ -1,0 +1,62 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { AgentCliProvider } from './types.js';
+import {
+	CONFIG_SECTION,
+	CONFIG_KEY_CLI_PROVIDER,
+	CONFIG_KEY_CODEX_COMMAND,
+	CONFIG_KEY_CLAUDE_COMMAND,
+} from './constants.js';
+
+const CODEX_SESSIONS_ROOT = path.join(os.homedir(), '.codex', 'sessions');
+
+function getTodayPathParts(): { year: string; month: string; day: string } {
+	const now = new Date();
+	return {
+		year: String(now.getFullYear()),
+		month: String(now.getMonth() + 1).padStart(2, '0'),
+		day: String(now.getDate()).padStart(2, '0'),
+	};
+}
+
+export function resolveWorkspacePath(cwd?: string): string | null {
+	return cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || null;
+}
+
+export function getConfiguredProvider(): AgentCliProvider {
+	const configured = vscode.workspace
+		.getConfiguration(CONFIG_SECTION)
+		.get<string>(CONFIG_KEY_CLI_PROVIDER, 'codex');
+	return configured === 'claude' ? 'claude' : 'codex';
+}
+
+export function getCliCommand(provider: AgentCliProvider): string {
+	const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+	if (provider === 'claude') {
+		return config.get<string>(CONFIG_KEY_CLAUDE_COMMAND, 'claude');
+	}
+	return config.get<string>(CONFIG_KEY_CODEX_COMMAND, 'codex');
+}
+
+export function getTerminalNamePrefix(provider: AgentCliProvider): string {
+	return provider === 'claude' ? 'Claude Code' : 'Codex CLI';
+}
+
+export function getProjectScanDir(provider: AgentCliProvider, workspacePath: string | null): string | null {
+	if (provider === 'claude') {
+		if (!workspacePath) return null;
+		const dirName = workspacePath.replace(/[^a-zA-Z0-9-]/g, '-');
+		return path.join(os.homedir(), '.claude', 'projects', dirName);
+	}
+	const { year, month, day } = getTodayPathParts();
+	return path.join(CODEX_SESSIONS_ROOT, year, month, day);
+}
+
+export function getSessionsFolderPath(provider: AgentCliProvider, workspacePath: string | null): string | null {
+	if (provider === 'claude') {
+		return getProjectScanDir(provider, workspacePath);
+	}
+	return CODEX_SESSIONS_ROOT;
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,15 @@
 import type * as vscode from 'vscode';
 
+export type AgentCliProvider = 'codex' | 'claude';
+
 export interface AgentState {
 	id: number;
 	terminalRef: vscode.Terminal;
+	provider: AgentCliProvider;
 	projectDir: string;
+	workspacePath: string;
 	jsonlFile: string;
+	launchTimestampMs?: number;
 	fileOffset: number;
 	lineBuffer: string;
 	activeToolIds: Set<string>;
@@ -22,8 +27,11 @@ export interface AgentState {
 export interface PersistedAgent {
 	id: number;
 	terminalName: string;
+	provider?: AgentCliProvider;
 	jsonlFile: string;
 	projectDir: string;
+	workspacePath?: string;
+	launchTimestampMs?: number;
 	/** Workspace folder name (only set for multi-root workspaces) */
 	folderName?: string;
 }

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -57,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1432,7 +1431,6 @@
       "integrity": "sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1443,7 +1441,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1503,7 +1500,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1755,7 +1751,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1861,7 +1856,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2083,7 +2077,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2770,7 +2763,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2832,7 +2824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3038,7 +3029,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3125,7 +3115,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3247,7 +3236,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- add first-class Codex CLI provider with configurable runtime selection (`pixel-agents.cliProvider`, default `codex`)
- keep Claude Code support and route launching/scanning by provider
- add Codex transcript parsing (`response_item` / `event_msg`) for tool activity + waiting detection
- add provider-aware sessions folder opening and persist provider metadata with agents
- lower `engines.vscode` to `^1.99.0` for Cursor compatibility
- add `scripts/build-codex-vsix.sh` and `npm run package:codex` for one-command package+install

## Notes
- existing lint warnings in the repository remain warnings (no new lint errors)
- built and packaged locally as `pixel-agents-codex-1.0.2.vsix` and installed in Cursor
