### PR TITLE
fix: recognize 'Agent' tool name for sub-agent visualization

### DIFF
--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -15,7 +15,7 @@ import {
 	TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
 } from './constants.js';
 
-export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
+export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
 
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
 	const base = (p: unknown) => typeof p === 'string' ? path.basename(p) : '';
@@ -31,7 +31,8 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
 		case 'Grep': return 'Searching code';
 		case 'WebFetch': return 'Fetching web content';
 		case 'WebSearch': return 'Searching the web';
-		case 'Task': {
+		case 'Task':
+		case 'Agent': {
 			const desc = typeof input.description === 'string' ? input.description : '';
 			return desc ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}` : 'Running subtask';
 		}
@@ -108,8 +109,9 @@ export function processTranscriptLine(
 						if (block.type === 'tool_result' && block.tool_use_id) {
 							console.log(`[Pixel Agents] Agent ${agentId} tool done: ${block.tool_use_id}`);
 							const completedToolId = block.tool_use_id;
-							// If the completed tool was a Task, clear its subagent tools
-							if (agent.activeToolNames.get(completedToolId) === 'Task') {
+							// If the completed tool was a Task/Agent, clear its subagent tools
+							const completedToolName = agent.activeToolNames.get(completedToolId);
+							if (completedToolName === 'Task' || completedToolName === 'Agent') {
 								agent.activeSubagentToolIds.delete(completedToolId);
 								agent.activeSubagentToolNames.delete(completedToolId);
 								webview?.postMessage({
@@ -203,8 +205,9 @@ function processProgressRecord(
 		return;
 	}
 
-	// Verify parent is an active Task tool (agent_progress handling)
-	if (agent.activeToolNames.get(parentToolId) !== 'Task') return;
+	// Verify parent is an active Task/Agent tool (agent_progress handling)
+	const parentToolName = agent.activeToolNames.get(parentToolId);
+	if (parentToolName !== 'Task' && parentToolName !== 'Agent') return;
 
 	const msg = data.message as Record<string, unknown> | undefined;
 	if (!msg) return;


### PR DESCRIPTION
Claude Code renamed the sub-agent tool from 'Task' to 'Agent', breaking sub-agent character spawning. The transcript parser only recognized 'Task' in four places:

- PERMISSION_EXEMPT_TOOLS set
- formatToolStatus switch (generates 'Subtask:' status prefix)
- Tool completion handler (clears sub-agent tracking)
- Progress record handler (validates parent tool type)

Add 'Agent' alongside 'Task' in all four locations so sub-agent characters spawn correctly with current Claude Code versions.