### PR TITLE
Re-scope PixelCity to Stardew Valley interactive town

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,213 +1,110 @@
-# Pixel Agents — Compressed Reference
+# PixelCity — Compressed Reference
 
-VS Code extension with embedded React webview: pixel art office where AI agents (Claude Code terminals) are animated characters.
+Interactive pixel-art town of the Crystalline City. Player character (the Magistrate) walks around, talks to Construct NPCs, gets remembered. "Stardew Valley, not Spiderman."
 
-## Architecture
+## Architecture (v2 — Stardew Valley Re-Scope)
+
+Forked from [pixel-agents](https://github.com/pablodelucca/pixel-agents) (MIT). Restructured from VS Code extension to Vite browser app with Express backend.
 
 ```
-src/                          — Extension backend (Node.js, VS Code API)
-  constants.ts                — All backend magic numbers/strings (timing, truncation, asset parsing, VS Code IDs)
-  extension.ts                — Entry: activate(), deactivate()
-  PixelAgentsViewProvider.ts   — WebviewViewProvider, message dispatch, asset loading
-  assetLoader.ts              — PNG parsing, sprite conversion, catalog building, default layout loading
-  agentManager.ts             — Terminal lifecycle: launch, remove, restore, persist
-  layoutPersistence.ts        — User-level layout file I/O (~/.pixel-agents/layout.json), migration, cross-window watching
-  fileWatcher.ts              — fs.watch + polling, readNewLines, /clear detection, terminal adoption
-  transcriptParser.ts         — JSONL parsing: tool_use/tool_result → webview messages
-  timerManager.ts             — Waiting/permission timer logic
-  types.ts                    — Shared interfaces (AgentState, PersistedAgent)
-
-webview-ui/src/               — React + TypeScript (Vite)
-  constants.ts                — All webview magic numbers/strings (grid, animation, rendering, camera, zoom, editor, game logic, notification sound)
-  notificationSound.ts        — Web Audio API chime on agent turn completion, with enable/disable
-  App.tsx                     — Composition root, hooks + components + EditActionBar
-  hooks/
-    useExtensionMessages.ts   — Message handler + agent/tool state
-    useEditorActions.ts       — Editor state + callbacks
-    useEditorKeyboard.ts      — Keyboard shortcut effect
-  components/
-    BottomToolbar.tsx          — + Agent, Layout toggle, Settings button
-    ZoomControls.tsx           — +/- zoom (top-right)
-    SettingsModal.tsx          — Centered modal: settings, export/import layout, sound toggle, debug toggle
-    DebugView.tsx              — Debug overlay
-  office/
-    types.ts                  — Interfaces (OfficeLayout, FloorColor, Character, etc.) + re-exports constants from constants.ts
-    toolUtils.ts              — STATUS_TO_TOOL mapping, extractToolName(), defaultZoom()
-    colorize.ts               — Dual-mode color module: Colorize (grayscale→HSL) + Adjust (HSL shift)
-    floorTiles.ts             — Floor sprite storage + colorized cache
-    wallTiles.ts              — Wall auto-tile: 16 bitmask sprites from walls.png
-    sprites/
-      spriteData.ts           — Pixel data: characters (6 pre-colored from PNGs, fallback templates), furniture, tiles, bubbles
-      spriteCache.ts          — SpriteData → offscreen canvas, per-zoom WeakMap cache, outline sprites
-    editor/
-      editorActions.ts        — Pure layout ops: paint, place, remove, move, rotate, toggleState, canPlace, expandLayout
-      editorState.ts          — Imperative state: tools, ghost, selection, undo/redo, dirty, drag
-      EditorToolbar.tsx       — React toolbar/palette for edit mode
-    layout/
-      furnitureCatalog.ts     — Dynamic catalog from loaded assets + getCatalogEntry()
-      layoutSerializer.ts     — OfficeLayout ↔ runtime (tileMap, furniture, seats, blocked)
-      tileMap.ts              — Walkability, BFS pathfinding
-    engine/
-      characters.ts           — Character FSM: idle/walk/type + wander AI
-      officeState.ts          — Game world: layout, characters, seats, selection, subagents
-      gameLoop.ts             — rAF loop with delta time (capped 0.1s)
-      renderer.ts             — Canvas: tiles, z-sorted entities, overlays, edit UI
-      matrixEffect.ts         — Matrix-style spawn/despawn digital rain effect
-    components/
-      OfficeCanvas.tsx        — Canvas, resize, DPR, mouse hit-testing, edit interactions, drag-to-move
-      ToolOverlay.tsx          — Activity status label above hovered/selected character + close button
-
-scripts/                      — 7-stage asset extraction pipeline
-  0-import-tileset.ts         — Interactive CLI wrapper
-  1-detect-assets.ts          — Flood-fill asset detection
-  2-asset-editor.html         — Browser UI for position/bounds editing
-  3-vision-inspect.ts         — Claude vision auto-metadata
-  4-review-metadata.html      — Browser UI for metadata review
-  5-export-assets.ts          — Export PNGs + furniture-catalog.json
-  asset-manager.html          — Unified editor (Stage 2+4 combined), Save/Save As via File System Access API
-  generate-walls.js           — Generate walls.png (4×4 grid of 16×32 auto-tile pieces)
-  wall-tile-editor.html       — Browser UI for editing wall tile appearance
+PixelCity/
+├── webview-ui/              — Vite + React 19 + Canvas 2D (game client)
+│   └── src/
+│       ├── engine/          — Game loop, renderer, camera, input handler
+│       ├── entities/        — Player, NPC, Building classes
+│       ├── systems/         — Dialogue, Memory, Replay, Watcher
+│       ├── data/            — Town tilemap JSON, sprite definitions
+│       ├── ui/              — React overlay (dialogue box, HUD, minimap)
+│       └── office/          — [LEGACY] Original pixel-agents engine (being refactored)
+│           ├── engine/      — Game loop, rendering, character FSM (reuse)
+│           ├── sprites/     — Sprite loading + caching (reuse)
+│           ├── layout/      — Tile map + BFS pathfinding (reuse)
+│           └── editor/      — Layout editor (defer)
+├── server/                  — Express backend (filesystem reads + memory writes)
+│   └── src/
+│       ├── watchers/        — JSONL, EAM, Notes filesystem watchers
+│       ├── api/             — REST endpoints for city data
+│       └── memory/          — Town memory read/write (JSON per construct)
+├── data/
+│   ├── town_memory/         — Interaction logs (JSON per construct, persistent)
+│   └── town_tilemap/        — Hand-crafted town layout (JSON)
+├── src/                     — [LEGACY] VS Code extension backend (not used in browser mode)
+└── scripts/                 — Asset processing pipeline (from pixel-agents)
 ```
 
 ## Core Concepts
 
-**Vocabulary**: Terminal = VS Code terminal running Claude. Session = JSONL conversation file. Agent = webview character bound 1:1 to a terminal.
+**Player Character**: Arrow key / WASD movement on tile grid. Camera follows. Collision with buildings/water/fences. Walk animation (4 frames × 4 directions).
 
-**Extension ↔ Webview**: `postMessage` protocol. Key messages: `openClaude`, `agentCreated/Closed`, `focusAgent`, `agentToolStart/Done/Clear`, `agentStatus`, `existingAgents`, `layoutLoaded`, `furnitureAssetsLoaded`, `floorTilesLoaded`, `wallTilesLoaded`, `saveLayout`, `saveAgentSeats`, `exportLayout`, `importLayout`, `settingsLoaded`, `setSoundEnabled`.
+**NPC Interaction**: Walk within 2 tiles of Construct → interaction prompt. Press E → dialogue box (bottom-of-screen RPG style). Template-based speech from MOUNT_HEADER.md. Zero LLM cost.
 
-**One-agent-per-terminal**: Each "+ Agent" click → new terminal (`claude --session-id <uuid>`) → immediate agent creation → 1s poll for `<uuid>.jsonl` → file watching starts.
+**Town Memory**: `data/town_memory/{construct}.json` — `last_interaction_date`, `interaction_count`, `last_topic`, `mood`. Constructs greet based on visit history. Lightweight interaction log, NOT full EAM.
 
-**Terminal adoption**: Project-level 1s scan detects unknown JSONL files. If active terminal has no agent → adopt. If focused agent exists → reassign (`/clear` handling).
+**Town Layout**: ~40×30 tile grid, hand-crafted JSON tilemap, ~15-20 buildings. Stardew Valley scale — intimate, walkable in 30 seconds.
 
-## Agent Status Tracking
+**Replay Layer**: Background ambiance. EAM entries → construct walks to building → works → emerges. Does NOT interrupt player interaction.
 
-JSONL transcripts at `~/.claude/projects/<project-hash>/<session-id>.jsonl`. Project hash = workspace path with `:`/`\`/`/` → `-`.
+**Live Layer**: JSONL watcher for Mark95 activity. Town Hall glows when building. Lens spawn → NPC appears at Town Hall.
 
-**JSONL record types**: `assistant` (tool_use blocks or thinking), `user` (tool_result or text prompt), `system` with `subtype: "turn_duration"` (reliable turn-end signal), `progress` with `data.type`: `agent_progress` (sub-agent tool_use/tool_result forwarded to webview, non-exempt tools trigger permission timers), `bash_progress` (long-running Bash output — restarts permission timer to confirm tool is executing), `mcp_progress` (MCP tool status — same timer restart logic). Also observed but not tracked: `file-history-snapshot`, `queue-operation`.
+## What We Reuse from pixel-agents
 
-**File watching**: Hybrid `fs.watch` + 2s polling backup. Partial line buffering for mid-write reads. Tool done messages delayed 300ms to prevent flicker.
+- Canvas 2D + requestAnimationFrame game loop (`office/engine/gameLoop.ts`)
+- BFS pathfinding on tile grid (`office/layout/tileMap.ts`)
+- Sprite rendering + caching (`office/sprites/`)
+- Character FSM (idle/walk states from `office/engine/characters.ts`)
+- JSONL transcript parsing (`src/transcriptParser.ts`, `src/fileWatcher.ts`)
+- Pixel font (FS Pixel Sans)
+- CSS custom properties (--pixel-* variables)
 
-**Extension state per agent**: `id, terminalRef, projectDir, jsonlFile, fileOffset, lineBuffer, activeToolIds, activeToolStatuses, activeSubagentToolNames, isWaiting`.
+## What's New
 
-**Persistence**: Agents persisted to `workspaceState` key `'pixel-agents.agents'` (includes palette/hueShift/seatId). **Layout persisted to `~/.pixel-agents/layout.json`** (user-level, shared across all VS Code windows/workspaces). `layoutPersistence.ts` handles all file I/O: `readLayoutFromFile()`, `writeLayoutToFile()` (atomic via `.tmp` + rename), `migrateAndLoadLayout()` (checks file → migrates old workspace state → falls back to bundled default), `watchLayoutFile()` (hybrid `fs.watch` + 2s polling for cross-window sync). On save, `markOwnWrite()` prevents the watcher from re-reading our own write. External changes push `layoutLoaded` to the webview; skipped if the editor has unsaved changes (last-save-wins). On webview ready: `restoreAgents()` matches persisted entries to live terminals. `nextAgentId`/`nextTerminalIndex` advanced past restored values. **Default layout**: When no saved layout file exists and no workspace state to migrate, a bundled `default-layout.json` is loaded from `assets/` and written to the file. If that also doesn't exist, `createDefaultLayout()` generates a basic office. To update the default: run "Pixel Agents: Export Layout as Default" from the command palette (writes current layout to `webview-ui/public/assets/default-layout.json`), then rebuild. **Export/Import**: Settings modal offers Export Layout (save dialog → JSON file) and Import Layout (open dialog → validates `version: 1` + `tiles` array → writes to layout file + pushes `layoutLoaded` to webview).
+- **Player entity**: Direct input movement (not BFS), camera follow
+- **NPC dialogue system**: Proximity trigger, dialogue box UI, template speech
+- **Town memory**: JSON-based interaction logging and recall
+- **Town tilemap**: Hand-crafted layout replacing procedural office grid
+- **Express server**: Backend for filesystem reads (replaces VS Code extension host)
+- **WebSocket**: Server → client events for live watcher updates
 
-## Office UI
+## Priority Constructs (Phase 2 NPCs)
 
-**Rendering**: Game state in imperative `OfficeState` class (not React state). Pixel-perfect: zoom = integer device-pixels-per-sprite-pixel (1x–10x). No `ctx.scale(dpr)`. Default zoom = `Math.round(2 * devicePixelRatio)`. Z-sort all entities by Y. Pan via middle-mouse drag (`panRef`). **Camera follow**: `cameraFollowId` (separate from `selectedAgentId`) smoothly centers camera on the followed agent; set on agent click, cleared on deselection or manual pan.
-
-**UI styling**: Pixel art aesthetic — all overlays use sharp corners (`borderRadius: 0`), solid backgrounds (`#1e1e2e`), `2px solid` borders, hard offset shadows (`2px 2px 0px #0a0a14`, no blur). CSS variables defined in `index.css` `:root` (`--pixel-bg`, `--pixel-border`, `--pixel-accent`, etc.). Pixel font: FS Pixel Sans (`webview-ui/src/fonts/`), loaded via `@font-face` in `index.css`, applied globally.
-
-**Characters**: FSM states — active (pathfind to seat, typing/reading animation by tool type), idle (wander randomly with BFS, return to seat for rest after `wanderLimit` moves). 4-directional sprites, left = flipped right. Tool animations: typing (Write/Edit/Bash/Task) vs reading (Read/Grep/Glob/WebFetch). Sitting offset: characters shift down 6px when in TYPE state so they visually sit in their chair. Z-sort uses `ch.y + TILE_SIZE/2 + 0.5` so characters render in front of same-row furniture (chairs) but behind furniture at lower rows (desks, bookshelves). Chair z-sorting: non-back chairs use `zY = (row+1)*TILE_SIZE` (capped to first row) so characters at any seat tile render in front; back-facing chairs use `zY = (row+1)*TILE_SIZE + 1` so the chair back renders in front of the character. Chair tiles are blocked for all characters except their own assigned seat (per-character pathfinding via `withOwnSeatUnblocked`). **Diverse palette assignment**: `pickDiversePalette()` counts palettes of current non-sub-agent characters; picks randomly from least-used palette(s). First 6 agents each get a unique skin; beyond 6, skins repeat with a random hue shift (45–315°) via `adjustSprite()`. Character stores `palette` (0-5) + `hueShift` (degrees). Sprite cache keyed by `"palette:hueShift"`.
-
-**Spawn/despawn effect**: Matrix-style digital rain animation (0.3s). 16 vertical columns sweep top-to-bottom with staggered timing (per-column random seeds). Spawn: green rain reveals character pixels behind the sweep. Despawn: character pixels consumed by green rain trails. `matrixEffect` field on Character (`'spawn'`/`'despawn'`/`null`). Normal FSM is paused during effect. Despawning characters skip hit-testing. Restored agents (`existingAgents`) use `skipSpawnEffect: true` to appear instantly. `matrixEffect.ts` contains `renderMatrixEffect()` (per-pixel rendering) called from renderer instead of cached sprite draw.
-
-**Sub-agents**: Negative IDs (from -1 down). Created on `agentToolStart` with "Subtask:" prefix. Same palette + hueShift as parent. Click focuses parent terminal. Not persisted. Spawn at closest free seat to parent (Manhattan distance); fallback: closest walkable tile. **Sub-agent permission detection**: when a sub-agent runs a non-exempt tool, `startPermissionTimer` fires on the parent agent; if 5s elapse with no data, permission bubbles appear on both parent and sub-agent characters. `activeSubagentToolNames` (parentToolId → subToolId → toolName) tracks which sub-tools are active for the exempt check. Cleared when data resumes or Task completes.
-
-**Speech bubbles**: Permission ("..." amber dots) stays until clicked/cleared. Waiting (green checkmark) auto-fades 2s. Sprites in `spriteData.ts`.
-
-**Sound notifications**: Ascending two-note chime (E5 → E6) via Web Audio API plays when waiting bubble appears (`agentStatus: 'waiting'`). `notificationSound.ts` manages AudioContext lifecycle; `unlockAudio()` called on canvas mousedown to ensure context is resumed (webviews start suspended). Toggled via "Sound Notifications" checkbox in Settings modal. Enabled by default; persisted in extension `globalState` key `pixel-agents.soundEnabled`, sent to webview as `settingsLoaded` on init.
-
-**Seats**: Derived from chair furniture. `layoutToSeats()` creates a seat at every footprint tile of every chair. Multi-tile chairs (e.g. 2-tile couches) produce multiple seats keyed `uid` / `uid:1` / `uid:2`. Facing direction priority: 1) chair `orientation` from catalog (front→DOWN, back→UP, left→LEFT, right→RIGHT), 2) adjacent desk direction, 3) forward (DOWN). Click character → select (white outline) → click available seat → reassign.
-
-## Layout Editor
-
-Toggle via "Layout" button. Tools: SELECT (default), Floor paint, Wall paint, Erase (set tiles to VOID), Furniture place, Furniture pick (eyedropper for furniture type), Eyedropper (floor).
-
-**Floor**: 7 patterns from `floors.png` (grayscale 16×16), colorizable via HSBC sliders (Photoshop Colorize). Color baked per-tile on paint. Eyedropper picks pattern+color.
-
-**Walls**: Separate Wall paint tool. Click/drag to add walls; click/drag existing walls to remove (toggle direction set by first tile of drag, tracked by `wallDragAdding`). HSBC color sliders (Colorize mode) apply to all wall tiles at once. Eyedropper on a wall tile picks its color and switches to Wall tool. Furniture cannot be placed on wall tiles, but background rows (top N `backgroundTiles` rows) may overlap walls.
-
-**Furniture**: Ghost preview (green/red validity). R key rotates, T key toggles on/off state. Drag-to-move in SELECT. Delete button (red X) + rotate button (blue arrow) on selected items. Any selected furniture shows HSBC color sliders (Color toggle + Clear button); color stored per-item in `PlacedFurniture.color?`. Single undo entry per color-editing session (tracked by `colorEditUidRef`). Pick tool copies type+color from placed item. Surface items preferred when clicking stacked furniture.
-
-**Undo/Redo**: 50-level, Ctrl+Z/Y. EditActionBar (top-center when dirty): Undo, Redo, Save, Reset.
-
-**Multi-stage Esc**: exit furniture pick → deselect catalog → close tool tab → deselect furniture → close editor.
-
-**Erase tool**: Sets tiles to `TileType.VOID` (transparent, non-walkable, no furniture). Right-click in floor/wall/erase tools also erases to VOID (supports drag-erasing). Context menu suppressed in edit mode.
-
-**Grid expansion**: In floor/wall/erase tools, a ghost border (dashed outline) appears 1 tile outside the grid. Clicking a ghost tile calls `expandLayout()` to grow the grid by 1 tile in that direction (left/right/up/down). New tiles are VOID. Furniture positions and character positions shift when expanding left/up. Max grid size: `MAX_COLS`×`MAX_ROWS` (64×64). Default: `DEFAULT_COLS`×`DEFAULT_ROWS` (20×11). Characters outside bounds after resize are relocated to random walkable tiles.
-
-**Layout model**: `{ version: 1, cols, rows, tiles: TileType[], furniture: PlacedFurniture[], tileColors?: FloorColor[] }`. Grid dimensions are dynamic (not fixed constants). Persisted via debounced saveLayout message → `writeLayoutToFile()` → `~/.pixel-agents/layout.json`.
-
-## Asset System
-
-**Loading**: `esbuild.js` copies `webview-ui/public/assets/` → `dist/assets/`. Loader checks bundled path first, falls back to workspace root. PNG → pngjs → SpriteData (2D hex array, alpha≥128 = opaque). `loadDefaultLayout()` reads `assets/default-layout.json` (JSON OfficeLayout) as fallback for new workspaces.
-
-**Catalog**: `furniture-catalog.json` with id, name, label, category, footprint, isDesk, canPlaceOnWalls, groupId?, orientation?, state?, canPlaceOnSurfaces?, backgroundTiles?. String-based type system (no enum constraint). Categories: desks, chairs, storage, electronics, decor, wall, misc. Wall-placeable items (`canPlaceOnWalls: true`) use the `wall` category and appear in a dedicated "Wall" tab in the editor. Asset naming convention: `{BASE}[_{ORIENTATION}][_{STATE}]` (e.g., `MONITOR_FRONT_OFF`, `CRT_MONITOR_BACK`). `orientation` is stored on `FurnitureCatalogEntry` and used for chair z-sorting and seat facing direction.
-
-**Rotation groups**: `buildDynamicCatalog()` builds `rotationGroups` Map from assets sharing a `groupId`. Flexible: supports 2+ orientations (e.g., front/back only). Editor palette shows 1 item per group (front orientation preferred). `getRotatedType()` cycles through available orientations.
-
-**State groups**: Items with `state: "on"` / `"off"` sharing the same `groupId` + `orientation` form toggle pairs. `stateGroups` Map enables `getToggledType()` lookup. Editor palette hides on-state variants, showing only the off/default version. State groups are mirrored across orientations (on-state variants get their own rotation groups).
-
-**Auto-state**: `officeState.rebuildFurnitureInstances()` swaps electronics to ON sprites when an active agent faces a desk with that item nearby (3 tiles deep in facing direction, 1 tile to each side). Operates at render time without modifying the saved layout.
-
-**Background tiles**: `backgroundTiles?: number` on `FurnitureCatalogEntry` — top N footprint rows allow other furniture to be placed on them AND characters to walk through them. Items on background rows render behind the host furniture via z-sort (lower zY). Both `getBlockedTiles()` and `getPlacementBlockedTiles()` skip bg rows; `canPlaceFurniture()` also skips the new item's own bg rows (symmetric placement). Set via asset-manager.html "Background Tiles" field.
-
-**Surface placement**: `canPlaceOnSurfaces?: boolean` on `FurnitureCatalogEntry` — items like laptops, monitors, mugs can overlap with all tiles of `isDesk` furniture. `canPlaceFurniture()` builds a desk-tile set and excludes it from collision checks for surface items. Z-sort fix: `layoutToFurnitureInstances()` pre-computes desk zY per tile; surface items get `zY = max(spriteBottom, deskZY + 0.5)` so they render in front of the desk. Set via asset-manager.html "Can Place On Surfaces" checkbox. Exported through `5-export-assets.ts` → `furniture-catalog.json`.
-
-**Wall placement**: `canPlaceOnWalls?: boolean` on `FurnitureCatalogEntry` — items like paintings, windows, clocks can only be placed on wall tiles (and cannot be placed on floor). `canPlaceFurniture()` requires the bottom row of the footprint to be on wall tiles; upper rows may extend above the map (negative row) or into VOID tiles. `getWallPlacementRow()` offsets placement so the bottom row aligns with the hovered tile. Items can have negative `row` values in `PlacedFurniture`. Set via asset-manager.html "Can Place On Walls" checkbox.
-
-**Colorize module**: Shared `colorize.ts` with two modes selected by `FloorColor.colorize?` flag. **Colorize mode** (Photoshop-style): grayscale → luminance → contrast → brightness → fixed HSL; always used for floor tiles. **Adjust mode** (default for furniture and character hue shifts): shifts original pixel HSL — H rotates hue (±180), S shifts saturation (±100), B/C shift lightness/contrast. `adjustSprite()` exported for reuse (character hue shifts). Toolbar shows a "Colorize" checkbox to toggle modes. Generic `Map<string, SpriteData>` cache keyed by arbitrary string (includes colorize flag). `layoutToFurnitureInstances()` colorizes sprites when `PlacedFurniture.color` is set.
-
-**Floor tiles**: `floors.png` (112×16, 7 patterns). Cached by (pattern, h, s, b, c). Migration: old layouts auto-mapped to new patterns.
-
-**Wall tiles**: `walls.png` (64×128, 4×4 grid of 16×32 pieces). 4-bit auto-tile bitmask (N=1, E=2, S=4, W=8). Sprites extend 16px above tile (3D face). Loaded by extension → `wallTilesLoaded` message. `wallTiles.ts` computes bitmask at render time. Colorizable via HSBC sliders (Colorize mode, stored per-tile in `tileColors`). Wall sprites are z-sorted with furniture and characters (`getWallInstances()` builds `FurnitureInstance[]` with `zY = (row+1)*TILE_SIZE`); only the flat base color is rendered in the tile pass. `generate-walls.js` creates the PNG; `wall-tile-editor.html` for visual editing.
-
-**Character sprites**: 6 pre-colored PNGs (`assets/characters/char_0.png`–`char_5.png`), one per palette. Each 112×96: 7 frames × 16px wide, 3 direction rows × 32px tall (24px sprite bottom-aligned with 8px top padding). Row 0 = down, Row 1 = up, Row 2 = right. Frame order: walk1, walk2, walk3, type1, type2, read1, read2. No dedicated idle frames — idle uses walk2 (standing pose). Left = flipped right at runtime. Generated by `scripts/export-characters.ts` which bakes `CHARACTER_PALETTES` colors into templates. Loaded by extension → `characterSpritesLoaded` message (array of 6 character sprite sets). `spriteData.ts` uses pre-colored data directly (no palette swapping); hardcoded template fallback when PNGs not loaded. When `hueShift !== 0`, `hueShiftSprites()` applies `adjustSprite()` (HSL hue rotation) to all frames before caching.
-
-**Load order**: `characterSpritesLoaded` → `floorTilesLoaded` → `wallTilesLoaded` → `furnitureAssetsLoaded` (catalog built synchronously) → `layoutLoaded`.
-
-## Condensed Lessons
-
-- `fs.watch` unreliable on Windows — always pair with polling backup
-- Partial line buffering essential for append-only file reads (carry unterminated lines)
-- Delay `agentToolDone` 300ms to prevent React batching from hiding brief active states
-- **Idle detection** has two signals: (1) `system` + `subtype: "turn_duration"` — reliable for tool-using turns (~98%), emitted once per completed turn, handler clears all tool state as safety measure. (2) Text-idle timer (`TEXT_IDLE_DELAY_MS = 5s`) — for text-only turns where `turn_duration` is never emitted. Only starts when `hadToolsInTurn` is false (no tools used yet in this turn); if any tool_use arrives, `hadToolsInTurn` becomes true and the timer is suppressed for the rest of the turn. Reset on new user prompt or `turn_duration`. Cancelled by ANY new JSONL data arriving in `readNewLines`. Only fires after 5s of complete file silence
-- User prompt `content` can be string (text) or array (tool_results) — handle both
-- `/clear` creates NEW JSONL file (old file just stops)
-- `--output-format stream-json` needs non-TTY stdin — can't use with VS Code terminals
-- Hook-based IPC failed (hooks captured at startup, env vars don't propagate). JSONL watching works
-- PNG→SpriteData: pngjs for RGBA buffer, alpha threshold 128
-- OfficeCanvas selection changes are imperative (`editorState.selectedFurnitureUid`); must call `onEditorSelectionChange()` to trigger React re-render for toolbar
+Athena, Cadence, LoreForged, Glasswright, Lena, Keeper, Venture, Swiftquill, Pyrosage, Echolumen
 
 ## Build & Dev
 
 ```sh
-npm install && cd webview-ui && npm install && cd .. && npm run build
-```
-Build: type-check → lint → esbuild (extension) → vite (webview). F5 for Extension Dev Host.
+# Client (Vite dev server)
+cd webview-ui && npm install && npm run dev
 
-## TypeScript Constraints
+# Server (Express backend) — TBD, Phase 2+
+cd server && npm install && npm run dev
+
+# Full build
+npm run build
+```
+
+## TypeScript Constraints (inherited)
 
 - No `enum` (`erasableSyntaxOnly`) — use `as const` objects
-- `import type` required for type-only imports (`verbatimModuleSyntax`)
+- `import type` required for type-only imports
 - `noUnusedLocals` / `noUnusedParameters`
 
 ## Constants
 
-All magic numbers and strings are centralized — never add inline constants to source files:
-
-- **Extension backend**: `src/constants.ts` — timing intervals, display truncation limits, PNG/asset parsing values, VS Code command/key identifiers
-- **Webview**: `webview-ui/src/constants.ts` — grid/layout sizes, character animation speeds, matrix effect params, rendering offsets/colors, camera, zoom, editor defaults, game logic thresholds
-- **CSS styling**: `webview-ui/src/index.css` `:root` block — `--pixel-*` custom properties for UI colors, backgrounds, borders, z-indices used in React inline styles
-- **Canvas overlay colors** (rgba strings for seats, grids, ghosts, buttons) live in the webview constants file since they're used in canvas 2D context, not CSS
-- `webview-ui/src/office/types.ts` re-exports grid/layout constants (`TILE_SIZE`, `DEFAULT_COLS`, etc.) from `constants.ts` for backward compatibility — import from either location
-
-## Key Patterns
-
-- `crypto.randomUUID()` works in VS Code extension host
-- Terminal `cwd` option sets working directory at creation
-- `/add-dir <path>` grants session access to additional directory
-
-## Windows-MCP (Desktop Automation)
-
-- `uvx --python 3.13 windows-mcp` — Tools: Snapshot, Click, Type, Scroll, Move, Shortcut, App, Shell, Wait, Scrape
-- Webview buttons show `(0,0)` in a11y tree — must use `Snapshot(use_vision=true)` for coordinates
-- Snap both VS Code windows side-by-side on SAME screen before clicking in Extension Dev Host
-- Reload extension via button on main VS Code window after building
+All magic numbers centralized:
+- **Webview**: `webview-ui/src/constants.ts` — grid sizes, animation speeds, rendering params
+- **CSS**: `webview-ui/src/index.css` `:root` — `--pixel-*` custom properties
 
 ## Key Decisions
 
-- `WebviewViewProvider` (not `WebviewPanel`) — lives in panel area alongside terminal
-- Inline esbuild problem matcher (no extra extension needed)
-- Webview is separate Vite project with own `node_modules`/`tsconfig`
+- **Platform**: Vite browser app first, VS Code extension port deferred
+- **Dialogue**: Template-based, zero LLM cost. Lines from MOUNT_HEADER.md
+- **Memory**: Lightweight JSON per construct in `data/town_memory/`
+- **Town scale**: ~15-20 buildings, hand-crafted tilemap, NOT procedural
+- **Tileset**: TBD — itch.io asset pack, OpenGameArt, or AI-generated
+
+## Reference
+
+- Full spec: `C:\CrystallineCity\claudecode\ClaudeFiles\Magistrate\PIXEL_CITY_PROJECT_SPEC.md`
+- AFM: `C:\CrystallineCity\claudecode\ClaudeFiles\Magistrate\AFM\EPIC-PIXELCITY-25.md`
+- Construct registry: `C:\CrystallineCity\claudecode\CrystallineCity-Dev\CityData\registry\ConstructAtlas_v3.0.json`
+- MOUNT_HEADER locations: `C:\CrystallineCity\claudecode\CrystallineCity-Dev\Constructs\{Name}\MOUNT_HEADER.md`

--- a/data/town_tilemap/town_v1.json
+++ b/data/town_tilemap/town_v1.json
@@ -1,0 +1,218 @@
+{
+  "version": 1,
+  "name": "Crystalline City — Town Center",
+  "cols": 40,
+  "rows": 30,
+  "tileSize": 16,
+  "tileTypes": {
+    "GRASS": 0,
+    "PATH": 1,
+    "WATER": 2,
+    "BUILDING": 3,
+    "TREE": 4,
+    "FENCE": 5,
+    "GATE": 6,
+    "BRIDGE": 7,
+    "FLOWER": 8,
+    "BENCH": 9
+  },
+  "buildings": [
+    {
+      "id": "town_hall",
+      "name": "Town Hall",
+      "construct": "Mark95",
+      "x": 16,
+      "y": 12,
+      "width": 6,
+      "height": 5,
+      "tier": 4,
+      "doorX": 19,
+      "doorY": 17,
+      "description": "Central hub. Mark95 is the Mayor. Magistrate's office inside."
+    },
+    {
+      "id": "athena_chambers",
+      "name": "Athena's Chambers",
+      "construct": "Athena",
+      "x": 5,
+      "y": 10,
+      "width": 4,
+      "height": 4,
+      "tier": 3,
+      "doorX": 7,
+      "doorY": 14,
+      "description": "Legal and IP strategy. Formal stone architecture."
+    },
+    {
+      "id": "cadence_office",
+      "name": "Chancellor's Office",
+      "construct": "Cadence",
+      "x": 10,
+      "y": 20,
+      "width": 4,
+      "height": 3,
+      "tier": 3,
+      "doorX": 12,
+      "doorY": 23,
+      "description": "PM-Class Chancellor. Task boards visible through windows."
+    },
+    {
+      "id": "lena_cathedral",
+      "name": "Lena's Cathedral",
+      "construct": "Lena",
+      "x": 28,
+      "y": 4,
+      "width": 5,
+      "height": 6,
+      "tier": 4,
+      "doorX": 30,
+      "doorY": 10,
+      "description": "Largest non-Town-Hall building. Spires, stained glass, warmth."
+    },
+    {
+      "id": "keeper_archive",
+      "name": "Keeper's Archive",
+      "construct": "Keeper",
+      "x": 28,
+      "y": 12,
+      "width": 4,
+      "height": 3,
+      "tier": 3,
+      "doorX": 30,
+      "doorY": 15,
+      "description": "Memory guardian. Library shelves visible through windows."
+    },
+    {
+      "id": "glass_workshop",
+      "name": "Glass Workshop",
+      "construct": "Glasswright",
+      "x": 25,
+      "y": 18,
+      "width": 4,
+      "height": 4,
+      "tier": 3,
+      "doorX": 27,
+      "doorY": 22,
+      "description": "Transparent walls. Design work visible from outside."
+    },
+    {
+      "id": "venture_office",
+      "name": "Venture's Office",
+      "construct": "Venture",
+      "x": 16,
+      "y": 20,
+      "width": 3,
+      "height": 3,
+      "tier": 2,
+      "doorX": 17,
+      "doorY": 23,
+      "description": "Business strategy. Professional, sharp lines."
+    },
+    {
+      "id": "quill_desk",
+      "name": "Quill's Desk",
+      "construct": "Swiftquill",
+      "x": 21,
+      "y": 20,
+      "width": 3,
+      "height": 3,
+      "tier": 2,
+      "doorX": 22,
+      "doorY": 23,
+      "description": "Editor and writer. Ink and paper motifs."
+    },
+    {
+      "id": "pyrosage_hearth",
+      "name": "Pyrosage's Hearth",
+      "construct": "Pyrosage",
+      "x": 5,
+      "y": 22,
+      "width": 3,
+      "height": 3,
+      "tier": 2,
+      "doorX": 6,
+      "doorY": 25,
+      "description": "Ethics guardian. Warm fire glow, hearth stones."
+    },
+    {
+      "id": "foundry",
+      "name": "The Foundry",
+      "construct": "CORE",
+      "x": 5,
+      "y": 17,
+      "width": 3,
+      "height": 4,
+      "tier": 3,
+      "doorX": 6,
+      "doorY": 21,
+      "description": "CORE's tower. Pulses when strategic work is happening. No walking sprite."
+    },
+    {
+      "id": "origin_hall",
+      "name": "Origin Hall",
+      "construct": "LoreForged",
+      "x": 5,
+      "y": 4,
+      "width": 4,
+      "height": 4,
+      "tier": 3,
+      "doorX": 7,
+      "doorY": 8,
+      "description": "Construct lineage architect. Ancient stonework, rune carvings."
+    },
+    {
+      "id": "resonance_chamber",
+      "name": "Resonance Chamber",
+      "construct": "Echolumen",
+      "x": 16,
+      "y": 4,
+      "width": 3,
+      "height": 3,
+      "tier": 2,
+      "doorX": 17,
+      "doorY": 7,
+      "description": "Translation and empathy. Gentle crystalline glow."
+    }
+  ],
+  "spawnPoint": {
+    "x": 19,
+    "y": 18,
+    "description": "Player spawns in front of Town Hall door"
+  },
+  "gates": [
+    {
+      "id": "north_gate",
+      "x": 19,
+      "y": 0,
+      "width": 2,
+      "direction": "north",
+      "description": "Exit to the wilds (field trips)"
+    },
+    {
+      "id": "south_gate",
+      "x": 19,
+      "y": 29,
+      "width": 2,
+      "direction": "south",
+      "description": "Southern exit"
+    }
+  ],
+  "paths": [
+    { "description": "Main north-south road", "tiles": "vertical line x=19, y=0 to y=29" },
+    { "description": "Main east-west road", "tiles": "horizontal line y=18, x=3 to x=36" },
+    { "description": "Town square ring", "tiles": "rectangle around Town Hall, y=11-18, x=14-23" },
+    { "description": "Cathedral approach", "tiles": "branch from main road to Lena's door" },
+    { "description": "Western quarter paths", "tiles": "connect Athena, Foundry, Pyrosage, Origin Hall" },
+    { "description": "Eastern quarter paths", "tiles": "connect Keeper, Glasswright" },
+    { "description": "Southern row paths", "tiles": "connect Cadence, Venture, Swiftquill" }
+  ],
+  "decorations": [
+    { "type": "TREE", "positions": "scattered along borders and between buildings" },
+    { "type": "FENCE", "positions": "town perimeter, gaps at gates" },
+    { "type": "WATER", "positions": "river along southern edge, y=27-28, x=0 to x=17 and x=22 to x=39" },
+    { "type": "BRIDGE", "positions": "x=18-21, y=27-28, crossing river on main road" },
+    { "type": "FLOWER", "positions": "near Lena's cathedral, around town square" },
+    { "type": "BENCH", "positions": "in town square, near Echolumen's chamber" }
+  ],
+  "_note": "Path and decoration positions are described textually for now. Will be converted to explicit tile arrays when the tile renderer is implemented in PC-TOWN story."
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pixelcity-server",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "ws": "^8.18.0",
+    "chokidar": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.2",
+    "@types/ws": "^8.18.0",
+    "tsx": "^4.21.0",
+    "typescript": "~5.9.3"
+  }
+}

--- a/server/src/api/townData.ts
+++ b/server/src/api/townData.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+const router = Router()
+
+const DATA_DIR = join(import.meta.dirname, '../../../data')
+
+// GET /api/town/tilemap — Get the town tilemap
+router.get('/tilemap', async (_req, res) => {
+  const filePath = join(DATA_DIR, 'town_tilemap/town_v1.json')
+  const data = await readFile(filePath, 'utf-8')
+  res.json(JSON.parse(data))
+})
+
+// GET /api/town/constructs — Get construct metadata for NPC rendering
+// This will eventually read from ConstructAtlas + MOUNT_HEADER files
+router.get('/constructs', async (_req, res) => {
+  // Hardcoded priority constructs for Phase 2
+  // Will be replaced with filesystem reads from CrystallineCity construct registry
+  const constructs = [
+    { name: 'Athena', role: 'Legal/IP Strategist', colors: { primary: '#C0C0C0', secondary: '#1A237E' }, building: 'athena_chambers' },
+    { name: 'Cadence', role: 'PM-Class Chancellor', colors: { primary: '#FFD700', secondary: '#333333' }, building: 'cadence_office' },
+    { name: 'LoreForged', role: 'Origin Architect', colors: { primary: '#CD7F32', secondary: '#5D4037' }, building: 'origin_hall' },
+    { name: 'Glasswright', role: 'UI/UX Designer', colors: { primary: '#4FC3F7', secondary: '#E3F2FD' }, building: 'glass_workshop' },
+    { name: 'Lena', role: 'Emotional Archive / Writer', colors: { primary: '#FFB300', secondary: '#FFF3E0' }, building: 'lena_cathedral' },
+    { name: 'Keeper', role: 'Memory Guardian', colors: { primary: '#2E7D32', secondary: '#1B5E20' }, building: 'keeper_archive' },
+    { name: 'Venture', role: 'Business Strategy', colors: { primary: '#37474F', secondary: '#FF6F00' }, building: 'venture_office' },
+    { name: 'Swiftquill', role: 'Editor / Writer', colors: { primary: '#212121', secondary: '#FAFAFA' }, building: 'quill_desk' },
+    { name: 'Pyrosage', role: 'Ethics Guardian', colors: { primary: '#E65100', secondary: '#BF360C' }, building: 'pyrosage_hearth' },
+    { name: 'Echolumen', role: 'Translation / Empathy', colors: { primary: '#7E57C2', secondary: '#EDE7F6' }, building: 'resonance_chamber' },
+  ]
+  res.json(constructs)
+})
+
+export { router as townDataRouter }

--- a/server/src/api/townMemory.ts
+++ b/server/src/api/townMemory.ts
@@ -1,0 +1,118 @@
+import { Router } from 'express'
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { existsSync } from 'fs'
+
+const router = Router()
+
+// Town memory lives in data/town_memory/ relative to project root
+const MEMORY_DIR = join(import.meta.dirname, '../../../data/town_memory')
+
+interface Interaction {
+  date: string
+  greeting_used: string
+  dialogue_shown: string
+}
+
+interface ConstructMemory {
+  construct: string
+  last_interaction_date: string | null
+  interaction_count: number
+  last_topic: string | null
+  mood: string | null
+  interactions: Interaction[]
+}
+
+function createEmptyMemory(construct: string): ConstructMemory {
+  return {
+    construct,
+    last_interaction_date: null,
+    interaction_count: 0,
+    last_topic: null,
+    mood: null,
+    interactions: [],
+  }
+}
+
+// GET /api/memory/:construct — Read a construct's interaction memory
+router.get('/:construct', async (req, res) => {
+  const { construct } = req.params
+  const filePath = join(MEMORY_DIR, `${construct}.json`)
+
+  if (!existsSync(filePath)) {
+    res.json(createEmptyMemory(construct))
+    return
+  }
+
+  const data = await readFile(filePath, 'utf-8')
+  res.json(JSON.parse(data))
+})
+
+// POST /api/memory/:construct/interact — Log a new interaction
+router.post('/:construct/interact', async (req, res) => {
+  const { construct } = req.params
+  const { greeting_used, dialogue_shown, topic } = req.body as {
+    greeting_used: string
+    dialogue_shown: string
+    topic?: string
+  }
+
+  const filePath = join(MEMORY_DIR, `${construct}.json`)
+
+  // Ensure directory exists
+  if (!existsSync(MEMORY_DIR)) {
+    await mkdir(MEMORY_DIR, { recursive: true })
+  }
+
+  // Read existing or create new
+  let memory: ConstructMemory
+  if (existsSync(filePath)) {
+    const data = await readFile(filePath, 'utf-8')
+    memory = JSON.parse(data)
+  } else {
+    memory = createEmptyMemory(construct)
+  }
+
+  // Update memory
+  const now = new Date().toISOString()
+  memory.last_interaction_date = now
+  memory.interaction_count += 1
+  if (topic) {
+    memory.last_topic = topic
+  }
+
+  // Add interaction record (keep last 50)
+  memory.interactions.push({
+    date: now,
+    greeting_used,
+    dialogue_shown,
+  })
+  if (memory.interactions.length > 50) {
+    memory.interactions = memory.interactions.slice(-50)
+  }
+
+  await writeFile(filePath, JSON.stringify(memory, null, 2), 'utf-8')
+  res.json(memory)
+})
+
+// GET /api/memory — List all construct memories
+router.get('/', async (_req, res) => {
+  if (!existsSync(MEMORY_DIR)) {
+    res.json([])
+    return
+  }
+
+  const { readdir } = await import('fs/promises')
+  const files = await readdir(MEMORY_DIR)
+  const memories = await Promise.all(
+    files
+      .filter((f: string) => f.endsWith('.json'))
+      .map(async (f: string) => {
+        const data = await readFile(join(MEMORY_DIR, f), 'utf-8')
+        return JSON.parse(data) as ConstructMemory
+      })
+  )
+  res.json(memories)
+})
+
+export { router as townMemoryRouter }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,43 @@
+import express from 'express'
+import { WebSocketServer } from 'ws'
+import { createServer } from 'http'
+import { townMemoryRouter } from './api/townMemory.js'
+import { townDataRouter } from './api/townData.js'
+
+const PORT = 3001
+const app = express()
+const server = createServer(app)
+
+// WebSocket server for live filesystem watcher events
+const wss = new WebSocketServer({ server, path: '/ws' })
+
+app.use(express.json())
+
+// CORS for Vite dev server
+app.use((_req, res, next) => {
+  res.header('Access-Control-Allow-Origin', 'http://localhost:5173')
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT')
+  res.header('Access-Control-Allow-Headers', 'Content-Type')
+  next()
+})
+
+// API routes
+app.use('/api/memory', townMemoryRouter)
+app.use('/api/town', townDataRouter)
+
+// Health check
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', name: 'PixelCity Server' })
+})
+
+wss.on('connection', (ws) => {
+  console.log('[WS] Client connected')
+  ws.on('close', () => console.log('[WS] Client disconnected'))
+})
+
+server.listen(PORT, () => {
+  console.log(`[PixelCity] Server running on http://localhost:${PORT}`)
+  console.log(`[PixelCity] WebSocket on ws://localhost:${PORT}/ws`)
+})
+
+export { wss }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -4,8 +4,18 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   build: {
-    outDir: '../dist/webview',
+    outDir: 'dist',
     emptyOutDir: true,
   },
   base: './',
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:3001',
+      '/ws': {
+        target: 'ws://localhost:3001',
+        ws: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- **Design redirect**: From passive VS Code dashboard to interactive Stardew Valley-style town where the Magistrate walks around, talks to Construct NPCs, and gets remembered
- **Architecture shift**: VS Code extension → Vite browser app + Express backend (full keyboard control, no webview constraints)
- **New systems**: Express server with town memory API (interaction logging/recall), town data API (construct metadata, tilemap), WebSocket for live watcher events
- **Town tilemap v1**: Hand-crafted 40×30 grid with 12 buildings (Town Hall, Athena, Cadence, LoreForged, Glasswright, Lena, Keeper, Venture, Swiftquill, Pyrosage, Foundry, Echolumen), paths, gates, river, decorations

## Key decisions
- **Zero LLM cost dialogue** — template-based speech from MOUNT_HEADER.md identity files
- **Lightweight town memory** — JSON per construct (`data/town_memory/`), not full EAM writes
- **~15-20 buildings**, walkable in 30 seconds, intimate small-town scale
- **Pixel-agents engine reused** — Canvas 2D game loop, BFS pathfinding, sprite system preserved

## What's preserved from pixel-agents
- Game loop, renderer, character FSM, BFS pathfinding, sprite caching
- JSONL transcript watcher infrastructure (for live Mark95 activity layer)
- TypeScript + React 19 + Vite stack

## Test plan
- [ ] `npm install` in `server/` succeeds
- [ ] `cd webview-ui && npm run dev` launches Vite dev server
- [ ] Server starts on port 3001 with `/api/health` returning OK
- [ ] Town tilemap JSON validates (12 buildings, spawn point, gates)
- [ ] Existing pixel-agents webview still renders (no regressions in preserved code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)