### PR TITLE
feat: add Connect to Pixel Agents terminal context menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ src/                          — Extension backend (Node.js, VS Code API)
   PixelAgentsViewProvider.ts   — WebviewViewProvider, message dispatch, asset loading
   assetLoader.ts              — PNG parsing, sprite conversion, catalog building, default layout loading
   agentManager.ts             — Terminal lifecycle: launch, remove, restore, persist
+  agentFactory.ts             — createAgentState() factory, single source of truth for AgentState initialization
   layoutPersistence.ts        — User-level layout file I/O (~/.pixel-agents/layout.json), migration, cross-window watching
   fileWatcher.ts              — fs.watch + polling, readNewLines, /clear detection, terminal adoption
   transcriptParser.ts         — JSONL parsing: tool_use/tool_result → webview messages
@@ -77,7 +78,7 @@ scripts/                      — 7-stage asset extraction pipeline
 
 **One-agent-per-terminal**: Each "+ Agent" click → new terminal (`claude --session-id <uuid>`) → immediate agent creation → 1s poll for `<uuid>.jsonl` → file watching starts.
 
-**Terminal adoption**: Project-level 1s scan detects unknown JSONL files. If active terminal has no agent → adopt. If focused agent exists → reassign (`/clear` handling).
+**Terminal adoption**: Project-level 1s scan detects unknown JSONL files. If focused agent exists → reassign (`/clear` handling). If only 1 unowned terminal → auto-adopt. If multiple unowned → adopt focused terminal. **Manual connect**: Terminal tab right-click → "Connect to Pixel Agents" → resolves project dir (shellIntegration.cwd → creationOptions.cwd → single-root fallback) → finds best untracked JSONL by mtime → adopts with fileOffset=size (skips history).
 
 ## Agent Status Tracking
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,17 @@
       {
         "command": "pixel-agents.exportDefaultLayout",
         "title": "Pixel Agents: Export Layout as Default"
+      },
+      {
+        "command": "pixel-agents.connectTerminal",
+        "title": "Connect to Pixel Agents"
       }
     ],
+    "menus": {
+      "terminal/title/context": [
+        { "command": "pixel-agents.connectTerminal" }
+      ]
+    },
     "viewsContainers": {
       "panel": [
         {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -12,7 +12,7 @@ import {
 	sendLayout,
 	getProjectDirPath,
 } from './agentManager.js';
-import { ensureProjectScan } from './fileWatcher.js';
+import { ensureProjectScan, adoptTerminalForFile } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
 import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
 import { writeLayoutToFile, readLayoutFromFile, watchLayoutFile } from './layoutPersistence.js';
@@ -293,6 +293,118 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				}
 			}
 		});
+	}
+
+	/** Connect an existing terminal to Pixel Agents (terminal tab context menu) */
+	connectTerminal(terminal: vscode.Terminal): void {
+		// Already owned?
+		for (const agent of this.agents.values()) {
+			if (agent.terminalRef === terminal) {
+				vscode.window.showInformationMessage('Pixel Agents: This terminal is already connected.');
+				return;
+			}
+		}
+
+		const projectDir = this.resolveProjectDir(terminal);
+		if (!projectDir) {
+			vscode.window.showWarningMessage('Pixel Agents: Could not determine project directory for this terminal.');
+			return;
+		}
+
+		const jsonlFile = this.findBestJsonlFile(projectDir);
+		if (!jsonlFile) {
+			vscode.window.showWarningMessage('Pixel Agents: No active Claude session found for this terminal.');
+			return;
+		}
+
+		// Skip past existing content (we only care about future activity)
+		let fileOffset = 0;
+		try {
+			fileOffset = fs.statSync(jsonlFile).size;
+		} catch { /* start from 0 */ }
+
+		this.knownJsonlFiles.add(jsonlFile);
+
+		const id = adoptTerminalForFile(
+			terminal, jsonlFile, projectDir,
+			this.nextAgentId, this.agents, this.activeAgentId,
+			this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+			this.webview, this.persistAgents,
+		);
+
+		if (id !== null) {
+			// Apply fileOffset to skip past history
+			const agent = this.agents.get(id);
+			if (agent) {
+				agent.fileOffset = fileOffset;
+			}
+
+			// Ensure project scan is running for this directory
+			ensureProjectScan(
+				projectDir, this.knownJsonlFiles, this.projectScanTimer, this.activeAgentId,
+				this.nextAgentId, this.agents,
+				this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+				this.webview, this.persistAgents,
+			);
+		}
+	}
+
+	/** Resolve the project directory for a terminal (cwd → Claude project hash path) */
+	private resolveProjectDir(terminal: vscode.Terminal): string | null {
+		// 1. Shell Integration API (most reliable)
+		const shellCwd = (terminal as unknown as { shellIntegration?: { cwd?: vscode.Uri } }).shellIntegration?.cwd;
+		if (shellCwd) {
+			return getProjectDirPath(shellCwd.fsPath);
+		}
+
+		// 2. creationOptions.cwd
+		const opts = terminal.creationOptions as vscode.TerminalOptions;
+		if (opts?.cwd) {
+			const cwdStr = typeof opts.cwd === 'string' ? opts.cwd : opts.cwd.fsPath;
+			return getProjectDirPath(cwdStr);
+		}
+
+		// 3. Single-root workspace fallback
+		const folders = vscode.workspace.workspaceFolders;
+		if (folders?.length === 1) {
+			return getProjectDirPath(folders[0].uri.fsPath);
+		}
+
+		return null;
+	}
+
+	/** Find the best untracked JSONL file (most recently modified) in a project directory */
+	private findBestJsonlFile(projectDir: string): string | null {
+		let files: string[];
+		try {
+			files = fs.readdirSync(projectDir)
+				.filter(f => f.endsWith('.jsonl'))
+				.map(f => path.join(projectDir, f));
+		} catch { return null; }
+
+		// Filter out files already tracked by agents
+		const trackedFiles = new Set<string>();
+		for (const agent of this.agents.values()) {
+			trackedFiles.add(agent.jsonlFile);
+		}
+
+		const untracked = files.filter(f => !trackedFiles.has(f));
+		if (untracked.length === 0) return null;
+
+		// Pick most recently modified
+		let best: string | null = null;
+		let bestMtime = 0;
+		for (const f of untracked) {
+			try {
+				const mtime = fs.statSync(f).mtimeMs;
+				if (mtime > bestMtime) {
+					bestMtime = mtime;
+					best = f;
+				}
+			} catch { /* skip */ }
+		}
+
+		return best;
 	}
 
 	/** Export current saved layout to webview-ui/public/assets/default-layout.json (dev utility) */

--- a/src/agentFactory.ts
+++ b/src/agentFactory.ts
@@ -1,0 +1,28 @@
+import type * as vscode from 'vscode';
+import type { AgentState } from './types.js';
+
+export function createAgentState(
+	id: number,
+	terminal: vscode.Terminal,
+	projectDir: string,
+	jsonlFile: string,
+	options?: { fileOffset?: number; folderName?: string },
+): AgentState {
+	return {
+		id,
+		terminalRef: terminal,
+		projectDir,
+		jsonlFile,
+		fileOffset: options?.fileOffset ?? 0,
+		lineBuffer: '',
+		activeToolIds: new Set(),
+		activeToolStatuses: new Map(),
+		activeToolNames: new Map(),
+		activeSubagentToolIds: new Map(),
+		activeSubagentToolNames: new Map(),
+		isWaiting: false,
+		permissionSent: false,
+		hadToolsInTurn: false,
+		folderName: options?.folderName,
+	};
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 export const VIEW_ID = 'pixel-agents.panelView';
 export const COMMAND_SHOW_PANEL = 'pixel-agents.showPanel';
 export const COMMAND_EXPORT_DEFAULT_LAYOUT = 'pixel-agents.exportDefaultLayout';
+export const COMMAND_CONNECT_TERMINAL = 'pixel-agents.connectTerminal';
 export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { PixelAgentsViewProvider } from './PixelAgentsViewProvider.js';
-import { VIEW_ID, COMMAND_SHOW_PANEL, COMMAND_EXPORT_DEFAULT_LAYOUT } from './constants.js';
+import { VIEW_ID, COMMAND_SHOW_PANEL, COMMAND_EXPORT_DEFAULT_LAYOUT, COMMAND_CONNECT_TERMINAL } from './constants.js';
 
 let providerInstance: PixelAgentsViewProvider | undefined;
 
@@ -21,6 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(COMMAND_EXPORT_DEFAULT_LAYOUT, () => {
 			provider.exportDefaultLayout();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(COMMAND_CONNECT_TERMINAL, (terminal: vscode.Terminal) => {
+			provider.connectTerminal(terminal);
 		})
 	);
 }


### PR DESCRIPTION
## Summary

- Add **"Connect to Pixel Agents"** terminal tab context menu for manually connecting a terminal running Claude to a pixel character
- Improve auto-adoption: when only 1 unowned terminal exists, adopt it automatically (no focus required)
- Extract `AgentState` factory (`agentFactory.ts`) to eliminate 4-site initialization duplication
- Fix passive wheel event listener warning in `OfficeCanvas`

## Problem

Previously, only terminals created via the "+ Agent" button were tracked. Users running `claude` directly in a terminal got no character. The auto-detection logic only tried the *focused* terminal, which was timing-dependent and failed entirely with multiple terminals.

## Solution

**Manual connect (primary path):** Terminal tab right-click → "Connect to Pixel Agents" → resolves project dir → finds best untracked JSONL by mtime → creates character. Works reliably with any number of terminals.

**1:1 auto-adopt (convenience):** When a new JSONL file appears and exactly 1 unowned terminal exists, auto-adopt without requiring focus.

<img width="489" height="312" alt="image" src="https://github.com/user-attachments/assets/270ed789-6a3c-4033-89ff-ea97cfb03497" />

## Changes

| File | Change |
|------|--------|
| `src/constants.ts` | `COMMAND_CONNECT_TERMINAL` constant |
| `package.json` | Command declaration + `terminal/title/context` menu |
| `src/extension.ts` | Command handler registration |
| `src/PixelAgentsViewProvider.ts` | `connectTerminal()`, `resolveProjectDir()`, `findBestJsonlFile()` |
| `src/fileWatcher.ts` | 1:1 auto-adopt logic + exported `adoptTerminalForFile` with guard |
| `src/agentFactory.ts` | New: `createAgentState()` factory |
| `src/agentManager.ts` | Uses factory, reduced duplication |
| `webview-ui/src/office/components/OfficeCanvas.tsx` | Wheel handler: passive → active event listener |
| `CLAUDE.md` | Architecture docs updated |

## Test plan

- [ ] Terminal right-click shows "Connect to Pixel Agents" menu
- [ ] Click menu on terminal running `claude` → character appears
- [ ] Click menu on already-connected terminal → info message
- [ ] Click menu on terminal without Claude session → warning message
- [ ] Single terminal + `claude` → auto character creation (no focus needed)
- [ ] Multiple terminals → no auto-adopt, use right-click menu
- [ ] "+ Agent" button → existing behavior unchanged
- [ ] Character click → terminal focuses
- [ ] Terminal close → character removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)