### PR TITLE
feat: add Agent Teams support and token usage fuel gauges

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -12,6 +12,7 @@ import {
 	sendLayout,
 	getProjectDirPath,
 } from './agentManager.js';
+import { getTeammatesForLead } from './teamManager.js';
 import { ensureProjectScan } from './fileWatcher.js';
 import { loadFurnitureAssets, sendAssetsToWebview, loadFloorTiles, sendFloorTilesToWebview, loadWallTiles, sendWallTilesToWebview, loadCharacterSprites, sendCharacterSpritesToWebview, loadDefaultLayout } from './assetLoader.js';
 import { WORKSPACE_KEY_AGENT_SEATS, GLOBAL_KEY_SOUND_ENABLED } from './constants.js';
@@ -73,12 +74,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				);
 			} else if (message.type === 'focusAgent') {
 				const agent = this.agents.get(message.id);
-				if (agent) {
+				if (agent?.terminalRef) {
 					agent.terminalRef.show();
 				}
 			} else if (message.type === 'closeAgent') {
 				const agent = this.agents.get(message.id);
-				if (agent) {
+				if (agent?.terminalRef) {
 					agent.terminalRef.dispose();
 				}
 			} else if (message.type === 'saveAgentSeats') {
@@ -284,6 +285,17 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 					if (this.activeAgentId.current === id) {
 						this.activeAgentId.current = null;
 					}
+					// Clean up all teammates of this lead first
+					const teammateIds = getTeammatesForLead(id, this.agents);
+					for (const tmId of teammateIds) {
+						removeAgent(
+							tmId, this.agents,
+							this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
+							this.jsonlPollTimers, this.persistAgents,
+						);
+						webviewView.webview.postMessage({ type: 'teammateRemoved', id: tmId });
+					}
+					// Then remove the lead
 					removeAgent(
 						id, this.agents,
 						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -52,11 +52,9 @@ export async function launchNewTerminal(
 		return;
 	}
 
-	// Pre-register expected JSONL file so project scan won't treat it as a /clear file
 	const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);
 	knownJsonlFiles.add(expectedFile);
 
-	// Create agent immediately (before JSONL file exists)
 	const id = nextAgentIdRef.current++;
 	const folderName = isMultiRoot && cwd ? path.basename(cwd) : undefined;
 	const agent: AgentState = {
@@ -74,6 +72,8 @@ export async function launchNewTerminal(
 		isWaiting: false,
 		permissionSent: false,
 		hadToolsInTurn: false,
+		inputTokens: 0,
+		outputTokens: 0,
 		folderName,
 	};
 
@@ -89,7 +89,6 @@ export async function launchNewTerminal(
 		webview, persistAgents,
 	);
 
-	// Poll for the specific JSONL file to appear
 	const pollTimer = setInterval(() => {
 		try {
 			if (fs.existsSync(agent.jsonlFile)) {
@@ -117,12 +116,10 @@ export function removeAgent(
 	const agent = agents.get(agentId);
 	if (!agent) return;
 
-	// Stop JSONL poll timer
 	const jpTimer = jsonlPollTimers.get(agentId);
 	if (jpTimer) { clearInterval(jpTimer); }
 	jsonlPollTimers.delete(agentId);
 
-	// Stop file watching
 	fileWatchers.get(agentId)?.close();
 	fileWatchers.delete(agentId);
 	const pt = pollingTimers.get(agentId);
@@ -130,11 +127,9 @@ export function removeAgent(
 	pollingTimers.delete(agentId);
 	try { fs.unwatchFile(agent.jsonlFile); } catch { /* ignore */ }
 
-	// Cancel timers
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 
-	// Remove from maps
 	agents.delete(agentId);
 	persistAgents();
 }
@@ -147,10 +142,15 @@ export function persistAgents(
 	for (const agent of agents.values()) {
 		persisted.push({
 			id: agent.id,
-			terminalName: agent.terminalRef.name,
+			terminalName: agent.terminalRef?.name ?? '',
 			jsonlFile: agent.jsonlFile,
 			projectDir: agent.projectDir,
 			folderName: agent.folderName,
+			isTeamLead: agent.isTeamLead,
+			teamName: agent.teamName,
+			isTeammate: agent.isTeammate,
+			teamRole: agent.teamRole,
+			leadAgentId: agent.leadAgentId,
 		});
 	}
 	context.workspaceState.update(WORKSPACE_KEY_AGENTS, persisted);
@@ -181,7 +181,51 @@ export function restoreAgents(
 	let restoredProjectDir: string | null = null;
 
 	for (const p of persisted) {
-		const terminal = liveTerminals.find(t => t.name === p.terminalName);
+		let terminal: vscode.Terminal | undefined;
+
+		if (p.isTeammate) {
+			// Teammates have no terminal — restore directly without terminal matching
+			const agent: AgentState = {
+				id: p.id,
+				terminalRef: undefined,
+				projectDir: p.projectDir,
+				jsonlFile: p.jsonlFile,
+				fileOffset: 0,
+				lineBuffer: '',
+				activeToolIds: new Set(),
+				activeToolStatuses: new Map(),
+				activeToolNames: new Map(),
+				activeSubagentToolIds: new Map(),
+				activeSubagentToolNames: new Map(),
+				isWaiting: false,
+				permissionSent: false,
+				hadToolsInTurn: false,
+				inputTokens: 0,
+				outputTokens: 0,
+				isTeammate: true,
+				teamRole: p.teamRole,
+				leadAgentId: p.leadAgentId,
+				folderName: p.folderName,
+			};
+			agents.set(p.id, agent);
+			knownJsonlFiles.add(p.jsonlFile);
+			console.log(`[Pixel Agents] Restored teammate ${p.id} (${p.teamRole ?? '?'}, lead: ${p.leadAgentId ?? '?'})`);
+
+			if (p.id > maxId) maxId = p.id;
+			restoredProjectDir = p.projectDir;
+
+			try {
+				if (fs.existsSync(p.jsonlFile)) {
+					const stat = fs.statSync(p.jsonlFile);
+					agent.fileOffset = stat.size;
+					startFileWatching(p.id, p.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
+				}
+			} catch { /* ignore */ }
+			continue;
+		}
+
+		// Regular agent — find matching terminal by name
+		terminal = liveTerminals.find(t => t.name === p.terminalName);
 		if (!terminal) continue;
 
 		const agent: AgentState = {
@@ -199,7 +243,11 @@ export function restoreAgents(
 			isWaiting: false,
 			permissionSent: false,
 			hadToolsInTurn: false,
+			inputTokens: 0,
+			outputTokens: 0,
 			folderName: p.folderName,
+			isTeamLead: p.isTeamLead,
+			teamName: p.teamName,
 		};
 
 		agents.set(p.id, agent);
@@ -207,7 +255,6 @@ export function restoreAgents(
 		console.log(`[Pixel Agents] Restored agent ${p.id} → terminal "${p.terminalName}"`);
 
 		if (p.id > maxId) maxId = p.id;
-		// Extract terminal index from name like "Claude Code #3"
 		const match = p.terminalName.match(/#(\d+)$/);
 		if (match) {
 			const idx = parseInt(match[1], 10);
@@ -216,14 +263,12 @@ export function restoreAgents(
 
 		restoredProjectDir = p.projectDir;
 
-		// Start file watching if JSONL exists, skipping to end of file
 		try {
 			if (fs.existsSync(p.jsonlFile)) {
 				const stat = fs.statSync(p.jsonlFile);
 				agent.fileOffset = stat.size;
 				startFileWatching(p.id, p.jsonlFile, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
 			} else {
-				// Poll for the file to appear
 				const pollTimer = setInterval(() => {
 					try {
 						if (fs.existsSync(agent.jsonlFile)) {
@@ -241,7 +286,6 @@ export function restoreAgents(
 		} catch { /* ignore errors during restore */ }
 	}
 
-	// Advance counters past restored IDs
 	if (maxId >= nextAgentIdRef.current) {
 		nextAgentIdRef.current = maxId + 1;
 	}
@@ -249,10 +293,8 @@ export function restoreAgents(
 		nextTerminalIndexRef.current = maxIdx + 1;
 	}
 
-	// Re-persist cleaned-up list (removes entries whose terminals are gone)
 	doPersist();
 
-	// Start project scan for /clear detection
 	if (restoredProjectDir) {
 		ensureProjectScan(
 			restoredProjectDir, knownJsonlFiles, projectScanTimerRef, activeAgentIdRef,
@@ -274,10 +316,27 @@ export function sendExistingAgents(
 	}
 	agentIds.sort((a, b) => a - b);
 
-	// Include persisted palette/seatId from separate key
-	const agentMeta = context.workspaceState.get<Record<string, { palette?: number; seatId?: string }>>(WORKSPACE_KEY_AGENT_SEATS, {});
+	// Base seat/palette data
+	const agentSeatMeta = context.workspaceState.get<Record<string, { palette?: number; hueShift?: number; seatId?: string }>>(WORKSPACE_KEY_AGENT_SEATS, {});
 
-	// Include folderName per agent
+	// Build enhanced metadata including team fields
+	const agentMeta: Record<number, {
+		palette?: number; hueShift?: number; seatId?: string;
+		isTeamLead?: boolean; teamName?: string;
+		isTeammate?: boolean; teamRole?: string; leadAgentId?: number;
+	}> = {};
+	for (const [id, agent] of agents) {
+		const seats = agentSeatMeta[id] ?? {};
+		agentMeta[id] = {
+			...seats,
+			isTeamLead: agent.isTeamLead,
+			teamName: agent.teamName,
+			isTeammate: agent.isTeammate,
+			teamRole: agent.teamRole,
+			leadAgentId: agent.leadAgentId,
+		};
+	}
+
 	const folderNames: Record<number, string> = {};
 	for (const [id, agent] of agents) {
 		if (agent.folderName) {
@@ -302,7 +361,6 @@ export function sendCurrentAgentStatuses(
 ): void {
 	if (!webview) return;
 	for (const [agentId, agent] of agents) {
-		// Re-send active tools
 		for (const [toolId, status] of agent.activeToolStatuses) {
 			webview.postMessage({
 				type: 'agentToolStart',
@@ -311,13 +369,26 @@ export function sendCurrentAgentStatuses(
 				status,
 			});
 		}
-		// Re-send waiting status
 		if (agent.isWaiting) {
 			webview.postMessage({
 				type: 'agentStatus',
 				id: agentId,
 				status: 'waiting',
 			});
+		}
+		// Re-send token usage on reconnect
+		if (agent.inputTokens > 0 || agent.outputTokens > 0) {
+			webview.postMessage({
+				type: 'agentTokenUsage',
+				id: agentId,
+				inputTokens: agent.inputTokens,
+				outputTokens: agent.outputTokens,
+				cacheReadTokens: 0,
+			});
+		}
+		// Re-send team lead status
+		if (agent.isTeamLead) {
+			webview.postMessage({ type: 'agentIsLead', id: agentId, teamName: agent.teamName });
 		}
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,3 +40,11 @@ export const WORKSPACE_KEY_AGENTS = 'pixel-agents.agents';
 export const WORKSPACE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
 export const WORKSPACE_KEY_LAYOUT = 'pixel-agents.layout';
 export const TERMINAL_NAME_PREFIX = 'Claude Code';
+
+// ── Agent Teams ───────────────────────────────────────────────
+export const AGENT_TOOL_NAME = 'Agent';
+export const TEAM_CREATE_TOOL_NAME = 'TeamCreate';
+export const TEAM_DELETE_TOOL_NAME = 'TeamDelete';
+export const SEND_MESSAGE_TOOL_NAME = 'SendMessage';
+/** How long (ms) to wait for a new JSONL file to appear after an Agent tool call */
+export const TEAMMATE_MATCH_WINDOW_MS = 30_000;

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -5,6 +5,7 @@ import type { AgentState } from './types.js';
 import { cancelWaitingTimer, cancelPermissionTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
 import { FILE_WATCHER_POLL_INTERVAL_MS, PROJECT_SCAN_INTERVAL_MS } from './constants.js';
+import { tryClaimJsonlForTeammate, clearExpiredPending } from './teamManager.js';
 
 export function startFileWatching(
 	agentId: number,
@@ -103,6 +104,7 @@ export function ensureProjectScan(
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
+	persistTeammates?: () => void,
 ): void {
 	if (projectScanTimerRef.current) return;
 	// Seed with all existing JSONL files so we only react to truly new ones
@@ -116,10 +118,11 @@ export function ensureProjectScan(
 	} catch { /* dir may not exist yet */ }
 
 	projectScanTimerRef.current = setInterval(() => {
+		clearExpiredPending();
 		scanForNewJsonlFiles(
 			projectDir, knownJsonlFiles, activeAgentIdRef, nextAgentIdRef,
 			agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-			webview, persistAgents,
+			webview, persistAgents, persistTeammates,
 		);
 	}, PROJECT_SCAN_INTERVAL_MS);
 }
@@ -136,6 +139,7 @@ function scanForNewJsonlFiles(
 	permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
 	webview: vscode.Webview | undefined,
 	persistAgents: () => void,
+	persistTeammates?: () => void,
 ): void {
 	let files: string[];
 	try {
@@ -145,35 +149,48 @@ function scanForNewJsonlFiles(
 	} catch { return; }
 
 	for (const file of files) {
-		if (!knownJsonlFiles.has(file)) {
-			knownJsonlFiles.add(file);
-			if (activeAgentIdRef.current !== null) {
-				// Active agent focused → /clear reassignment
-				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
-				reassignAgentToFile(
-					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-					webview, persistAgents,
-				);
-			} else {
-				// No active agent → try to adopt the focused terminal
-				const activeTerminal = vscode.window.activeTerminal;
-				if (activeTerminal) {
-					let owned = false;
-					for (const agent of agents.values()) {
-						if (agent.terminalRef === activeTerminal) {
-							owned = true;
-							break;
-						}
+		if (knownJsonlFiles.has(file)) continue;
+		knownJsonlFiles.add(file);
+
+		// ── Agent Teams: check if this JSONL belongs to a pending teammate ──
+		const teammateId = tryClaimJsonlForTeammate(
+			file, agents, nextAgentIdRef, webview,
+			persistTeammates ?? persistAgents,
+		);
+		if (teammateId !== null) {
+			// Start file watching for the new teammate (same pattern as regular agents)
+			startFileWatching(teammateId, file, agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers, webview);
+			readNewLines(teammateId, agents, waitingTimers, permissionTimers, webview);
+			continue;
+		}
+		// ────────────────────────────────────────────────────────────────────
+
+		if (activeAgentIdRef.current !== null) {
+			// Active agent focused → /clear reassignment
+			console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
+			reassignAgentToFile(
+				activeAgentIdRef.current, file,
+				agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+				webview, persistAgents,
+			);
+		} else {
+			// No active agent → try to adopt the focused terminal
+			const activeTerminal = vscode.window.activeTerminal;
+			if (activeTerminal) {
+				let owned = false;
+				for (const agent of agents.values()) {
+					if (agent.terminalRef === activeTerminal) {
+						owned = true;
+						break;
 					}
-					if (!owned) {
-						adoptTerminalForFile(
-							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
-							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
-							webview, persistAgents,
-						);
-					}
+				}
+				if (!owned) {
+					adoptTerminalForFile(
+						activeTerminal, file, projectDir,
+						nextAgentIdRef, agents, activeAgentIdRef,
+						fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+						webview, persistAgents,
+					);
 				}
 			}
 		}
@@ -210,6 +227,8 @@ function adoptTerminalForFile(
 		isWaiting: false,
 		permissionSent: false,
 		hadToolsInTurn: false,
+		inputTokens: 0,
+		outputTokens: 0,
 	};
 
 	agents.set(id, agent);

--- a/src/teamManager.ts
+++ b/src/teamManager.ts
@@ -1,0 +1,198 @@
+import * as path from 'path';
+import type * as vscode from 'vscode';
+import type { AgentState } from './types.js';
+import { TEAMMATE_MATCH_WINDOW_MS } from './constants.js';
+
+interface PendingTeammate {
+	name: string;
+	subagentType: string;
+	timestamp: number;
+}
+
+/** leadAgentId → Map<toolId, pending teammate info> */
+const pendingTeammates = new Map<number, Map<string, PendingTeammate>>();
+
+/**
+ * Called when a lead agent's JSONL shows an Agent tool_use.
+ * Registers a pending teammate that will be claimed when its JSONL appears.
+ */
+export function registerPendingTeammate(
+	leadAgentId: number,
+	toolId: string,
+	name: string,
+	subagentType: string,
+	agents: Map<number, AgentState>,
+	webview: vscode.Webview | undefined,
+): void {
+	// Mark this agent as a team lead if not already
+	const lead = agents.get(leadAgentId);
+	if (lead && !lead.isTeamLead) {
+		lead.isTeamLead = true;
+		webview?.postMessage({ type: 'agentIsLead', id: leadAgentId, teamName: lead.teamName });
+		console.log(`[Pixel Agents] Agent ${leadAgentId} marked as team lead`);
+	}
+
+	let leadPending = pendingTeammates.get(leadAgentId);
+	if (!leadPending) {
+		leadPending = new Map();
+		pendingTeammates.set(leadAgentId, leadPending);
+	}
+	leadPending.set(toolId, { name, subagentType, timestamp: Date.now() });
+	console.log(`[Pixel Agents] Pending teammate: "${name}" (toolId: ${toolId}) for lead ${leadAgentId}`);
+}
+
+/**
+ * Called when a new JSONL file is detected. Checks if any lead has a pending
+ * teammate registration within the match window. Returns the new agent ID if
+ * claimed, or null if this file should be handled by existing /clear logic.
+ */
+export function tryClaimJsonlForTeammate(
+	newJsonlFile: string,
+	agents: Map<number, AgentState>,
+	nextAgentIdRef: { current: number },
+	webview: vscode.Webview | undefined,
+	persistAgentsFn: () => void,
+): number | null {
+	const now = Date.now();
+
+	for (const [leadAgentId, pending] of pendingTeammates) {
+		if (!agents.has(leadAgentId)) {
+			// Lead is gone — purge its pending entries
+			pendingTeammates.delete(leadAgentId);
+			continue;
+		}
+
+		// Find the oldest pending entry within the match window (FIFO matching)
+		let oldestToolId: string | null = null;
+		let oldestTimestamp = Infinity;
+		for (const [toolId, info] of pending) {
+			if (now - info.timestamp <= TEAMMATE_MATCH_WINDOW_MS && info.timestamp < oldestTimestamp) {
+				oldestTimestamp = info.timestamp;
+				oldestToolId = toolId;
+			}
+		}
+
+		if (!oldestToolId) continue;
+
+		const pendingInfo = pending.get(oldestToolId)!;
+		pending.delete(oldestToolId);
+		if (pending.size === 0) {
+			pendingTeammates.delete(leadAgentId);
+		}
+
+		const leadAgent = agents.get(leadAgentId)!;
+
+		// Create a new AgentState for this teammate (no terminal — auto-spawned)
+		const id = nextAgentIdRef.current++;
+		const agent: AgentState = {
+			id,
+			terminalRef: undefined, // teammates have no visible VS Code terminal
+			projectDir: leadAgent.projectDir,
+			jsonlFile: newJsonlFile,
+			fileOffset: 0,
+			lineBuffer: '',
+			activeToolIds: new Set(),
+			activeToolStatuses: new Map(),
+			activeToolNames: new Map(),
+			activeSubagentToolIds: new Map(),
+			activeSubagentToolNames: new Map(),
+			isWaiting: false,
+			permissionSent: false,
+			hadToolsInTurn: false,
+			inputTokens: 0,
+			outputTokens: 0,
+			isTeammate: true,
+			teamRole: pendingInfo.name,
+			leadAgentId,
+		};
+
+		agents.set(id, agent);
+
+		// Register in lead's teammate map
+		if (!leadAgent.teammateAgentIds) {
+			leadAgent.teammateAgentIds = new Map();
+		}
+		leadAgent.teammateAgentIds.set(oldestToolId, id);
+
+		persistAgentsFn();
+
+		console.log(`[Pixel Agents] Teammate ${id} ("${pendingInfo.name}") claimed JSONL: ${path.basename(newJsonlFile)}`);
+
+		webview?.postMessage({
+			type: 'teammateCreated',
+			id,
+			leadId: leadAgentId,
+			role: pendingInfo.name,
+		});
+
+		return id;
+	}
+
+	return null;
+}
+
+/**
+ * Called when a TeamCreate tool_use is detected. Marks the agent as a lead
+ * with the given team name.
+ */
+export function markAgentAsLead(
+	agentId: number,
+	teamName: string | undefined,
+	agents: Map<number, AgentState>,
+	webview: vscode.Webview | undefined,
+): void {
+	const agent = agents.get(agentId);
+	if (!agent) return;
+	agent.isTeamLead = true;
+	if (teamName) {
+		agent.teamName = teamName;
+	}
+	console.log(`[Pixel Agents] Agent ${agentId} marked as team lead (team: ${teamName ?? 'unnamed'})`);
+	webview?.postMessage({ type: 'agentIsLead', id: agentId, teamName });
+}
+
+/**
+ * Called when a lead agent's terminal closes. Returns the IDs of all teammate
+ * agents that should be removed. Callers are responsible for stopping their
+ * file watchers and sending agentClosed / removing from the agents map.
+ */
+export function getTeammatesForLead(
+	leadAgentId: number,
+	agents: Map<number, AgentState>,
+): number[] {
+	const toRemove: number[] = [];
+	for (const [id, agent] of agents) {
+		if (agent.isTeammate && agent.leadAgentId === leadAgentId) {
+			toRemove.push(id);
+		}
+	}
+	// Also clear any pending registrations for this lead
+	pendingTeammates.delete(leadAgentId);
+	return toRemove;
+}
+
+/**
+ * Called when a SendMessage tool_use is detected. Shows a brief speech bubble
+ * on the sending character.
+ */
+export function handleSendMessage(
+	agentId: number,
+	webview: vscode.Webview | undefined,
+): void {
+	webview?.postMessage({ type: 'agentSendMessage', id: agentId });
+}
+
+/** Purge expired pending entries (called periodically, e.g. on project scan) */
+export function clearExpiredPending(): void {
+	const now = Date.now();
+	for (const [leadId, pending] of pendingTeammates) {
+		for (const [toolId, info] of pending) {
+			if (now - info.timestamp > TEAMMATE_MATCH_WINDOW_MS) {
+				pending.delete(toolId);
+			}
+		}
+		if (pending.size === 0) {
+			pendingTeammates.delete(leadId);
+		}
+	}
+}

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -13,9 +13,32 @@ import {
 	TEXT_IDLE_DELAY_MS,
 	BASH_COMMAND_DISPLAY_MAX_LENGTH,
 	TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+	AGENT_TOOL_NAME,
+	TEAM_CREATE_TOOL_NAME,
+	TEAM_DELETE_TOOL_NAME,
+	SEND_MESSAGE_TOOL_NAME,
 } from './constants.js';
+import {
+	registerPendingTeammate,
+	markAgentAsLead,
+	handleSendMessage,
+} from './teamManager.js';
 
-export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
+export const PERMISSION_EXEMPT_TOOLS = new Set([
+	'Task',
+	'AskUserQuestion',
+	AGENT_TOOL_NAME,
+	TEAM_CREATE_TOOL_NAME,
+	TEAM_DELETE_TOOL_NAME,
+	SEND_MESSAGE_TOOL_NAME,
+	'TaskCreate',
+	'TaskUpdate',
+	'TaskList',
+	'TaskGet',
+	'ExitPlanMode',
+	'EnterPlanMode',
+	'TeamDelete',
+]);
 
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
 	const base = (p: unknown) => typeof p === 'string' ? path.basename(p) : '';
@@ -37,7 +60,28 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
 		}
 		case 'AskUserQuestion': return 'Waiting for your answer';
 		case 'EnterPlanMode': return 'Planning';
-		case 'NotebookEdit': return `Editing notebook`;
+		case 'NotebookEdit': return 'Editing notebook';
+		case AGENT_TOOL_NAME: {
+			const name = typeof input.name === 'string' ? input.name : (input.subagent_type as string) || 'agent';
+			return `Spawning: ${name}`;
+		}
+		case TEAM_CREATE_TOOL_NAME: {
+			const teamName = typeof input.team_name === 'string' ? input.team_name : 'team';
+			return `Creating team: ${teamName}`;
+		}
+		case TEAM_DELETE_TOOL_NAME: return 'Closing team';
+		case SEND_MESSAGE_TOOL_NAME: {
+			const recipient = typeof input.recipient === 'string' ? input.recipient : '';
+			const summary = typeof input.summary === 'string' ? input.summary : '';
+			return recipient ? `→ ${recipient}${summary ? ': ' + summary : ''}` : 'Sending message';
+		}
+		case 'TaskCreate': {
+			const subject = typeof input.subject === 'string' ? input.subject : '';
+			return subject ? `Task: ${subject.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? subject.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : subject}` : 'Creating task';
+		}
+		case 'TaskUpdate': return 'Updating task';
+		case 'TaskList': return 'Checking tasks';
+		case 'TaskGet': return 'Reading task';
 		default: return `Using ${toolName}`;
 	}
 }
@@ -56,6 +100,25 @@ export function processTranscriptLine(
 		const record = JSON.parse(line);
 
 		if (record.type === 'assistant' && Array.isArray(record.message?.content)) {
+			// Extract token usage from this assistant turn
+			const usage = record.message?.usage as Record<string, number> | undefined;
+			if (usage) {
+				const inputTokens = (usage.input_tokens ?? 0);
+				const outputTokens = (usage.output_tokens ?? 0);
+				const cacheReadTokens = (usage.cache_read_input_tokens ?? 0);
+				if (inputTokens > 0 || outputTokens > 0) {
+					agent.inputTokens = inputTokens;
+					agent.outputTokens = outputTokens;
+					webview?.postMessage({
+						type: 'agentTokenUsage',
+						id: agentId,
+						inputTokens,
+						outputTokens,
+						cacheReadTokens,
+					});
+				}
+			}
+
 			const blocks = record.message.content as Array<{
 				type: string; id?: string; name?: string; input?: Record<string, unknown>;
 			}>;
@@ -75,6 +138,20 @@ export function processTranscriptLine(
 						agent.activeToolIds.add(block.id);
 						agent.activeToolStatuses.set(block.id, status);
 						agent.activeToolNames.set(block.id, toolName);
+
+						// ── Team tool detection ────────────────────────────────────
+						if (toolName === AGENT_TOOL_NAME && block.input) {
+							const name = typeof block.input.name === 'string' ? block.input.name : (block.input.subagent_type as string) || 'agent';
+							const subagentType = typeof block.input.subagent_type === 'string' ? block.input.subagent_type : '';
+							registerPendingTeammate(agentId, block.id, name, subagentType, agents, webview);
+						} else if (toolName === TEAM_CREATE_TOOL_NAME && block.input) {
+							const teamName = typeof block.input.team_name === 'string' ? block.input.team_name : undefined;
+							markAgentAsLead(agentId, teamName, agents, webview);
+						} else if (toolName === SEND_MESSAGE_TOOL_NAME) {
+							handleSendMessage(agentId, webview);
+						}
+						// ──────────────────────────────────────────────────────────
+
 						if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
 							hasNonExemptTool = true;
 						}
@@ -90,10 +167,7 @@ export function processTranscriptLine(
 					startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
 				}
 			} else if (blocks.some(b => b.type === 'text') && !agent.hadToolsInTurn) {
-				// Text-only response in a turn that hasn't used any tools.
-				// turn_duration handles tool-using turns reliably but is never
-				// emitted for text-only turns, so we use a silence-based timer:
-				// if no new JSONL data arrives within TEXT_IDLE_DELAY_MS, mark as waiting.
+				// Text-only response — use silence-based idle timer
 				startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, webview);
 			}
 		} else if (record.type === 'progress') {
@@ -131,8 +205,6 @@ export function processTranscriptLine(
 							}, TOOL_DONE_DELAY_MS);
 						}
 					}
-					// All tools completed — allow text-idle timer as fallback
-					// for turn-end detection when turn_duration is not emitted
 					if (agent.activeToolIds.size === 0) {
 						agent.hadToolsInTurn = false;
 					}
@@ -193,8 +265,6 @@ function processProgressRecord(
 	const data = record.data as Record<string, unknown> | undefined;
 	if (!data) return;
 
-	// bash_progress / mcp_progress: tool is actively executing, not stuck on permission.
-	// Restart the permission timer to give the running tool another window.
 	const dataType = data.type as string | undefined;
 	if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
 		if (agent.activeToolIds.has(parentToolId)) {
@@ -203,7 +273,6 @@ function processProgressRecord(
 		return;
 	}
 
-	// Verify parent is an active Task tool (agent_progress handling)
 	if (agent.activeToolNames.get(parentToolId) !== 'Task') return;
 
 	const msg = data.message as Record<string, unknown> | undefined;
@@ -222,7 +291,6 @@ function processProgressRecord(
 				const status = formatToolStatus(toolName, block.input || {});
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool start: ${block.id} ${status} (parent: ${parentToolId})`);
 
-				// Track sub-tool IDs
 				let subTools = agent.activeSubagentToolIds.get(parentToolId);
 				if (!subTools) {
 					subTools = new Set();
@@ -230,7 +298,6 @@ function processProgressRecord(
 				}
 				subTools.add(block.id);
 
-				// Track sub-tool names (for permission checking)
 				let subNames = agent.activeSubagentToolNames.get(parentToolId);
 				if (!subNames) {
 					subNames = new Map();
@@ -259,15 +326,10 @@ function processProgressRecord(
 			if (block.type === 'tool_result' && block.tool_use_id) {
 				console.log(`[Pixel Agents] Agent ${agentId} subagent tool done: ${block.tool_use_id} (parent: ${parentToolId})`);
 
-				// Remove from tracking
 				const subTools = agent.activeSubagentToolIds.get(parentToolId);
-				if (subTools) {
-					subTools.delete(block.tool_use_id);
-				}
+				if (subTools) subTools.delete(block.tool_use_id);
 				const subNames = agent.activeSubagentToolNames.get(parentToolId);
-				if (subNames) {
-					subNames.delete(block.tool_use_id);
-				}
+				if (subNames) subNames.delete(block.tool_use_id);
 
 				const toolId = block.tool_use_id;
 				setTimeout(() => {
@@ -280,8 +342,6 @@ function processProgressRecord(
 				}, 300);
 			}
 		}
-		// If there are still active non-exempt sub-agent tools, restart the permission timer
-		// (handles the case where one sub-agent completes but another is still stuck)
 		let stillHasNonExempt = false;
 		for (const [, subNames] of agent.activeSubagentToolNames) {
 			for (const [, toolName] of subNames) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@ import type * as vscode from 'vscode';
 
 export interface AgentState {
 	id: number;
-	terminalRef: vscode.Terminal;
+	/** VS Code terminal reference — undefined for auto-spawned teammates (no visible terminal) */
+	terminalRef?: vscode.Terminal;
 	projectDir: string;
 	jsonlFile: string;
 	fileOffset: number;
@@ -17,6 +18,28 @@ export interface AgentState {
 	hadToolsInTurn: boolean;
 	/** Workspace folder name (only set for multi-root workspaces) */
 	folderName?: string;
+
+	// ── Token tracking ────────────────────────────────────────
+	/** Most recent assistant turn's input_tokens (reflects accumulated context) */
+	inputTokens: number;
+	/** Most recent assistant turn's output_tokens */
+	outputTokens: number;
+
+	// ── Agent Teams ───────────────────────────────────────────
+	/** True when this agent has used TeamCreate or Agent tool to spawn teammates */
+	isTeamLead?: boolean;
+	/** Team name from TeamCreate input, if known */
+	teamName?: string;
+	/** True when this agent was auto-spawned as a teammate by a lead agent */
+	isTeammate?: boolean;
+	/** Role/name extracted from the Agent tool call that spawned this agent */
+	teamRole?: string;
+	/** Agent ID of the lead that spawned this teammate */
+	leadAgentId?: number;
+	/** Pending teammate registrations: toolId → { name, subagentType, timestamp } */
+	pendingTeammateTools?: Map<string, { name: string; subagentType: string; timestamp: number }>;
+	/** Spawned teammate agent IDs: toolId → agentId */
+	teammateAgentIds?: Map<string, number>;
 }
 
 export interface PersistedAgent {
@@ -26,4 +49,11 @@ export interface PersistedAgent {
 	projectDir: string;
 	/** Workspace folder name (only set for multi-root workspaces) */
 	folderName?: string;
+
+	// ── Agent Teams ───────────────────────────────────────────
+	isTeamLead?: boolean;
+	teamName?: string;
+	isTeammate?: boolean;
+	teamRole?: string;
+	leadAgentId?: number;
 }

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -111,3 +111,18 @@ export const CHARACTER_HIT_HALF_WIDTH = 8
 export const CHARACTER_HIT_HEIGHT = 24
 export const TOOL_OVERLAY_VERTICAL_OFFSET = 32
 export const PULSE_ANIMATION_DURATION_SEC = 1.5
+
+// ── Agent Teams ───────────────────────────────────────────────
+/** Duration (s) for the SendMessage speech bubble */
+export const SEND_MESSAGE_BUBBLE_DURATION_SEC = 2.0
+/** Label font size in sprite-pixels (scaled by zoom at render time) */
+export const TEAM_LABEL_FONT_SIZE_SP = 4
+/** Fuel gauge dimensions in sprite-pixels */
+export const FUEL_GAUGE_WIDTH_SP = 16
+export const FUEL_GAUGE_HEIGHT_SP = 2
+/** Context window token limit (all current Claude models) */
+export const MAX_CONTEXT_TOKENS = 200_000
+/** Fuel gauge fill color thresholds (fractions of MAX_CONTEXT_TOKENS) */
+export const TOKEN_WARN_THRESHOLD = 0.6
+export const TOKEN_DANGER_THRESHOLD = 0.8
+export const TOKEN_CRITICAL_THRESHOLD = 0.95

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -81,7 +81,7 @@ export function useExtensionMessages(
 
   useEffect(() => {
     // Buffer agents from existingAgents until layout is loaded
-    let pendingAgents: Array<{ id: number; palette?: number; hueShift?: number; seatId?: string; folderName?: string }> = []
+    let pendingAgents: Array<{ id: number; palette?: number; hueShift?: number; seatId?: string; folderName?: string; teamFields?: { isTeamLead?: boolean; teamName?: string; isTeammate?: boolean; teamRole?: string; leadAgentId?: number } }> = []
 
     const handler = (e: MessageEvent) => {
       const msg = e.data
@@ -104,7 +104,7 @@ export function useExtensionMessages(
         }
         // Add buffered agents now that layout (and seats) are correct
         for (const p of pendingAgents) {
-          os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName)
+          os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName, p.teamFields)
         }
         pendingAgents = []
         layoutReadyRef.current = true
@@ -145,14 +145,50 @@ export function useExtensionMessages(
         os.removeAllSubagents(id)
         setSubagentCharacters((prev) => prev.filter((s) => s.parentAgentId !== id))
         os.removeAgent(id)
+      } else if (msg.type === 'agentIsLead') {
+        const id = msg.id as number
+        const teamName = msg.teamName as string | undefined
+        os.markAsLead(id, teamName)
+      } else if (msg.type === 'teammateCreated') {
+        const id = msg.id as number
+        const leadId = msg.leadId as number
+        const role = msg.role as string | undefined
+        const folderName = msg.folderName as string | undefined
+        setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]))
+        if (layoutReadyRef.current) {
+          os.addAgent(id, undefined, undefined, undefined, false, folderName, { isTeammate: true, teamRole: role, leadAgentId: leadId })
+          saveAgentSeats(os)
+        } else {
+          pendingAgents.push({ id, folderName, teamFields: { isTeammate: true, teamRole: role, leadAgentId: leadId } })
+        }
+      } else if (msg.type === 'teammateRemoved') {
+        const id = msg.id as number
+        setAgents((prev) => prev.filter((a) => a !== id))
+        setSelectedAgent((prev) => (prev === id ? null : prev))
+        os.removeAgent(id)
+      } else if (msg.type === 'agentSendMessage') {
+        const id = msg.id as number
+        os.showSendMessageBubble(id)
+      } else if (msg.type === 'agentTokenUsage') {
+        const id = msg.id as number
+        const inputTokens = msg.inputTokens as number
+        const outputTokens = msg.outputTokens as number
+        os.setAgentTokens(id, inputTokens, outputTokens)
       } else if (msg.type === 'existingAgents') {
         const incoming = msg.agents as number[]
-        const meta = (msg.agentMeta || {}) as Record<number, { palette?: number; hueShift?: number; seatId?: string }>
+        const meta = (msg.agentMeta || {}) as Record<number, { palette?: number; hueShift?: number; seatId?: string; isTeamLead?: boolean; teamName?: string; isTeammate?: boolean; teamRole?: string; leadAgentId?: number }>
         const folderNames = (msg.folderNames || {}) as Record<number, string>
         // Buffer agents — they'll be added in layoutLoaded after seats are built
         for (const id of incoming) {
           const m = meta[id]
-          pendingAgents.push({ id, palette: m?.palette, hueShift: m?.hueShift, seatId: m?.seatId, folderName: folderNames[id] })
+          const teamFields = (m?.isTeamLead || m?.isTeammate) ? {
+            isTeamLead: m.isTeamLead,
+            teamName: m.teamName,
+            isTeammate: m.isTeammate,
+            teamRole: m.teamRole,
+            leadAgentId: m.leadAgentId,
+          } : undefined
+          pendingAgents.push({ id, palette: m?.palette, hueShift: m?.hueShift, seatId: m?.seatId, folderName: folderNames[id], teamFields })
         }
         setAgents((prev) => {
           const ids = new Set(prev)

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -78,6 +78,8 @@ export function createCharacter(
     matrixEffect: null,
     matrixEffectTimer: 0,
     matrixEffectSeeds: [],
+    inputTokens: 0,
+    outputTokens: 0,
   }
 }
 

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -12,6 +12,7 @@ import {
   CHARACTER_SITTING_OFFSET_PX,
   CHARACTER_HIT_HALF_WIDTH,
   CHARACTER_HIT_HEIGHT,
+  SEND_MESSAGE_BUBBLE_DURATION_SEC,
 } from '../../constants.js'
 import type { Character, Seat, FurnitureInstance, TileType as TileTypeVal, OfficeLayout, PlacedFurniture } from '../types.js'
 import { createCharacter, updateCharacter } from './characters.js'
@@ -193,7 +194,7 @@ export class OfficeState {
     return { palette, hueShift }
   }
 
-  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean, folderName?: string): void {
+  addAgent(id: number, preferredPalette?: number, preferredHueShift?: number, preferredSeatId?: string, skipSpawnEffect?: boolean, folderName?: string, teamFields?: { isTeamLead?: boolean; teamName?: string; isTeammate?: boolean; teamRole?: string; leadAgentId?: number }): void {
     if (this.characters.has(id)) return
 
     let palette: number
@@ -238,6 +239,13 @@ export class OfficeState {
 
     if (folderName) {
       ch.folderName = folderName
+    }
+    if (teamFields) {
+      if (teamFields.isTeamLead) ch.isTeamLead = true
+      if (teamFields.teamName) ch.teamName = teamFields.teamName
+      if (teamFields.isTeammate) ch.isTeammate = true
+      if (teamFields.teamRole) ch.teamRole = teamFields.teamRole
+      if (teamFields.leadAgentId !== undefined) ch.leadAgentId = teamFields.leadAgentId
     }
     if (!skipSpawnEffect) {
       ch.matrixEffect = 'spawn'
@@ -613,6 +621,32 @@ export class OfficeState {
     }
   }
 
+  /** Mark an existing agent as a team lead */
+  markAsLead(id: number, teamName?: string): void {
+    const ch = this.characters.get(id)
+    if (!ch) return
+    ch.isTeamLead = true
+    if (teamName) ch.teamName = teamName
+  }
+
+  /** Update token usage for a character (for fuel gauge rendering) */
+  setAgentTokens(id: number, inputTokens: number, outputTokens: number): void {
+    const ch = this.characters.get(id)
+    if (ch) {
+      ch.inputTokens = inputTokens
+      ch.outputTokens = outputTokens
+    }
+  }
+
+  /** Show a brief SendMessage speech bubble on a character */
+  showSendMessageBubble(id: number): void {
+    const ch = this.characters.get(id)
+    if (ch) {
+      ch.bubbleType = 'message'
+      ch.bubbleTimer = SEND_MESSAGE_BUBBLE_DURATION_SEC
+    }
+  }
+
   update(dt: number): void {
     const toDelete: number[] = []
     for (const ch of this.characters.values()) {
@@ -638,8 +672,8 @@ export class OfficeState {
         updateCharacter(ch, dt, this.walkableTiles, this.seats, this.tileMap, this.blockedTiles)
       )
 
-      // Tick bubble timer for waiting bubbles
-      if (ch.bubbleType === 'waiting') {
+      // Tick bubble timer for waiting and message bubbles
+      if (ch.bubbleType === 'waiting' || ch.bubbleType === 'message') {
         ch.bubbleTimer -= dt
         if (ch.bubbleTimer <= 0) {
           ch.bubbleType = null

--- a/webview-ui/src/office/engine/renderer.ts
+++ b/webview-ui/src/office/engine/renderer.ts
@@ -38,6 +38,13 @@ import {
   SELECTION_HIGHLIGHT_COLOR,
   DELETE_BUTTON_BG,
   ROTATE_BUTTON_BG,
+  TEAM_LABEL_FONT_SIZE_SP,
+  FUEL_GAUGE_WIDTH_SP,
+  FUEL_GAUGE_HEIGHT_SP,
+  MAX_CONTEXT_TOKENS,
+  TOKEN_WARN_THRESHOLD,
+  TOKEN_DANGER_THRESHOLD,
+  TOKEN_CRITICAL_THRESHOLD,
 } from '../../constants.js'
 
 // ── Render functions ────────────────────────────────────────────
@@ -482,6 +489,74 @@ export function renderBubbles(
   }
 }
 
+/** Render team role labels and token fuel gauges above/below characters. */
+export function renderCharacterLabels(
+  ctx: CanvasRenderingContext2D,
+  characters: Character[],
+  offsetX: number,
+  offsetY: number,
+  zoom: number,
+): void {
+  for (const ch of characters) {
+    if (ch.matrixEffect === 'despawn') continue
+
+    const sittingOff = ch.state === CharacterState.TYPE ? CHARACTER_SITTING_OFFSET_PX : 0
+    const charCenterX = Math.round(offsetX + ch.x * zoom)
+    // Top of the 24px-tall character sprite (anchor is bottom-center)
+    const charTopY = Math.round(offsetY + (ch.y + sittingOff) * zoom) - Math.round(24 * zoom)
+
+    // ── Team label (LEAD or role) ──────────────────────────────
+    const label = ch.isTeamLead ? 'LEAD' : (ch.teamRole ?? null)
+    if (label) {
+      const fontSize = Math.max(6, Math.round(TEAM_LABEL_FONT_SIZE_SP * zoom))
+      ctx.save()
+      ctx.font = `bold ${fontSize}px monospace`
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'bottom'
+      const textW = ctx.measureText(label).width
+      const bgPad = Math.max(1, Math.round(zoom * 0.5))
+      const bgX = charCenterX - textW / 2 - bgPad
+      const bgY = charTopY - fontSize - bgPad * 2
+      const bgW = textW + bgPad * 2
+      const bgH = fontSize + bgPad * 2
+      ctx.fillStyle = ch.isTeamLead ? 'rgba(255, 200, 50, 0.88)' : 'rgba(80, 180, 255, 0.88)'
+      ctx.fillRect(bgX, bgY, bgW, bgH)
+      ctx.fillStyle = '#0a0a14'
+      ctx.fillText(label, charCenterX, charTopY - bgPad)
+      ctx.restore()
+    }
+
+    // ── Fuel gauge (token usage) ───────────────────────────────
+    if (ch.inputTokens > 0) {
+      const fraction = Math.min(ch.inputTokens / MAX_CONTEXT_TOKENS, 1)
+      const gaugeW = Math.round(FUEL_GAUGE_WIDTH_SP * zoom)
+      const gaugeH = Math.max(2, Math.round(FUEL_GAUGE_HEIGHT_SP * zoom))
+      const gaugeX = charCenterX - Math.floor(gaugeW / 2)
+      // 2 sprite-pixels below the character anchor
+      const gaugeY = Math.round(offsetY + (ch.y + sittingOff) * zoom) + Math.round(2 * zoom)
+
+      ctx.save()
+      // Background track
+      ctx.fillStyle = 'rgba(20, 20, 30, 0.75)'
+      ctx.fillRect(gaugeX, gaugeY, gaugeW, gaugeH)
+      // Filled portion
+      let fillColor: string
+      if (fraction >= TOKEN_CRITICAL_THRESHOLD) {
+        fillColor = '#ef4444'
+      } else if (fraction >= TOKEN_DANGER_THRESHOLD) {
+        fillColor = '#f97316'
+      } else if (fraction >= TOKEN_WARN_THRESHOLD) {
+        fillColor = '#fbbf24'
+      } else {
+        fillColor = '#4ade80'
+      }
+      ctx.fillStyle = fillColor
+      ctx.fillRect(gaugeX, gaugeY, Math.max(1, Math.round(gaugeW * fraction)), gaugeH)
+      ctx.restore()
+    }
+  }
+}
+
 export interface ButtonBounds {
   /** Center X in device pixels */
   cx: number
@@ -578,6 +653,9 @@ export function renderFrame(
 
   // Speech bubbles (always on top of characters)
   renderBubbles(ctx, characters, offsetX, offsetY, zoom)
+
+  // Team labels + fuel gauges (always on top)
+  renderCharacterLabels(ctx, characters, offsetX, offsetY, zoom)
 
   // Editor overlays
   if (editor) {

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -178,8 +178,8 @@ export interface Character {
   /** Assigned seat uid, or null if no seat */
   seatId: string | null
   /** Active speech bubble type, or null if none showing */
-  bubbleType: 'permission' | 'waiting' | null
-  /** Countdown timer for bubble (waiting: 2→0, permission: unused) */
+  bubbleType: 'permission' | 'waiting' | 'message' | null
+  /** Countdown timer for bubble (waiting: 2→0, permission: unused, message: countdown) */
   bubbleTimer: number
   /** Timer to stay seated while inactive after seat reassignment (counts down to 0) */
   seatTimer: number
@@ -195,4 +195,18 @@ export interface Character {
   matrixEffectSeeds: number[]
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string
+  /** Whether this character is a team lead (uses TeamCreate tool) */
+  isTeamLead?: boolean
+  /** Team name for lead characters */
+  teamName?: string
+  /** Whether this character is an Agent Teams teammate (own JSONL, no terminal) */
+  isTeammate?: boolean
+  /** Role/name label for teammate characters */
+  teamRole?: string
+  /** Lead agent ID for teammate characters */
+  leadAgentId?: number
+  /** Cumulative input tokens from last assistant turn (for fuel gauge) */
+  inputTokens: number
+  /** Cumulative output tokens from last assistant turn */
+  outputTokens: number
 }


### PR DESCRIPTION
Backend (extension):
- src/constants.ts: add Agent/TeamCreate/TeamDelete/SendMessage tool name constants and TEAMMATE_MATCH_WINDOW_MS
- src/types.ts: make terminalRef optional for teammates; add inputTokens, outputTokens, and team fields to AgentState and PersistedAgent
- src/teamManager.ts: new module — registerPendingTeammate, tryClaimJsonlForTeammate, markAgentAsLead, getTeammatesForLead, handleSendMessage, clearExpiredPending
- src/transcriptParser.ts: detect Agent/TeamCreate/SendMessage tool events; extract token usage; expand PERMISSION_EXEMPT_TOOLS
- src/fileWatcher.ts: call tryClaimJsonlForTeammate before /clear logic
- src/agentManager.ts: persist/restore teammates; re-send token/lead on reconnect
- src/PixelAgentsViewProvider.ts: despawn all teammates on lead terminal close

Webview:
- webview-ui/src/constants.ts: team label, fuel gauge, token threshold constants
- webview-ui/src/office/types.ts: add team + token fields to Character; add 'message' bubble type
- webview-ui/src/office/engine/characters.ts: init inputTokens/outputTokens
- webview-ui/src/office/engine/officeState.ts: addAgent teamFields param; markAsLead, setAgentTokens, showSendMessageBubble; tick 'message' bubbles
- webview-ui/src/hooks/useExtensionMessages.ts: handle agentIsLead, teammateCreated, teammateRemoved, agentSendMessage, agentTokenUsage
- webview-ui/src/office/engine/renderer.ts: renderCharacterLabels — LEAD/role badge and color-coded fuel gauge per character