### PR TITLE
fix: support Agent tool for sub-agent visualization

### DIFF
--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -15,7 +15,7 @@ import {
 	TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
 } from './constants.js';
 
-export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
+export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
 
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
 	const base = (p: unknown) => typeof p === 'string' ? path.basename(p) : '';
@@ -31,6 +31,7 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
 		case 'Grep': return 'Searching code';
 		case 'WebFetch': return 'Fetching web content';
 		case 'WebSearch': return 'Searching the web';
+		case 'Agent':
 		case 'Task': {
 			const desc = typeof input.description === 'string' ? input.description : '';
 			return desc ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}` : 'Running subtask';
@@ -108,8 +109,8 @@ export function processTranscriptLine(
 						if (block.type === 'tool_result' && block.tool_use_id) {
 							console.log(`[Pixel Agents] Agent ${agentId} tool done: ${block.tool_use_id}`);
 							const completedToolId = block.tool_use_id;
-							// If the completed tool was a Task, clear its subagent tools
-							if (agent.activeToolNames.get(completedToolId) === 'Task') {
+							// If the completed tool was a Task or Agent, clear its subagent tools
+							if (agent.activeToolNames.get(completedToolId) === 'Task' || agent.activeToolNames.get(completedToolId) === 'Agent') {
 								agent.activeSubagentToolIds.delete(completedToolId);
 								agent.activeSubagentToolNames.delete(completedToolId);
 								webview?.postMessage({


### PR DESCRIPTION
The Agent tool (used by Claude Code's Task tool invocations) was not being visualized as a sub-agent character in the Pixel Agents office.

Three changes in transcriptParser.ts:

1. Add 'Agent' to PERMISSION_EXEMPT_TOOLS so it does not trigger the false permission-wait heuristic while the sub-agent is running.

2. Add `case 'Agent':` before `case 'Task':` in formatToolStatus so the status string starts with "Subtask: <description>". The webview checks for this prefix to call addSubagent() and spawn a new pixel character linked to the parent agent.

3. Include 'Agent' in the subagentClear guard so the spawned character is correctly despawned when the Agent tool completes.