### PR TITLE
fix: improve cross-platform compatibility for macOS and Linux

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -142,6 +142,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // Ensure project scan runs even with no restored agents (to adopt external terminals)
         const projectDir = getProjectDirPath();
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        console.log(`[Extension] platform: ${process.platform}, arch: ${process.arch}`);
         console.log('[Extension] workspaceRoot:', workspaceRoot);
         console.log('[Extension] projectDir:', projectDir);
         if (projectDir) {

--- a/src/assetLoader.ts
+++ b/src/assetLoader.ts
@@ -75,11 +75,12 @@ export async function loadFurnitureAssets(workspaceRoot: string): Promise<Loaded
     for (const asset of catalog) {
       try {
         // Ensure file path includes 'assets/' prefix if not already present
-        let filePath = asset.file;
+        // Normalize to forward slashes for consistent comparison (catalog uses POSIX paths)
+        let filePath = asset.file.split(path.win32.sep).join(path.posix.sep);
         if (!filePath.startsWith('assets/')) {
           filePath = `assets/${filePath}`;
         }
-        const assetPath = path.join(workspaceRoot, filePath);
+        const assetPath = path.join(workspaceRoot, ...filePath.split('/'));
 
         if (!fs.existsSync(assetPath)) {
           console.warn(`  ⚠️  Asset file not found: ${asset.file}`);

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -17,10 +17,20 @@ export function startFileWatching(
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
   webview: vscode.Webview | undefined,
 ): void {
-  // Primary: fs.watch (unreliable on macOS — may miss events)
+  // Primary: fs.watch (unreliable on macOS — may miss events; may hit inotify limits on Linux)
   try {
     const watcher = fs.watch(filePath, () => {
       readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
+    });
+    watcher.on('error', (err) => {
+      console.log(
+        `[Pixel Agents] fs.watch error for agent ${agentId}: ${err.message}` +
+          (process.platform === 'linux'
+            ? ' (if ENOSPC, try increasing fs.inotify.max_user_watches)'
+            : ''),
+      );
+      watcher.close();
+      fileWatchers.delete(agentId);
     });
     fileWatchers.set(agentId, watcher);
   } catch (e) {

--- a/src/layoutPersistence.ts
+++ b/src/layoutPersistence.ts
@@ -137,8 +137,9 @@ export function watchLayoutFile(
       fsWatcher = fs.watch(filePath, () => {
         checkForChange();
       });
-      fsWatcher.on('error', () => {
-        // fs.watch can be unreliable — polling backup handles it
+      fsWatcher.on('error', (err) => {
+        // fs.watch can be unreliable on macOS (kqueue) and may hit inotify limits on Linux
+        console.log(`[Pixel Agents] Layout fs.watch error: ${err.message}`);
         fsWatcher?.close();
         fsWatcher = null;
       });


### PR DESCRIPTION
## Summary

Improves cross-platform robustness for macOS and Linux, addressing the "Windows-only testing" known limitation noted in the README.

## Changes

### 1. Graceful `fs.watch` error handling (`fileWatcher.ts`)
- Added `error` event handler on the `fs.watch` watcher to prevent unhandled errors from crashing the extension
- On Linux, `fs.watch` can fail with `ENOSPC` when the system runs out of inotify watchers — the error message now includes a hint to increase `fs.inotify.max_user_watches`
- The existing triple-redundancy (fs.watch + fs.watchFile + polling) already provides excellent macOS support; this change ensures errors are handled cleanly rather than potentially propagating

### 2. Cross-platform asset path normalization (`assetLoader.ts`)
- The furniture catalog JSON stores file paths with POSIX separators (`/`). The path comparison (`startsWith("assets/")`) worked correctly, but the resolved path could theoretically mix separators on Windows
- Now normalizes catalog paths using `path.posix`/`path.win32` and splits on `/` when joining, ensuring consistent behavior across all platforms

### 3. Platform logging on startup (`PixelAgentsViewProvider.ts`)
- Logs `process.platform` and `process.arch` at startup for easier debugging of platform-specific issues

### 4. Layout watcher error logging (`layoutPersistence.ts`)
- The `fs.watch` error handler for the layout file watcher previously swallowed errors silently — now logs them for debugging

## Testing

- ✅ Full build (`npm run build`) passes on macOS (arm64, Darwin)
- ✅ TypeScript type-checking passes
- ✅ ESLint passes (via lint-staged)
- ✅ All changes are backwards-compatible — no behavioral changes on Windows

## Notes

After reviewing the codebase thoroughly, the extension is already well-architected for cross-platform use:
- All file paths use `path.join()` consistently
- File watching already uses triple redundancy (fs.watch + fs.watchFile + manual polling)
- The project directory naming (`getProjectDirPath`) matches Claude Code's own convention across platforms

These changes are defensive improvements that handle edge cases (fs.watch errors, path normalization) and improve debuggability on non-Windows platforms.