### PR TITLE
feat: Electron desktop app port (Phases 1-3)

### DIFF
--- a/electron/agentHandle.ts
+++ b/electron/agentHandle.ts
@@ -1,0 +1,93 @@
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+
+export interface AgentHandle {
+  /** OS process ID */
+  readonly pid: number;
+  /** Claude session UUID */
+  readonly sessionId: string;
+  /** Display name (matches TERMINAL_NAME_PREFIX pattern) */
+  readonly name: string;
+  /** Working directory the process was spawned in */
+  readonly cwd: string;
+  /** Underlying child process (for advanced use) */
+  readonly process: ChildProcess;
+  /** Whether the process has exited */
+  readonly exited: boolean;
+  /** Send SIGTERM to the process */
+  kill(): void;
+  /** Register a callback for process exit */
+  onExit(callback: (code: number | null) => void): void;
+  /** Satisfies the TerminalHandle-like interface expected by AgentState */
+  show(): void;
+  /** Alias for kill(), matches vscode.Terminal.dispose() */
+  dispose(): void;
+}
+
+/**
+ * Spawn a new `claude` child process with the given session ID and working directory.
+ * Returns an AgentHandle wrapping the process.
+ */
+export function spawnAgent(sessionId: string, cwd: string, name: string): AgentHandle {
+  const child = spawn('claude', ['--session-id', sessionId], {
+    cwd,
+    stdio: 'pipe',
+    // Ensure the process is killed when the parent exits
+    detached: false,
+  });
+
+  if (!child.pid) {
+    throw new Error(`Failed to spawn claude process for session ${sessionId}`);
+  }
+
+  let hasExited = false;
+  const exitCallbacks: Array<(code: number | null) => void> = [];
+
+  child.on('exit', (code) => {
+    hasExited = true;
+    for (const cb of exitCallbacks) {
+      cb(code);
+    }
+  });
+
+  // Log stderr for debugging
+  child.stderr?.on('data', (data: Buffer) => {
+    const text = data.toString().trim();
+    if (text) {
+      console.log(`[Agent ${name}] stderr: ${text}`);
+    }
+  });
+
+  const handle: AgentHandle = {
+    pid: child.pid,
+    sessionId,
+    name,
+    cwd,
+    process: child,
+    get exited() {
+      return hasExited;
+    },
+    kill() {
+      if (!hasExited) {
+        child.kill('SIGTERM');
+      }
+    },
+    onExit(callback: (code: number | null) => void) {
+      if (hasExited) {
+        // Already exited — fire callback immediately
+        callback(child.exitCode);
+      } else {
+        exitCallbacks.push(callback);
+      }
+    },
+    show() {
+      // No-op in Electron (no terminal panel to show)
+    },
+    dispose() {
+      handle.kill();
+    },
+  };
+
+  console.log(`[Agent] Spawned claude process: pid=${child.pid}, session=${sessionId}, cwd=${cwd}`);
+  return handle;
+}

--- a/electron/appController.ts
+++ b/electron/appController.ts
@@ -1,0 +1,457 @@
+/**
+ * AppController — Main orchestrator for the Electron app.
+ * Replaces PixelAgentsViewProvider.ts from the VS Code extension.
+ *
+ * Wires together:
+ * - ProcessManager (child_process.spawn for Claude sessions)
+ * - Shared file watching, transcript parsing, timer management (from src/)
+ * - Asset loading (from src/assetLoader.ts)
+ * - Layout persistence (from src/layoutPersistence.ts)
+ * - Simple JSON store (electron/store.ts)
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  loadCharacterSprites,
+  loadDefaultLayout,
+  loadFloorTiles,
+  loadFurnitureAssets,
+  loadWallTiles,
+  sendAssetsToWebview,
+  sendCharacterSpritesToWebview,
+  sendFloorTilesToWebview,
+  sendWallTilesToWebview,
+} from '../src/assetLoader.js';
+import { JSONL_POLL_INTERVAL_MS } from '../src/constants.js';
+import { ensureProjectScan, readNewLines, startFileWatching } from '../src/fileWatcher.js';
+import type { LayoutWatcher } from '../src/layoutPersistence.js';
+import {
+  readLayoutFromFile,
+  watchLayoutFile,
+  writeLayoutToFile,
+} from '../src/layoutPersistence.js';
+import { cancelPermissionTimer, cancelWaitingTimer } from '../src/timerManager.js';
+import type { AgentState, MessageSender, PersistedAgent } from '../src/types.js';
+import { ProcessManager } from './processManager.js';
+import { store } from './store.js';
+
+// Store keys (match VS Code extension keys for compatibility)
+const STORE_KEY_AGENTS = 'pixel-agents.agents';
+const STORE_KEY_AGENT_SEATS = 'pixel-agents.agentSeats';
+const STORE_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
+
+export class AppController {
+  private processManager = new ProcessManager();
+  private agents = new Map<number, AgentState>();
+  private sender: MessageSender;
+
+  // Agent ID counter — shared with ensureProjectScan for /clear + adoption
+  private nextAgentIdRef = { current: 1 };
+
+  // Per-agent timers (same maps as VS Code extension)
+  private fileWatchers = new Map<number, fs.FSWatcher>();
+  private pollingTimers = new Map<number, ReturnType<typeof setInterval>>();
+  private waitingTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private permissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private jsonlPollTimers = new Map<number, ReturnType<typeof setInterval>>();
+
+  // /clear detection: project-level scan for new JSONL files
+  private activeAgentId = { current: null as number | null };
+  private knownJsonlFiles = new Set<string>();
+  private projectScanTimer = { current: null as ReturnType<typeof setInterval> | null };
+
+  // Bundled default layout
+  private defaultLayout: Record<string, unknown> | null = null;
+
+  // Cross-window layout sync
+  private layoutWatcher: LayoutWatcher | null = null;
+
+  // Path to bundled assets (set from main.ts)
+  private assetsRoot: string | null = null;
+
+  /**
+   * @param sendMessage — function to send IPC messages to the renderer
+   * @param appPath — app.getAppPath(), used to locate bundled assets
+   */
+  constructor(sendMessage: (message: unknown) => void, appPath: string) {
+    this.sender = { postMessage: sendMessage };
+
+    // Resolve assets root: dist/assets/ relative to the app path
+    const bundledAssetsDir = path.join(appPath, 'dist', 'assets');
+    if (fs.existsSync(bundledAssetsDir)) {
+      this.assetsRoot = path.join(appPath, 'dist');
+    }
+
+    // Wire process exit → agent cleanup
+    this.processManager.onProcessExit = (id: number) => {
+      this.handleProcessExit(id);
+    };
+  }
+
+  // ── IPC Message Dispatch ─────────────────────────────────────
+
+  handleMessage(message: unknown): void {
+    const msg = message as Record<string, unknown>;
+    const type = msg.type as string;
+
+    switch (type) {
+      case 'webviewReady':
+        this.handleWebviewReady();
+        break;
+      case 'openClaude':
+        this.handleOpenClaude(msg.folderPath as string | undefined);
+        break;
+      case 'focusAgent':
+        this.handleFocusAgent(msg.id as number);
+        break;
+      case 'closeAgent':
+        this.handleCloseAgent(msg.id as number);
+        break;
+      case 'saveLayout':
+        this.layoutWatcher?.markOwnWrite();
+        writeLayoutToFile(msg.layout as Record<string, unknown>);
+        break;
+      case 'saveAgentSeats':
+        store.update(STORE_KEY_AGENT_SEATS, msg.seats);
+        break;
+      case 'setSoundEnabled':
+        store.update(STORE_KEY_SOUND_ENABLED, msg.enabled);
+        break;
+      default:
+        console.log(`[AppController] Unhandled message type: ${type}`);
+    }
+  }
+
+  // ── Webview Ready ────────────────────────────────────────────
+
+  private handleWebviewReady(): void {
+    // Send persisted settings
+    const soundEnabled = store.get<boolean>(STORE_KEY_SOUND_ENABLED, true);
+    this.sender.postMessage({ type: 'settingsLoaded', soundEnabled });
+
+    // Send existing agents (empty on fresh start)
+    this.sendExistingAgents();
+
+    // Start project scan for the current working directory
+    const cwd = process.cwd();
+    const projectDir = this.getProjectDirPath(cwd);
+    if (projectDir) {
+      ensureProjectScan(
+        projectDir,
+        this.knownJsonlFiles,
+        this.projectScanTimer,
+        this.activeAgentId,
+        this.nextAgentIdRef,
+        this.agents,
+        this.fileWatchers,
+        this.pollingTimers,
+        this.waitingTimers,
+        this.permissionTimers,
+        this.sender,
+        () => this.persistAgents(),
+        () => this.processManager.getFocusedHandle(),
+      );
+    }
+
+    // Load and send assets, then layout
+    this.loadAndSendAssets();
+  }
+
+  // ── Agent Lifecycle ──────────────────────────────────────────
+
+  private handleOpenClaude(folderPath?: string): void {
+    const cwd = folderPath || process.cwd();
+    const id = this.nextAgentIdRef.current++;
+    const result = this.processManager.spawn(id, cwd);
+
+    // Pre-register expected JSONL so project scan won't treat it as a /clear file
+    this.knownJsonlFiles.add(result.jsonlFile);
+
+    // Create agent
+    const agent: AgentState = {
+      id,
+      terminalRef: result.handle,
+      projectDir: result.projectDir,
+      jsonlFile: result.jsonlFile,
+      fileOffset: 0,
+      lineBuffer: '',
+      activeToolIds: new Set(),
+      activeToolStatuses: new Map(),
+      activeToolNames: new Map(),
+      activeSubagentToolIds: new Map(),
+      activeSubagentToolNames: new Map(),
+      isWaiting: false,
+      permissionSent: false,
+      hadToolsInTurn: false,
+    };
+
+    this.agents.set(id, agent);
+    this.activeAgentId.current = id;
+    this.persistAgents();
+
+    console.log(`[AppController] Agent ${id}: created, pid=${result.handle.pid}`);
+    this.sender.postMessage({ type: 'agentCreated', id });
+
+    // Start project scan (for /clear detection)
+    ensureProjectScan(
+      result.projectDir,
+      this.knownJsonlFiles,
+      this.projectScanTimer,
+      this.activeAgentId,
+      this.nextAgentIdRef,
+      this.agents,
+      this.fileWatchers,
+      this.pollingTimers,
+      this.waitingTimers,
+      this.permissionTimers,
+      this.sender,
+      () => this.persistAgents(),
+      () => this.processManager.getFocusedHandle(),
+    );
+
+    // Poll for the JSONL file to appear
+    const pollTimer = setInterval(() => {
+      try {
+        if (fs.existsSync(agent.jsonlFile)) {
+          console.log(
+            `[AppController] Agent ${id}: found JSONL file ${path.basename(agent.jsonlFile)}`,
+          );
+          clearInterval(pollTimer);
+          this.jsonlPollTimers.delete(id);
+          startFileWatching(
+            id,
+            agent.jsonlFile,
+            this.agents,
+            this.fileWatchers,
+            this.pollingTimers,
+            this.waitingTimers,
+            this.permissionTimers,
+            this.sender,
+          );
+          readNewLines(id, this.agents, this.waitingTimers, this.permissionTimers, this.sender);
+        }
+      } catch {
+        /* file may not exist yet */
+      }
+    }, JSONL_POLL_INTERVAL_MS);
+    this.jsonlPollTimers.set(id, pollTimer);
+  }
+
+  private handleFocusAgent(id: number): void {
+    this.processManager.focus(id);
+    this.activeAgentId.current = id;
+  }
+
+  private handleCloseAgent(id: number): void {
+    this.processManager.kill(id);
+    // The exit handler will call handleProcessExit
+  }
+
+  private handleProcessExit(id: number): void {
+    if (this.activeAgentId.current === id) {
+      this.activeAgentId.current = null;
+    }
+    this.removeAgent(id);
+    this.sender.postMessage({ type: 'agentClosed', id });
+  }
+
+  // ── Agent Removal ────────────────────────────────────────────
+
+  private removeAgent(agentId: number): void {
+    const agent = this.agents.get(agentId);
+    if (!agent) return;
+
+    // Stop JSONL poll timer
+    const jpTimer = this.jsonlPollTimers.get(agentId);
+    if (jpTimer) {
+      clearInterval(jpTimer);
+    }
+    this.jsonlPollTimers.delete(agentId);
+
+    // Stop file watching
+    this.fileWatchers.get(agentId)?.close();
+    this.fileWatchers.delete(agentId);
+    const pt = this.pollingTimers.get(agentId);
+    if (pt) {
+      clearInterval(pt);
+    }
+    this.pollingTimers.delete(agentId);
+    try {
+      fs.unwatchFile(agent.jsonlFile);
+    } catch {
+      /* ignore */
+    }
+
+    // Cancel timers
+    cancelWaitingTimer(agentId, this.waitingTimers);
+    cancelPermissionTimer(agentId, this.permissionTimers);
+
+    // Remove from map
+    this.agents.delete(agentId);
+    this.persistAgents();
+  }
+
+  // ── Persistence ──────────────────────────────────────────────
+
+  private persistAgents(): void {
+    const persisted: PersistedAgent[] = [];
+    for (const agent of this.agents.values()) {
+      persisted.push({
+        id: agent.id,
+        terminalName: agent.terminalRef.name,
+        jsonlFile: agent.jsonlFile,
+        projectDir: agent.projectDir,
+        folderName: agent.folderName,
+      });
+    }
+    store.update(STORE_KEY_AGENTS, persisted);
+  }
+
+  private sendExistingAgents(): void {
+    const agentIds: number[] = [];
+    for (const id of this.agents.keys()) {
+      agentIds.push(id);
+    }
+    agentIds.sort((a, b) => a - b);
+
+    const agentMeta = store.get<Record<string, { palette?: number; seatId?: string }>>(
+      STORE_KEY_AGENT_SEATS,
+      {},
+    );
+
+    const folderNames: Record<number, string> = {};
+    for (const [id, agent] of this.agents) {
+      if (agent.folderName) {
+        folderNames[id] = agent.folderName;
+      }
+    }
+
+    this.sender.postMessage({
+      type: 'existingAgents',
+      agents: agentIds,
+      agentMeta,
+      folderNames,
+    });
+
+    // Re-send current statuses for any active agents
+    for (const [agentId, agent] of this.agents) {
+      for (const [toolId, status] of agent.activeToolStatuses) {
+        this.sender.postMessage({
+          type: 'agentToolStart',
+          id: agentId,
+          toolId,
+          status,
+        });
+      }
+      if (agent.isWaiting) {
+        this.sender.postMessage({
+          type: 'agentStatus',
+          id: agentId,
+          status: 'waiting',
+        });
+      }
+    }
+  }
+
+  // ── Asset Loading ────────────────────────────────────────────
+
+  private async loadAndSendAssets(): Promise<void> {
+    try {
+      const assetsRoot = this.assetsRoot;
+      if (!assetsRoot) {
+        console.log('[AppController] No assets directory found');
+        this.sendLayout();
+        this.startLayoutWatcher();
+        return;
+      }
+
+      console.log(`[AppController] Loading assets from: ${assetsRoot}`);
+
+      // Load bundled default layout
+      this.defaultLayout = loadDefaultLayout(assetsRoot);
+
+      // Load character sprites
+      const charSprites = await loadCharacterSprites(assetsRoot);
+      if (charSprites) {
+        sendCharacterSpritesToWebview(this.sender, charSprites);
+      }
+
+      // Load floor tiles
+      const floorTiles = await loadFloorTiles(assetsRoot);
+      if (floorTiles) {
+        sendFloorTilesToWebview(this.sender, floorTiles);
+      }
+
+      // Load wall tiles
+      const wallTiles = await loadWallTiles(assetsRoot);
+      if (wallTiles) {
+        sendWallTilesToWebview(this.sender, wallTiles);
+      }
+
+      // Load furniture assets
+      const assets = await loadFurnitureAssets(assetsRoot);
+      if (assets) {
+        sendAssetsToWebview(this.sender, assets);
+      }
+    } catch (err) {
+      console.error('[AppController] Error loading assets:', err);
+    }
+
+    // Always send layout after assets
+    this.sendLayout();
+    this.startLayoutWatcher();
+  }
+
+  // ── Layout ───────────────────────────────────────────────────
+
+  private sendLayout(): void {
+    // Simplified migrateAndLoadLayout for Electron (no workspace state to migrate)
+    let layout = readLayoutFromFile();
+    if (!layout && this.defaultLayout) {
+      console.log('[AppController] Writing bundled default layout to file');
+      writeLayoutToFile(this.defaultLayout);
+      layout = this.defaultLayout;
+    }
+
+    this.sender.postMessage({ type: 'layoutLoaded', layout });
+  }
+
+  private startLayoutWatcher(): void {
+    if (this.layoutWatcher) return;
+    this.layoutWatcher = watchLayoutFile((layout) => {
+      console.log('[AppController] External layout change — pushing to webview');
+      this.sender.postMessage({ type: 'layoutLoaded', layout });
+    });
+  }
+
+  // ── Utility ──────────────────────────────────────────────────
+
+  private getProjectDirPath(cwd: string): string | null {
+    const dirName = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
+    return path.join(os.homedir(), '.claude', 'projects', dirName);
+  }
+
+  // ── Cleanup ──────────────────────────────────────────────────
+
+  dispose(): void {
+    this.layoutWatcher?.dispose();
+    this.layoutWatcher = null;
+
+    // Remove all agents
+    for (const id of [...this.agents.keys()]) {
+      this.removeAgent(id);
+    }
+
+    // Stop project scan
+    if (this.projectScanTimer.current) {
+      clearInterval(this.projectScanTimer.current);
+      this.projectScanTimer.current = null;
+    }
+
+    // Kill all child processes
+    this.processManager.killAll();
+  }
+}

--- a/electron/esbuild.js
+++ b/electron/esbuild.js
@@ -1,0 +1,42 @@
+const esbuild = require('esbuild');
+
+const production = process.argv.includes('--production');
+
+async function main() {
+  // Build main process
+  await esbuild.build({
+    entryPoints: ['electron/main.ts'],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    target: 'node20',
+    outfile: 'dist-electron/main.js',
+    external: ['electron'],
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    logLevel: 'info',
+  });
+
+  // Build preload script (separate bundle — runs in its own context)
+  await esbuild.build({
+    entryPoints: ['electron/preload.ts'],
+    bundle: true,
+    format: 'cjs',
+    platform: 'node',
+    target: 'node20',
+    outfile: 'dist-electron/preload.js',
+    external: ['electron'],
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    logLevel: 'info',
+  });
+
+  console.log('Electron build complete.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,58 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import * as path from 'path';
+
+import { AppController } from './appController.js';
+
+let mainWindow: BrowserWindow | null = null;
+let controller: AppController | null = null;
+
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  const indexPath = path.join(__dirname, '..', 'dist', 'webview', 'index.html');
+  mainWindow.loadFile(indexPath);
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+export function sendToRenderer(message: unknown): void {
+  mainWindow?.webContents.send('main-message', message);
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  // Create controller after window exists so sendToRenderer works
+  controller = new AppController(sendToRenderer, app.getAppPath());
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  controller?.dispose();
+  controller = null;
+  app.quit();
+});
+
+// IPC: renderer -> main → AppController
+ipcMain.on('webview-message', (_event, message: unknown) => {
+  if (controller) {
+    controller.handleMessage(message);
+  } else {
+    console.log('[Main] No controller, message dropped:', JSON.stringify(message));
+  }
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,15 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  postMessage: (message: unknown): void => {
+    ipcRenderer.send('webview-message', message);
+  },
+  onMessage: (callback: (message: unknown) => void): void => {
+    ipcRenderer.on('main-message', (_event, message: unknown) => {
+      callback(message);
+    });
+  },
+  removeMessageListener: (): void => {
+    ipcRenderer.removeAllListeners('main-message');
+  },
+});

--- a/electron/processManager.ts
+++ b/electron/processManager.ts
@@ -1,0 +1,126 @@
+import * as crypto from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { AgentHandle } from './agentHandle.js';
+import { spawnAgent } from './agentHandle.js';
+
+const TERMINAL_NAME_PREFIX = 'Claude Code';
+
+export interface SpawnResult {
+  handle: AgentHandle;
+  sessionId: string;
+  projectDir: string;
+  jsonlFile: string;
+}
+
+/**
+ * Manages all Claude child processes for the Electron app.
+ * Replaces vscode.window.createTerminal / vscode.window.terminals.
+ *
+ * Agent IDs are provided externally by the AppController (which owns
+ * the shared nextAgentIdRef used by ensureProjectScan as well).
+ */
+export class ProcessManager {
+  private handles = new Map<number, AgentHandle>();
+  private nextIndex = 1;
+  private focusedId: number | null = null;
+
+  /** Callback fired when a process exits */
+  onProcessExit: ((id: number) => void) | null = null;
+
+  /**
+   * Spawn a new Claude agent process.
+   * @param agentId — externally-assigned agent ID (from AppController's nextAgentIdRef)
+   * @param cwd — working directory for the Claude process
+   */
+  spawn(agentId: number, cwd: string): SpawnResult {
+    const sessionId = crypto.randomUUID();
+    const idx = this.nextIndex++;
+    const name = `${TERMINAL_NAME_PREFIX} #${idx}`;
+
+    const handle = spawnAgent(sessionId, cwd, name);
+
+    // Wire up exit handling
+    handle.onExit((_code) => {
+      console.log(`[ProcessManager] Agent ${agentId} (pid=${handle.pid}) exited`);
+      this.handles.delete(agentId);
+      if (this.focusedId === agentId) {
+        this.focusedId = null;
+      }
+      this.onProcessExit?.(agentId);
+    });
+
+    this.handles.set(agentId, handle);
+    this.focusedId = agentId;
+
+    const projectDir = getProjectDirPath(cwd);
+    const jsonlFile = path.join(projectDir, `${sessionId}.jsonl`);
+
+    return { handle, sessionId, projectDir, jsonlFile };
+  }
+
+  /** Kill a specific agent by ID */
+  kill(id: number): void {
+    const handle = this.handles.get(id);
+    if (handle) {
+      handle.kill();
+      // The exit handler will clean up the map entry
+    }
+  }
+
+  /** Get a handle by agent ID */
+  getHandle(id: number): AgentHandle | undefined {
+    return this.handles.get(id);
+  }
+
+  /** Get all active handles */
+  getAllHandles(): Map<number, AgentHandle> {
+    return this.handles;
+  }
+
+  /** Set which agent is "focused" (replaces vscode.window.activeTerminal) */
+  focus(id: number): void {
+    if (this.handles.has(id)) {
+      this.focusedId = id;
+    }
+  }
+
+  /** Get the currently focused agent handle (replaces vscode.window.activeTerminal) */
+  getFocusedHandle(): AgentHandle | null {
+    if (this.focusedId !== null) {
+      return this.handles.get(this.focusedId) ?? null;
+    }
+    return null;
+  }
+
+  /** Get the focused agent ID */
+  getFocusedId(): number | null {
+    return this.focusedId;
+  }
+
+  /** Advance the terminal name index past restored values */
+  advanceIndex(maxIndex: number): void {
+    if (maxIndex >= this.nextIndex) {
+      this.nextIndex = maxIndex + 1;
+    }
+  }
+
+  /** Kill all processes (for cleanup on app quit) */
+  killAll(): void {
+    for (const handle of this.handles.values()) {
+      handle.kill();
+    }
+    this.handles.clear();
+    this.focusedId = null;
+  }
+}
+
+/**
+ * Derive the project directory path from a working directory.
+ * Matches the VS Code extension's `getProjectDirPath()` logic.
+ */
+export function getProjectDirPath(cwd: string): string {
+  const dirName = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
+  return path.join(os.homedir(), '.claude', 'projects', dirName);
+}

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -1,0 +1,63 @@
+/**
+ * Simple JSON key-value store persisted at ~/.pixel-agents/electron-store.json.
+ * Replaces vscode.ExtensionContext.workspaceState / globalState for Electron.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const STORE_DIR = '.pixel-agents';
+const STORE_FILE = 'electron-store.json';
+
+class Store {
+  private data: Record<string, unknown> = {};
+  private readonly filePath: string;
+
+  constructor() {
+    this.filePath = path.join(os.homedir(), STORE_DIR, STORE_FILE);
+    this.load();
+  }
+
+  get<T>(key: string, defaultValue: T): T {
+    const value = this.data[key];
+    if (value === undefined) return defaultValue;
+    return value as T;
+  }
+
+  update(key: string, value: unknown): void {
+    if (value === undefined) {
+      delete this.data[key];
+    } else {
+      this.data[key] = value;
+    }
+    this.save();
+  }
+
+  private load(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const raw = fs.readFileSync(this.filePath, 'utf-8');
+        this.data = JSON.parse(raw) as Record<string, unknown>;
+      }
+    } catch {
+      this.data = {};
+    }
+  }
+
+  private save(): void {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      const tmp = this.filePath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(this.data, null, 2), 'utf-8');
+      fs.renameSync(tmp, this.filePath);
+    } catch (err) {
+      console.error('[Store] Failed to save:', err);
+    }
+  }
+}
+
+export const store = new Store();

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "strict": true,
+    "rootDir": "..",
+    "outDir": "../dist-electron",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@types/node": "22.x",
         "@types/pngjs": "^6.0.5",
         "@types/vscode": "^1.107.0",
+        "cross-env": "^7.0.3",
+        "electron": "^33.0.0",
         "esbuild": "^0.27.2",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -59,6 +61,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -747,6 +779,42 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -754,12 +822,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.19.9",
@@ -781,12 +864,31 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.109.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -1182,6 +1284,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1200,6 +1310,42 @@
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -1328,6 +1474,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1371,6 +1529,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1459,12 +1635,48 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1502,6 +1714,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1517,12 +1736,57 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1682,6 +1946,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1962,6 +2233,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1982,6 +2273,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2061,6 +2361,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fsevents": {
@@ -2181,6 +2495,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -2210,6 +2539,24 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
       }
     },
     "node_modules/globals": {
@@ -2253,6 +2600,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -2362,6 +2734,25 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -2908,6 +3299,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3063,6 +3470,28 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3107,6 +3536,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3167,6 +3605,18 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-all": {
@@ -3414,6 +3864,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -3464,6 +3923,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -3565,6 +4033,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3647,6 +4121,25 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3655,6 +4148,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
@@ -3737,6 +4242,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3755,6 +4266,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -3780,6 +4303,24 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -3861,6 +4402,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/set-function-length": {
@@ -4103,6 +4667,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4261,6 +4832,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -4396,6 +4979,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -4539,6 +5135,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4732,6 +5337,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
@@ -4746,6 +5357,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
     "lint:webview:fix": "cd webview-ui && eslint . --fix",
     "import-tileset": "tsx scripts/import-tileset-cli.ts",
     "format": "prettier --write \"src/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
-    "format:check": "prettier --check \"src/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\""
+    "format:check": "prettier --check \"src/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
+    "build:electron": "node electron/esbuild.js",
+    "build:webview:electron": "cd webview-ui && cross-env BUILD_TARGET=electron npm run build",
+    "start:electron": "npm run build:webview:electron && npm run build:electron && electron dist-electron/main.js"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
@@ -83,6 +86,8 @@
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
+    "cross-env": "^7.0.3",
+    "electron": "^33.0.0",
     "typescript-eslint": "^8.54.0"
   },
   "lint-staged": {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -158,6 +158,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.permissionTimers,
             this.webview,
             this.persistAgents,
+            () => vscode.window.activeTerminal ?? null,
           );
 
           // Load furniture assets BEFORE sending layout

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -12,7 +12,7 @@ import {
 import { ensureProjectScan, readNewLines, startFileWatching } from './fileWatcher.js';
 import { migrateAndLoadLayout } from './layoutPersistence.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
-import type { AgentState, PersistedAgent } from './types.js';
+import type { AgentState, MessageSender, PersistedAgent } from './types.js';
 
 export function getProjectDirPath(cwd?: string): string | null {
   const workspacePath = cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
@@ -35,7 +35,7 @@ export async function launchNewTerminal(
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
   jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
   projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   persistAgents: () => void,
   folderPath?: string,
 ): Promise<void> {
@@ -87,7 +87,7 @@ export async function launchNewTerminal(
   activeAgentIdRef.current = id;
   persistAgents();
   console.log(`[Pixel Agents] Agent ${id}: created for terminal ${terminal.name}`);
-  webview?.postMessage({ type: 'agentCreated', id, folderName });
+  sender?.postMessage({ type: 'agentCreated', id, folderName });
 
   ensureProjectScan(
     projectDir,
@@ -100,8 +100,9 @@ export async function launchNewTerminal(
     pollingTimers,
     waitingTimers,
     permissionTimers,
-    webview,
+    sender,
     persistAgents,
+    () => vscode.window.activeTerminal ?? null,
   );
 
   // Poll for the specific JSONL file to appear
@@ -121,9 +122,9 @@ export async function launchNewTerminal(
           pollingTimers,
           waitingTimers,
           permissionTimers,
-          webview,
+          sender,
         );
-        readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+        readNewLines(id, agents, waitingTimers, permissionTimers, sender);
       }
     } catch {
       /* file may not exist yet */
@@ -205,7 +206,7 @@ export function restoreAgents(
   jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
   projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
   activeAgentIdRef: { current: number | null },
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   doPersist: () => void,
 ): void {
   const persisted = context.workspaceState.get<PersistedAgent[]>(WORKSPACE_KEY_AGENTS, []);
@@ -265,7 +266,7 @@ export function restoreAgents(
           pollingTimers,
           waitingTimers,
           permissionTimers,
-          webview,
+          sender,
         );
       } else {
         // Poll for the file to appear
@@ -285,7 +286,7 @@ export function restoreAgents(
                 pollingTimers,
                 waitingTimers,
                 permissionTimers,
-                webview,
+                sender,
               );
             }
           } catch {
@@ -323,8 +324,9 @@ export function restoreAgents(
       pollingTimers,
       waitingTimers,
       permissionTimers,
-      webview,
+      sender,
       doPersist,
+      () => vscode.window.activeTerminal ?? null,
     );
   }
 }
@@ -332,9 +334,9 @@ export function restoreAgents(
 export function sendExistingAgents(
   agents: Map<number, AgentState>,
   context: vscode.ExtensionContext,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
-  if (!webview) return;
+  if (!sender) return;
   const agentIds: number[] = [];
   for (const id of agents.keys()) {
     agentIds.push(id);
@@ -357,25 +359,25 @@ export function sendExistingAgents(
     `[Pixel Agents] sendExistingAgents: agents=${JSON.stringify(agentIds)}, meta=${JSON.stringify(agentMeta)}`,
   );
 
-  webview.postMessage({
+  sender.postMessage({
     type: 'existingAgents',
     agents: agentIds,
     agentMeta,
     folderNames,
   });
 
-  sendCurrentAgentStatuses(agents, webview);
+  sendCurrentAgentStatuses(agents, sender);
 }
 
 export function sendCurrentAgentStatuses(
   agents: Map<number, AgentState>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
-  if (!webview) return;
+  if (!sender) return;
   for (const [agentId, agent] of agents) {
     // Re-send active tools
     for (const [toolId, status] of agent.activeToolStatuses) {
-      webview.postMessage({
+      sender.postMessage({
         type: 'agentToolStart',
         id: agentId,
         toolId,
@@ -384,7 +386,7 @@ export function sendCurrentAgentStatuses(
     }
     // Re-send waiting status
     if (agent.isWaiting) {
-      webview.postMessage({
+      sender.postMessage({
         type: 'agentStatus',
         id: agentId,
         status: 'waiting',
@@ -395,12 +397,12 @@ export function sendCurrentAgentStatuses(
 
 export function sendLayout(
   context: vscode.ExtensionContext,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   defaultLayout?: Record<string, unknown> | null,
 ): void {
-  if (!webview) return;
+  if (!sender) return;
   const layout = migrateAndLoadLayout(context, defaultLayout);
-  webview.postMessage({
+  sender.postMessage({
     type: 'layoutLoaded',
     layout,
   });

--- a/src/assetLoader.ts
+++ b/src/assetLoader.ts
@@ -8,7 +8,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { PNG } from 'pngjs';
-import * as vscode from 'vscode';
 
 import {
   CHAR_COUNT,
@@ -24,6 +23,7 @@ import {
   WALL_PIECE_HEIGHT,
   WALL_PIECE_WIDTH,
 } from './constants.js';
+import type { MessageSender } from './types.js';
 
 export interface FurnitureAsset {
   id: string;
@@ -252,8 +252,8 @@ export async function loadWallTiles(assetsRoot: string): Promise<LoadedWallTiles
 /**
  * Send wall tiles to webview
  */
-export function sendWallTilesToWebview(webview: vscode.Webview, wallTiles: LoadedWallTiles): void {
-  webview.postMessage({
+export function sendWallTilesToWebview(sender: MessageSender, wallTiles: LoadedWallTiles): void {
+  sender.postMessage({
     type: 'wallTilesLoaded',
     sprites: wallTiles.sprites,
   });
@@ -316,11 +316,8 @@ export async function loadFloorTiles(assetsRoot: string): Promise<LoadedFloorTil
 /**
  * Send floor tiles to webview
  */
-export function sendFloorTilesToWebview(
-  webview: vscode.Webview,
-  floorTiles: LoadedFloorTiles,
-): void {
-  webview.postMessage({
+export function sendFloorTilesToWebview(sender: MessageSender, floorTiles: LoadedFloorTiles): void {
+  sender.postMessage({
     type: 'floorTilesLoaded',
     sprites: floorTiles.sprites,
   });
@@ -413,10 +410,10 @@ export async function loadCharacterSprites(
  * Send character sprites to webview
  */
 export function sendCharacterSpritesToWebview(
-  webview: vscode.Webview,
+  sender: MessageSender,
   charSprites: LoadedCharacterSprites,
 ): void {
-  webview.postMessage({
+  sender.postMessage({
     type: 'characterSpritesLoaded',
     characters: charSprites.characters,
   });
@@ -426,7 +423,7 @@ export function sendCharacterSpritesToWebview(
 /**
  * Send loaded assets to webview
  */
-export function sendAssetsToWebview(webview: vscode.Webview, assets: LoadedAssets): void {
+export function sendAssetsToWebview(sender: MessageSender, assets: LoadedAssets): void {
   if (!assets) {
     console.log('[AssetLoader] ⚠️  No assets to send');
     return;
@@ -442,7 +439,7 @@ export function sendAssetsToWebview(webview: vscode.Webview, assets: LoadedAsset
   console.log(
     `[AssetLoader] Posting furnitureAssetsLoaded message with ${assets.catalog.length} assets`,
   );
-  webview.postMessage({
+  sender.postMessage({
     type: 'furnitureAssetsLoaded',
     catalog: assets.catalog,
     sprites: spritesObj,

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,11 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as vscode from 'vscode';
 
 import { FILE_WATCHER_POLL_INTERVAL_MS, PROJECT_SCAN_INTERVAL_MS } from './constants.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
-import type { AgentState } from './types.js';
+import type { AgentState, MessageSender, TerminalHandle } from './types.js';
 
 export function startFileWatching(
   agentId: number,
@@ -15,12 +14,12 @@ export function startFileWatching(
   pollingTimers: Map<number, ReturnType<typeof setInterval>>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   // Primary: fs.watch (unreliable on macOS — may miss events)
   try {
     const watcher = fs.watch(filePath, () => {
-      readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
+      readNewLines(agentId, agents, waitingTimers, permissionTimers, sender);
     });
     fileWatchers.set(agentId, watcher);
   } catch (e) {
@@ -30,7 +29,7 @@ export function startFileWatching(
   // Secondary: fs.watchFile (stat-based polling, reliable on macOS)
   try {
     fs.watchFile(filePath, { interval: FILE_WATCHER_POLL_INTERVAL_MS }, () => {
-      readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
+      readNewLines(agentId, agents, waitingTimers, permissionTimers, sender);
     });
   } catch (e) {
     console.log(`[Pixel Agents] fs.watchFile failed for agent ${agentId}: ${e}`);
@@ -47,7 +46,7 @@ export function startFileWatching(
       }
       return;
     }
-    readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
+    readNewLines(agentId, agents, waitingTimers, permissionTimers, sender);
   }, FILE_WATCHER_POLL_INTERVAL_MS);
   pollingTimers.set(agentId, interval);
 }
@@ -57,7 +56,7 @@ export function readNewLines(
   agents: Map<number, AgentState>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   const agent = agents.get(agentId);
   if (!agent) return;
@@ -82,13 +81,13 @@ export function readNewLines(
       cancelPermissionTimer(agentId, permissionTimers);
       if (agent.permissionSent) {
         agent.permissionSent = false;
-        webview?.postMessage({ type: 'agentToolPermissionClear', id: agentId });
+        sender?.postMessage({ type: 'agentToolPermissionClear', id: agentId });
       }
     }
 
     for (const line of lines) {
       if (!line.trim()) continue;
-      processTranscriptLine(agentId, line, agents, waitingTimers, permissionTimers, webview);
+      processTranscriptLine(agentId, line, agents, waitingTimers, permissionTimers, sender);
     }
   } catch (e) {
     console.log(`[Pixel Agents] Read error for agent ${agentId}: ${e}`);
@@ -106,8 +105,9 @@ export function ensureProjectScan(
   pollingTimers: Map<number, ReturnType<typeof setInterval>>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   persistAgents: () => void,
+  getActiveTerminal?: () => TerminalHandle | null,
 ): void {
   if (projectScanTimerRef.current) return;
   // Seed with all existing JSONL files so we only react to truly new ones
@@ -134,8 +134,9 @@ export function ensureProjectScan(
       pollingTimers,
       waitingTimers,
       permissionTimers,
-      webview,
+      sender,
       persistAgents,
+      getActiveTerminal,
     );
   }, PROJECT_SCAN_INTERVAL_MS);
 }
@@ -150,8 +151,9 @@ function scanForNewJsonlFiles(
   pollingTimers: Map<number, ReturnType<typeof setInterval>>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   persistAgents: () => void,
+  getActiveTerminal?: () => TerminalHandle | null,
 ): void {
   let files: string[];
   try {
@@ -179,12 +181,12 @@ function scanForNewJsonlFiles(
           pollingTimers,
           waitingTimers,
           permissionTimers,
-          webview,
+          sender,
           persistAgents,
         );
       } else {
         // No active agent → try to adopt the focused terminal
-        const activeTerminal = vscode.window.activeTerminal;
+        const activeTerminal = getActiveTerminal?.() ?? null;
         if (activeTerminal) {
           let owned = false;
           for (const agent of agents.values()) {
@@ -205,7 +207,7 @@ function scanForNewJsonlFiles(
               pollingTimers,
               waitingTimers,
               permissionTimers,
-              webview,
+              sender,
               persistAgents,
             );
           }
@@ -216,7 +218,7 @@ function scanForNewJsonlFiles(
 }
 
 function adoptTerminalForFile(
-  terminal: vscode.Terminal,
+  terminal: TerminalHandle,
   jsonlFile: string,
   projectDir: string,
   nextAgentIdRef: { current: number },
@@ -226,7 +228,7 @@ function adoptTerminalForFile(
   pollingTimers: Map<number, ReturnType<typeof setInterval>>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   persistAgents: () => void,
 ): void {
   const id = nextAgentIdRef.current++;
@@ -254,7 +256,7 @@ function adoptTerminalForFile(
   console.log(
     `[Pixel Agents] Agent ${id}: adopted terminal "${terminal.name}" for ${path.basename(jsonlFile)}`,
   );
-  webview?.postMessage({ type: 'agentCreated', id });
+  sender?.postMessage({ type: 'agentCreated', id });
 
   startFileWatching(
     id,
@@ -264,9 +266,9 @@ function adoptTerminalForFile(
     pollingTimers,
     waitingTimers,
     permissionTimers,
-    webview,
+    sender,
   );
-  readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+  readNewLines(id, agents, waitingTimers, permissionTimers, sender);
 }
 
 export function reassignAgentToFile(
@@ -277,7 +279,7 @@ export function reassignAgentToFile(
   pollingTimers: Map<number, ReturnType<typeof setInterval>>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
   persistAgents: () => void,
 ): void {
   const agent = agents.get(agentId);
@@ -300,7 +302,7 @@ export function reassignAgentToFile(
   // Clear activity
   cancelWaitingTimer(agentId, waitingTimers);
   cancelPermissionTimer(agentId, permissionTimers);
-  clearAgentActivity(agent, agentId, permissionTimers, webview);
+  clearAgentActivity(agent, agentId, permissionTimers, sender);
 
   // Swap to new file
   agent.jsonlFile = newFilePath;
@@ -317,7 +319,7 @@ export function reassignAgentToFile(
     pollingTimers,
     waitingTimers,
     permissionTimers,
-    webview,
+    sender,
   );
-  readNewLines(agentId, agents, waitingTimers, permissionTimers, webview);
+  readNewLines(agentId, agents, waitingTimers, permissionTimers, sender);
 }

--- a/src/timerManager.ts
+++ b/src/timerManager.ts
@@ -1,13 +1,11 @@
-import type * as vscode from 'vscode';
-
 import { PERMISSION_TIMER_DELAY_MS } from './constants.js';
-import type { AgentState } from './types.js';
+import type { AgentState, MessageSender } from './types.js';
 
 export function clearAgentActivity(
   agent: AgentState | undefined,
   agentId: number,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   if (!agent) return;
   agent.activeToolIds.clear();
@@ -18,8 +16,8 @@ export function clearAgentActivity(
   agent.isWaiting = false;
   agent.permissionSent = false;
   cancelPermissionTimer(agentId, permissionTimers);
-  webview?.postMessage({ type: 'agentToolsClear', id: agentId });
-  webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+  sender?.postMessage({ type: 'agentToolsClear', id: agentId });
+  sender?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
 }
 
 export function cancelWaitingTimer(
@@ -38,7 +36,7 @@ export function startWaitingTimer(
   delayMs: number,
   agents: Map<number, AgentState>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   cancelWaitingTimer(agentId, waitingTimers);
   const timer = setTimeout(() => {
@@ -47,7 +45,7 @@ export function startWaitingTimer(
     if (agent) {
       agent.isWaiting = true;
     }
-    webview?.postMessage({
+    sender?.postMessage({
       type: 'agentStatus',
       id: agentId,
       status: 'waiting',
@@ -72,7 +70,7 @@ export function startPermissionTimer(
   agents: Map<number, AgentState>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionExemptTools: Set<string>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   cancelPermissionTimer(agentId, permissionTimers);
   const timer = setTimeout(() => {
@@ -105,13 +103,13 @@ export function startPermissionTimer(
     if (hasNonExempt) {
       agent.permissionSent = true;
       console.log(`[Pixel Agents] Agent ${agentId}: possible permission wait detected`);
-      webview?.postMessage({
+      sender?.postMessage({
         type: 'agentToolPermission',
         id: agentId,
       });
       // Also notify stuck sub-agents
       for (const parentToolId of stuckSubagentParentToolIds) {
-        webview?.postMessage({
+        sender?.postMessage({
           type: 'subagentToolPermission',
           id: agentId,
           parentToolId,

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import type * as vscode from 'vscode';
 
 import {
   BASH_COMMAND_DISPLAY_MAX_LENGTH,
@@ -14,7 +13,7 @@ import {
   startPermissionTimer,
   startWaitingTimer,
 } from './timerManager.js';
-import type { AgentState } from './types.js';
+import type { AgentState, MessageSender } from './types.js';
 
 export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'AskUserQuestion']);
 
@@ -62,7 +61,7 @@ export function processTranscriptLine(
   agents: Map<number, AgentState>,
   waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   const agent = agents.get(agentId);
   if (!agent) return;
@@ -82,7 +81,7 @@ export function processTranscriptLine(
         cancelWaitingTimer(agentId, waitingTimers);
         agent.isWaiting = false;
         agent.hadToolsInTurn = true;
-        webview?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
+        sender?.postMessage({ type: 'agentStatus', id: agentId, status: 'active' });
         let hasNonExemptTool = false;
         for (const block of blocks) {
           if (block.type === 'tool_use' && block.id) {
@@ -95,7 +94,7 @@ export function processTranscriptLine(
             if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
               hasNonExemptTool = true;
             }
-            webview?.postMessage({
+            sender?.postMessage({
               type: 'agentToolStart',
               id: agentId,
               toolId: block.id,
@@ -104,17 +103,17 @@ export function processTranscriptLine(
           }
         }
         if (hasNonExemptTool) {
-          startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
+          startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, sender);
         }
       } else if (blocks.some((b) => b.type === 'text') && !agent.hadToolsInTurn) {
         // Text-only response in a turn that hasn't used any tools.
         // turn_duration handles tool-using turns reliably but is never
         // emitted for text-only turns, so we use a silence-based timer:
         // if no new JSONL data arrives within TEXT_IDLE_DELAY_MS, mark as waiting.
-        startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, webview);
+        startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, sender);
       }
     } else if (record.type === 'progress') {
-      processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, webview);
+      processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, sender);
     } else if (record.type === 'user') {
       const content = record.message?.content;
       if (Array.isArray(content)) {
@@ -129,7 +128,7 @@ export function processTranscriptLine(
               if (agent.activeToolNames.get(completedToolId) === 'Task') {
                 agent.activeSubagentToolIds.delete(completedToolId);
                 agent.activeSubagentToolNames.delete(completedToolId);
-                webview?.postMessage({
+                sender?.postMessage({
                   type: 'subagentClear',
                   id: agentId,
                   parentToolId: completedToolId,
@@ -140,7 +139,7 @@ export function processTranscriptLine(
               agent.activeToolNames.delete(completedToolId);
               const toolId = completedToolId;
               setTimeout(() => {
-                webview?.postMessage({
+                sender?.postMessage({
                   type: 'agentToolDone',
                   id: agentId,
                   toolId,
@@ -156,13 +155,13 @@ export function processTranscriptLine(
         } else {
           // New user text prompt — new turn starting
           cancelWaitingTimer(agentId, waitingTimers);
-          clearAgentActivity(agent, agentId, permissionTimers, webview);
+          clearAgentActivity(agent, agentId, permissionTimers, sender);
           agent.hadToolsInTurn = false;
         }
       } else if (typeof content === 'string' && content.trim()) {
         // New user text prompt — new turn starting
         cancelWaitingTimer(agentId, waitingTimers);
-        clearAgentActivity(agent, agentId, permissionTimers, webview);
+        clearAgentActivity(agent, agentId, permissionTimers, sender);
         agent.hadToolsInTurn = false;
       }
     } else if (record.type === 'system' && record.subtype === 'turn_duration') {
@@ -176,13 +175,13 @@ export function processTranscriptLine(
         agent.activeToolNames.clear();
         agent.activeSubagentToolIds.clear();
         agent.activeSubagentToolNames.clear();
-        webview?.postMessage({ type: 'agentToolsClear', id: agentId });
+        sender?.postMessage({ type: 'agentToolsClear', id: agentId });
       }
 
       agent.isWaiting = true;
       agent.permissionSent = false;
       agent.hadToolsInTurn = false;
-      webview?.postMessage({
+      sender?.postMessage({
         type: 'agentStatus',
         id: agentId,
         status: 'waiting',
@@ -197,9 +196,9 @@ function processProgressRecord(
   agentId: number,
   record: Record<string, unknown>,
   agents: Map<number, AgentState>,
-  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  _waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
-  webview: vscode.Webview | undefined,
+  sender: MessageSender | undefined,
 ): void {
   const agent = agents.get(agentId);
   if (!agent) return;
@@ -215,7 +214,7 @@ function processProgressRecord(
   const dataType = data.type as string | undefined;
   if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
     if (agent.activeToolIds.has(parentToolId)) {
-      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
+      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, sender);
     }
     return;
   }
@@ -261,7 +260,7 @@ function processProgressRecord(
           hasNonExemptSubTool = true;
         }
 
-        webview?.postMessage({
+        sender?.postMessage({
           type: 'subagentToolStart',
           id: agentId,
           parentToolId,
@@ -271,7 +270,7 @@ function processProgressRecord(
       }
     }
     if (hasNonExemptSubTool) {
-      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
+      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, sender);
     }
   } else if (msgType === 'user') {
     for (const block of content) {
@@ -292,7 +291,7 @@ function processProgressRecord(
 
         const toolId = block.tool_use_id;
         setTimeout(() => {
-          webview?.postMessage({
+          sender?.postMessage({
             type: 'subagentToolDone',
             id: agentId,
             parentToolId,
@@ -314,7 +313,7 @@ function processProgressRecord(
       if (stillHasNonExempt) break;
     }
     if (stillHasNonExempt) {
-      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
+      startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, sender);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,18 @@
-import type * as vscode from 'vscode';
+/** Minimal postMessage interface satisfied by both vscode.Webview and Electron IPC */
+export interface MessageSender {
+  postMessage(message: unknown): void;
+}
+
+/** Minimal terminal interface satisfied by both vscode.Terminal and AgentHandle */
+export interface TerminalHandle {
+  name: string;
+  show(): void;
+  dispose(): void;
+}
 
 export interface AgentState {
   id: number;
-  terminalRef: vscode.Terminal;
+  terminalRef: TerminalHandle;
   projectDir: string;
   jsonlFile: string;
   fileOffset: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"webview-ui",
 		"dist",
 		"out",
-		"scripts"
+		"scripts",
+		"electron"
 	]
 }

--- a/webview-ui/src/electronApi.ts
+++ b/webview-ui/src/electronApi.ts
@@ -1,0 +1,24 @@
+declare global {
+  interface Window {
+    electronAPI?: {
+      postMessage(message: unknown): void;
+      onMessage(callback: (message: unknown) => void): void;
+      removeMessageListener(): void;
+    };
+  }
+}
+
+// Wire incoming IPC messages to the same DOM event useExtensionMessages.ts listens on:
+//   window.addEventListener('message', handler)  →  handler reads e.data
+if (window.electronAPI) {
+  window.electronAPI.onMessage((message: unknown) => {
+    window.dispatchEvent(new MessageEvent('message', { data: message }));
+  });
+}
+
+// Exact same export shape as vscodeApi.ts
+export const vscode = {
+  postMessage(msg: unknown): void {
+    window.electronAPI?.postMessage(msg);
+  },
+};

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -1,5 +1,8 @@
+import path from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+
+const isElectron = process.env.BUILD_TARGET === 'electron';
 
 export default defineConfig({
   plugins: [react()],
@@ -8,4 +11,14 @@ export default defineConfig({
     emptyOutDir: true,
   },
   base: './',
+  resolve: isElectron
+    ? {
+        alias: [
+          {
+            find: /^.*vscodeApi\.js$/,
+            replacement: path.resolve(__dirname, 'src/electronApi.ts'),
+          },
+        ],
+      }
+    : {},
 });


### PR DESCRIPTION
## Summary
- **Phase 1 — Electron Shell & IPC Bridge**: BrowserWindow, preload contextBridge, conditional Vite alias (`vscodeApi` → `electronApi`), esbuild config for main+preload
- **Phase 2 — Agent Lifecycle**: `AgentHandle` wrapping `child_process.spawn` for Claude sessions, `ProcessManager` replacing VS Code terminal management
- **Phase 3 — JSONL Watcher & Shared Types**: `MessageSender`/`TerminalHandle` interfaces decouple shared modules (`fileWatcher`, `transcriptParser`, `timerManager`, `assetLoader`) from VS Code APIs; `AppController` orchestrates ProcessManager, file watching, asset loading, layout persistence, and IPC for Electron

## Test plan
- [ ] VS Code extension builds and runs normally (`npm run build`, F5 launch)
- [ ] Electron app builds (`npm run build:electron`) and launches (`npm run start:electron`)
- [ ] Webview loads in Electron window and sends `webviewReady` IPC message
- [ ] "+ Agent" spawns a Claude child process and creates an agent character
- [ ] JSONL file watching detects tool_use/tool_result and animates characters
- [ ] Layout saves/loads persist across Electron app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)