### PR TITLE
feat: detect agents across all workspace folders in multi-root workspaces

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -27,14 +27,17 @@ import {
 } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
 import {
+  GLOBAL_KEY_ALWAYS_SHOW_LABELS,
   GLOBAL_KEY_LAST_SEEN_VERSION,
   GLOBAL_KEY_SOUND_ENABLED,
+  GLOBAL_KEY_WATCH_ALL_SESSIONS,
   LAYOUT_REVISION_KEY,
   WORKSPACE_KEY_AGENT_SEATS,
 } from './constants.js';
 import {
   dismissedJsonlFiles,
   ensureProjectScan,
+  isTrackedProjectDir,
   startExternalSessionScanning,
   startStaleExternalAgentCheck,
 } from './fileWatcher.js';
@@ -63,6 +66,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   // External session detection (VS Code extension panel, etc.)
   externalScanTimer: ReturnType<typeof setInterval> | null = null;
   staleCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+  // Global session scanning (opt-in "Watch All Sessions" toggle)
+  watchAllSessions = { current: false };
+  globalDismissedFiles = new Set<string>();
 
   // Bundled default layout (loaded from assets/default-layout.json)
   defaultLayout: Record<string, unknown> | null = null;
@@ -152,6 +159,51 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.context.globalState.update(GLOBAL_KEY_SOUND_ENABLED, message.enabled);
       } else if (message.type === 'setLastSeenVersion') {
         this.context.globalState.update(GLOBAL_KEY_LAST_SEEN_VERSION, message.version as string);
+      } else if (message.type === 'setAlwaysShowLabels') {
+        this.context.globalState.update(GLOBAL_KEY_ALWAYS_SHOW_LABELS, message.enabled);
+      } else if (message.type === 'setWatchAllSessions') {
+        const enabled = message.enabled as boolean;
+        this.context.globalState.update(GLOBAL_KEY_WATCH_ALL_SESSIONS, enabled);
+        this.watchAllSessions.current = enabled;
+        if (enabled) {
+          // Clear only toggle-specific dismissals so global agents can be re-adopted
+          for (const file of this.globalDismissedFiles) {
+            dismissedJsonlFiles.delete(file);
+          }
+          this.globalDismissedFiles.clear();
+        } else {
+          // Remove all external agents not from the current workspace folders
+          const workspaceDirs = new Set<string>();
+          for (const folder of vscode.workspace.workspaceFolders ?? []) {
+            const dir = getProjectDirPath(folder.uri.fsPath);
+            if (dir) workspaceDirs.add(dir);
+          }
+          const toRemove: number[] = [];
+          for (const [id, agent] of this.agents) {
+            if (agent.isExternal && !workspaceDirs.has(agent.projectDir)) {
+              toRemove.push(id);
+            }
+          }
+          for (const id of toRemove) {
+            const agent = this.agents.get(id);
+            if (agent) {
+              dismissedJsonlFiles.set(agent.jsonlFile, Date.now());
+              this.globalDismissedFiles.add(agent.jsonlFile);
+              this.knownJsonlFiles.delete(agent.jsonlFile);
+            }
+            removeAgent(
+              id,
+              this.agents,
+              this.fileWatchers,
+              this.pollingTimers,
+              this.waitingTimers,
+              this.permissionTimers,
+              this.jsonlPollTimers,
+              this.persistAgents,
+            );
+            this.webview?.postMessage({ type: 'agentClosed', id });
+          }
+        }
       } else if (message.type === 'webviewReady') {
         restoreAgents(
           this.context,
@@ -177,12 +229,23 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         );
         const extensionVersion =
           (this.context.extension.packageJSON as { version?: string }).version ?? '';
+        const watchAllSessions = this.context.globalState.get<boolean>(
+          GLOBAL_KEY_WATCH_ALL_SESSIONS,
+          false,
+        );
+        const alwaysShowLabels = this.context.globalState.get<boolean>(
+          GLOBAL_KEY_ALWAYS_SHOW_LABELS,
+          false,
+        );
+        this.watchAllSessions.current = watchAllSessions;
         const config = readConfig();
         this.webview?.postMessage({
           type: 'settingsLoaded',
           soundEnabled,
           lastSeenVersion,
           extensionVersion,
+          watchAllSessions,
+          alwaysShowLabels,
           externalAssetDirectories: config.externalAssetDirectories,
         });
 
@@ -229,6 +292,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.jsonlPollTimers,
             this.webview,
             this.persistAgents,
+            this.watchAllSessions,
           );
 
           // In multi-root workspaces, also scan project dirs for all other folders

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,14 @@ export const EXTERNAL_STALE_CHECK_INTERVAL_MS = 30_000;
  *  so the file's mtime becomes stale before the dismissal expires. */
 export const DISMISSED_COOLDOWN_MS = 180_000; // 3 minutes
 
+// ── Global Session Scanning (opt-in "Watch All Sessions" toggle) ──
+/** Only adopt global JSONL files larger than this (filters out empty/init-only sessions) */
+export const GLOBAL_SCAN_ACTIVE_MIN_SIZE = 3_072; // 3KB
+/** Only adopt global JSONL files modified within this window */
+export const GLOBAL_SCAN_ACTIVE_MAX_AGE_MS = 600_000; // 10 minutes
+/** VS Code globalState key for the Watch All Sessions toggle */
+export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
+
 // ── Display Truncation ──────────────────────────────────────
 export const BASH_COMMAND_DISPLAY_MAX_LENGTH = 30;
 export const TASK_DESCRIPTION_DISPLAY_MAX_LENGTH = 40;
@@ -33,6 +41,7 @@ export const LAYOUT_REVISION_KEY = 'layoutRevision';
 // ── Settings Persistence ────────────────────────────────────
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 export const GLOBAL_KEY_LAST_SEEN_VERSION = 'pixel-agents.lastSeenVersion';
+export const GLOBAL_KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -10,6 +11,8 @@ import {
   EXTERNAL_SCAN_INTERVAL_MS,
   EXTERNAL_STALE_CHECK_INTERVAL_MS,
   FILE_WATCHER_POLL_INTERVAL_MS,
+  GLOBAL_SCAN_ACTIVE_MAX_AGE_MS,
+  GLOBAL_SCAN_ACTIVE_MIN_SIZE,
   PROJECT_SCAN_INTERVAL_MS,
 } from './constants.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
@@ -189,6 +192,11 @@ export function readNewLines(
 
 // Track all project directories to scan (supports multi-root workspaces)
 const trackedProjectDirs = new Set<string>();
+
+/** Check if a project dir is tracked by the workspace scanner. */
+export function isTrackedProjectDir(dir: string): boolean {
+  return trackedProjectDirs.has(dir);
+}
 
 /**
  * Seed a project directory's known files and register it for periodic scanning.
@@ -456,15 +464,24 @@ function adoptExternalSession(
   permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
   webview: vscode.Webview | undefined,
   persistAgents: () => void,
+  folderName?: string,
 ): void {
   const id = nextAgentIdRef.current++;
+  // Skip to end of file -- only show live activity going forward, not replay history
+  let fileOffset = 0;
+  try {
+    const stat = fs.statSync(jsonlFile);
+    fileOffset = stat.size;
+  } catch {
+    /* start from beginning if stat fails */
+  }
   const agent: AgentState = {
     id,
     terminalRef: undefined,
     isExternal: true,
     projectDir,
     jsonlFile,
-    fileOffset: 0,
+    fileOffset,
     lineBuffer: '',
     activeToolIds: new Set(),
     activeToolStatuses: new Map(),
@@ -478,13 +495,16 @@ function adoptExternalSession(
     lastDataAt: Date.now(),
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
+    folderName,
   };
 
   agents.set(id, agent);
   persistAgents();
 
-  console.log(`[Pixel Agents] Agent ${id}: detected external session ${path.basename(jsonlFile)}`);
-  webview?.postMessage({ type: 'agentCreated', id, isExternal: true });
+  console.log(
+    `[Pixel Agents] Agent ${id}: detected external session ${path.basename(jsonlFile)}${folderName ? ` (${folderName})` : ''}`,
+  );
+  webview?.postMessage({ type: 'agentCreated', id, isExternal: true, folderName });
 
   startFileWatching(
     id,
@@ -515,76 +535,81 @@ export function startExternalSessionScanning(
   jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
   webview: vscode.Webview | undefined,
   persistAgents: () => void,
+  watchAllSessionsRef?: { current: boolean },
 ): ReturnType<typeof setInterval> {
   return setInterval(() => {
-    let files: string[];
-    try {
-      files = fs
-        .readdirSync(projectDir)
-        .filter((f) => f.endsWith('.jsonl'))
-        .map((f) => path.join(projectDir, f));
-    } catch {
-      return;
+    // Scan all tracked project dirs (multi-root workspace support)
+    for (const dir of trackedProjectDirs) {
+      scanExternalDir(
+        dir,
+        knownJsonlFiles,
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        webview,
+        persistAgents,
+      );
     }
+    // If "Watch All Sessions" is ON, also scan all global project dirs
+    if (watchAllSessionsRef?.current) {
+      scanGlobalProjectDirs(
+        knownJsonlFiles,
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        webview,
+        persistAgents,
+      );
+    }
+  }, EXTERNAL_SCAN_INTERVAL_MS);
+}
 
-    const now = Date.now();
+/** Scan a single project dir for external sessions. */
+function scanExternalDir(
+  projectDir: string,
+  knownJsonlFiles: Set<string>,
+  nextAgentIdRef: { current: number },
+  agents: Map<number, AgentState>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+): void {
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(projectDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => path.join(projectDir, f));
+  } catch {
+    return;
+  }
 
-    for (const file of files) {
-      // --resume detection: seeded files whose mtime changed have new data.
-      // Adopt directly, bypassing content check (old /clear files have
-      // /clear content but should still be adoptable when resumed).
-      // File stays in knownJsonlFiles (safe from per-agent /clear stealing).
-      const seededMtime = seededMtimes.get(file);
-      if (seededMtime !== undefined) {
-        try {
-          const stat = fs.statSync(file);
-          if (stat.mtimeMs <= seededMtime) continue; // No new writes, skip
-        } catch {
-          continue;
-        }
-        // mtime changed → --resume. Check not tracked, not dismissed.
-        if (clearDismissedFiles.has(file)) continue;
-        const normalizedFile = path.resolve(file);
-        let tracked = false;
-        for (const agent of agents.values()) {
-          if (path.resolve(agent.jsonlFile) === normalizedFile) {
-            tracked = true;
-            break;
-          }
-        }
-        if (tracked) continue;
-        seededMtimes.delete(file);
-        console.log(`[Pixel Agents] Resumed session detected: ${path.basename(file)}`);
-        adoptExternalSession(
-          file,
-          projectDir,
-          nextAgentIdRef,
-          agents,
-          fileWatchers,
-          pollingTimers,
-          waitingTimers,
-          permissionTimers,
-          webview,
-          persistAgents,
-        );
+  const now = Date.now();
+
+  for (const file of files) {
+    // --resume detection: seeded files whose mtime changed have new data.
+    // Adopt directly, bypassing content check (old /clear files have
+    // /clear content but should still be adoptable when resumed).
+    // File stays in knownJsonlFiles (safe from per-agent /clear stealing).
+    const seededMtime = seededMtimes.get(file);
+    if (seededMtime !== undefined) {
+      try {
+        const stat = fs.statSync(file);
+        if (stat.mtimeMs <= seededMtime) continue; // No new writes, skip
+      } catch {
         continue;
       }
-
-      // Skip files already known (seeded or adopted). seededMtimes handles --resume above.
-      if (knownJsonlFiles.has(file)) continue;
-
-      // Skip files permanently dismissed by /clear (never re-adopted)
+      // mtime changed → --resume. Check not tracked, not dismissed.
       if (clearDismissedFiles.has(file)) continue;
-
-      // Skip files recently dismissed by the user (closed via X).
-      // Dismissal expires after DISMISSED_COOLDOWN_MS so resumed sessions can be re-adopted.
-      const dismissedAt = dismissedJsonlFiles.get(file);
-      if (dismissedAt && now - dismissedAt < DISMISSED_COOLDOWN_MS) continue;
-      if (dismissedAt) dismissedJsonlFiles.delete(file); // Expired, clean up
-
-      // Check if already tracked by an agent (normalize paths for comparison).
-      // This prevents the external scanner from adopting /clear files (already
-      // reassigned to a terminal agent) while allowing untracked files through.
       const normalizedFile = path.resolve(file);
       let tracked = false;
       for (const agent of agents.values()) {
@@ -594,36 +619,8 @@ export function startExternalSessionScanning(
         }
       }
       if (tracked) continue;
-
-      // Only adopt recently-active files (modified within threshold).
-      try {
-        const stat = fs.statSync(file);
-        if (now - stat.mtimeMs > EXTERNAL_ACTIVE_THRESHOLD_MS) continue;
-      } catch {
-        continue;
-      }
-
-      // Content check with two-tick delay for /clear files:
-      // First tick: skip /clear files (give per-agent 3s to claim for internal /clear).
-      // Second tick: per-agent didn't claim → adopt as new external agent.
-      try {
-        const buf = Buffer.alloc(8192);
-        const fd = fs.openSync(file, 'r');
-        const bytesRead = fs.readSync(fd, buf, 0, 8192, 0);
-        fs.closeSync(fd);
-        if (buf.toString('utf-8', 0, bytesRead).includes('/clear</command-name>')) {
-          if (!pendingClearFiles.has(file)) {
-            pendingClearFiles.set(file, now);
-            continue; // First tick: skip, give per-agent a chance
-          }
-          pendingClearFiles.delete(file);
-          // Second tick: per-agent didn't claim → fall through to adopt
-        }
-      } catch {
-        continue;
-      }
-
-      knownJsonlFiles.add(file);
+      seededMtimes.delete(file);
+      console.log(`[Pixel Agents] Resumed session detected: ${path.basename(file)}`);
       adoptExternalSession(
         file,
         projectDir,
@@ -636,8 +633,156 @@ export function startExternalSessionScanning(
         webview,
         persistAgents,
       );
+      continue;
     }
-  }, EXTERNAL_SCAN_INTERVAL_MS);
+
+    // Skip files already known (seeded or adopted). seededMtimes handles --resume above.
+    if (knownJsonlFiles.has(file)) continue;
+
+    // Skip files permanently dismissed by /clear (never re-adopted)
+    if (clearDismissedFiles.has(file)) continue;
+
+    // Skip files recently dismissed by the user (closed via X).
+    // Dismissal expires after DISMISSED_COOLDOWN_MS so resumed sessions can be re-adopted.
+    const dismissedAt = dismissedJsonlFiles.get(file);
+    if (dismissedAt && now - dismissedAt < DISMISSED_COOLDOWN_MS) continue;
+    if (dismissedAt) dismissedJsonlFiles.delete(file); // Expired, clean up
+
+    // Check if already tracked by an agent (normalize paths for comparison).
+    // This prevents the external scanner from adopting /clear files (already
+    // reassigned to a terminal agent) while allowing untracked files through.
+    const normalizedFile = path.resolve(file);
+    let tracked = false;
+    for (const agent of agents.values()) {
+      if (path.resolve(agent.jsonlFile) === normalizedFile) {
+        tracked = true;
+        break;
+      }
+    }
+    if (tracked) continue;
+
+    // Only adopt recently-active files (modified within threshold).
+    try {
+      const stat = fs.statSync(file);
+      if (now - stat.mtimeMs > EXTERNAL_ACTIVE_THRESHOLD_MS) continue;
+    } catch {
+      continue;
+    }
+
+    // Content check with two-tick delay for /clear files:
+    // First tick: skip /clear files (give per-agent 3s to claim for internal /clear).
+    // Second tick: per-agent didn't claim → adopt as new external agent.
+    try {
+      const buf = Buffer.alloc(8192);
+      const fd = fs.openSync(file, 'r');
+      const bytesRead = fs.readSync(fd, buf, 0, 8192, 0);
+      fs.closeSync(fd);
+      if (buf.toString('utf-8', 0, bytesRead).includes('/clear</command-name>')) {
+        if (!pendingClearFiles.has(file)) {
+          pendingClearFiles.set(file, now);
+          continue; // First tick: skip, give per-agent a chance
+        }
+        pendingClearFiles.delete(file);
+        // Second tick: per-agent didn't claim → fall through to adopt
+      }
+    } catch {
+      continue;
+    }
+
+    knownJsonlFiles.add(file);
+    adoptExternalSession(
+      file,
+      projectDir,
+      nextAgentIdRef,
+      agents,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      webview,
+      persistAgents,
+    );
+  }
+}
+
+/** Derive a readable folder name from the Claude project dir hash. */
+function folderNameFromProjectDir(dirName: string): string {
+  const parts = dirName.replace(/^-+/, '').split('-');
+  return parts[parts.length - 1] || dirName;
+}
+
+/** Scan ALL ~/.claude/projects/ directories for active sessions (global discovery). */
+function scanGlobalProjectDirs(
+  knownJsonlFiles: Set<string>,
+  nextAgentIdRef: { current: number },
+  agents: Map<number, AgentState>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+): void {
+  const projectsRoot = path.join(os.homedir(), '.claude', 'projects');
+  let dirs: fs.Dirent[];
+  try {
+    dirs = fs.readdirSync(projectsRoot, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return;
+  }
+
+  const now = Date.now();
+  for (const dir of dirs) {
+    const dirPath = path.join(projectsRoot, dir.name);
+    // Skip directories already tracked by workspace scanning
+    if (trackedProjectDirs.has(dirPath)) continue;
+
+    let files: string[];
+    try {
+      files = fs
+        .readdirSync(dirPath)
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) => path.join(dirPath, f));
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (knownJsonlFiles.has(file)) continue;
+      let tracked = false;
+      for (const agent of agents.values()) {
+        if (agent.jsonlFile === file) {
+          tracked = true;
+          break;
+        }
+      }
+      if (tracked) continue;
+      // Activity filter: >3KB AND modified within 10 minutes
+      try {
+        const stat = fs.statSync(file);
+        if (stat.size < GLOBAL_SCAN_ACTIVE_MIN_SIZE) continue;
+        if (now - stat.mtimeMs > GLOBAL_SCAN_ACTIVE_MAX_AGE_MS) continue;
+      } catch {
+        continue;
+      }
+
+      const folderName = folderNameFromProjectDir(dir.name);
+      knownJsonlFiles.add(file);
+      adoptExternalSession(
+        file,
+        dirPath,
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        webview,
+        persistAgents,
+        folderName,
+      );
+    }
+  }
 }
 
 /**

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -153,6 +153,9 @@ function App() {
     externalAssetDirectories,
     lastSeenVersion,
     extensionVersion,
+    watchAllSessions,
+    setWatchAllSessions,
+    alwaysShowLabels,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -174,11 +177,19 @@ function App() {
     vscode.postMessage({ type: 'setLastSeenVersion', version: currentMajorMinor });
   }, [currentMajorMinor]);
 
+  // Sync alwaysShowOverlay from persisted settings
+  useEffect(() => {
+    setAlwaysShowOverlay(alwaysShowLabels);
+  }, [alwaysShowLabels]);
+
   const handleToggleDebugMode = useCallback(() => setIsDebugMode((prev) => !prev), []);
-  const handleToggleAlwaysShowOverlay = useCallback(
-    () => setAlwaysShowOverlay((prev) => !prev),
-    [],
-  );
+  const handleToggleAlwaysShowOverlay = useCallback(() => {
+    setAlwaysShowOverlay((prev) => {
+      const newVal = !prev;
+      vscode.postMessage({ type: 'setAlwaysShowLabels', enabled: newVal });
+      return newVal;
+    });
+  }, []);
 
   const handleSelectAgent = useCallback((id: number) => {
     vscode.postMessage({ type: 'focusAgent', id });
@@ -306,6 +317,12 @@ function App() {
         onToggleAlwaysShowOverlay={handleToggleAlwaysShowOverlay}
         workspaceFolders={workspaceFolders}
         externalAssetDirectories={externalAssetDirectories}
+        watchAllSessions={watchAllSessions}
+        onToggleWatchAllSessions={() => {
+          const newVal = !watchAllSessions;
+          setWatchAllSessions(newVal);
+          vscode.postMessage({ type: 'setWatchAllSessions', enabled: newVal });
+        }}
       />
 
       <VersionIndicator

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -14,6 +14,8 @@ interface BottomToolbarProps {
   onToggleAlwaysShowOverlay: () => void;
   workspaceFolders: WorkspaceFolder[];
   externalAssetDirectories: string[];
+  watchAllSessions: boolean;
+  onToggleWatchAllSessions: () => void;
 }
 
 const panelStyle: React.CSSProperties = {
@@ -57,6 +59,8 @@ export function BottomToolbar({
   onToggleAlwaysShowOverlay,
   workspaceFolders,
   externalAssetDirectories,
+  watchAllSessions,
+  onToggleWatchAllSessions,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -277,6 +281,8 @@ export function BottomToolbar({
           alwaysShowOverlay={alwaysShowOverlay}
           onToggleAlwaysShowOverlay={onToggleAlwaysShowOverlay}
           externalAssetDirectories={externalAssetDirectories}
+          watchAllSessions={watchAllSessions}
+          onToggleWatchAllSessions={onToggleWatchAllSessions}
         />
       </div>
     </div>

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -11,6 +11,8 @@ interface SettingsModalProps {
   alwaysShowOverlay: boolean;
   onToggleAlwaysShowOverlay: () => void;
   externalAssetDirectories: string[];
+  watchAllSessions: boolean;
+  onToggleWatchAllSessions: () => void;
 }
 
 const menuItemBase: React.CSSProperties = {
@@ -36,6 +38,8 @@ export function SettingsModal({
   alwaysShowOverlay,
   onToggleAlwaysShowOverlay,
   externalAssetDirectories,
+  watchAllSessions,
+  onToggleWatchAllSessions,
 }: SettingsModalProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
@@ -237,6 +241,35 @@ export function SettingsModal({
             }}
           >
             {soundLocal ? 'X' : ''}
+          </span>
+        </button>
+        <button
+          onClick={onToggleWatchAllSessions}
+          onMouseEnter={() => setHovered('watchAll')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...menuItemBase,
+            background: hovered === 'watchAll' ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+        >
+          <span>Watch All Sessions</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              border: '2px solid rgba(255, 255, 255, 0.5)',
+              borderRadius: 0,
+              background: watchAllSessions ? 'rgba(90, 140, 255, 0.8)' : 'transparent',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '12px',
+              lineHeight: 1,
+              color: '#fff',
+            }}
+          >
+            {watchAllSessions ? 'X' : ''}
           </span>
         </button>
         <button

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -60,6 +60,9 @@ export interface ExtensionMessageState {
   externalAssetDirectories: string[];
   lastSeenVersion: string;
   extensionVersion: string;
+  watchAllSessions: boolean;
+  setWatchAllSessions: (v: boolean) => void;
+  alwaysShowLabels: boolean;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -93,6 +96,8 @@ export function useExtensionMessages(
   const [externalAssetDirectories, setExternalAssetDirectories] = useState<string[]>([]);
   const [lastSeenVersion, setLastSeenVersion] = useState('');
   const [extensionVersion, setExtensionVersion] = useState('');
+  const [watchAllSessions, setWatchAllSessions] = useState(false);
+  const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -390,6 +395,12 @@ export function useExtensionMessages(
       } else if (msg.type === 'settingsLoaded') {
         const soundOn = msg.soundEnabled as boolean;
         setSoundEnabled(soundOn);
+        if (typeof msg.watchAllSessions === 'boolean') {
+          setWatchAllSessions(msg.watchAllSessions as boolean);
+        }
+        if (typeof msg.alwaysShowLabels === 'boolean') {
+          setAlwaysShowLabels(msg.alwaysShowLabels as boolean);
+        }
         if (Array.isArray(msg.externalAssetDirectories)) {
           setExternalAssetDirectories(msg.externalAssetDirectories as string[]);
         }
@@ -435,5 +446,8 @@ export function useExtensionMessages(
     externalAssetDirectories,
     lastSeenVersion,
     extensionVersion,
+    watchAllSessions,
+    setWatchAllSessions,
+    alwaysShowLabels,
   };
 }


### PR DESCRIPTION
## Motivation

VS Code's [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) let users open multiple project folders in a single window. Claude Code writes JSONL transcripts to a directory based on the workspace path — so each folder gets its own project directory under `~/.claude/projects/`.

This PR combines the multi-workspace scanning from with global session discovery inspired by #103.    
                                                                       
  **Multi-workspace scanning:** VS Code's multi-root workspaces let users open multiple project folders in a single window. Claude Code writes JSONL transcripts to a directory  based on the workspace path, so each folder gets its own project directory under ~/.claude/projects/. Previously, ensureProjectScan only registered the first workspace folder's project directory. Agents in other folders were never detected.                                                                                                                   
                  
  **Example:** User has ~/frontend and ~/backend open as a multi-root workspace. They start Claude in ~/backend, the agent works fine but never appears in the Pixel Agents panel because only ~/frontend's project dir is scanned.
                                                                                                                                                                                    
  Global session scanning (#103): Users running Claude Code in external terminals, tmux sessions, or the VS Code extension panel had no way to see those agents in the office. This adds an opt-in "Watch All Sessions" toggle that scans ALL ~/.claude/projects/ directories, showing every active Claude session on the machine as a character.

## Changes
                                                                                                                                                                                    
  ### `src/fileWatcher.ts`
  - `ensureProjectScan` now maintains a module-level `Set<string>` of tracked project directories
  - The shared interval timer iterates over **all** tracked dirs instead of just one                                                                                                
  - New `scanGlobalProjectDirs()` scans all `~/.claude/projects/` directories, skipping already-tracked workspace dirs                                                              
  - New `folderNameFromProjectDir()` derives a display name from the Claude project dir hash                                                                                        
  - `startExternalSessionScanning()` accepts `watchAllSessionsRef` and conditionally calls global scan each tick
                                                                                                                                                                                    
  ### `src/PixelAgentsViewProvider.ts`
  - On `webviewReady`, registers project dirs for **all** workspace folders (not just the first)                                                                                    
  - `setWatchAllSessions` message handler: ON clears toggle dismissals, OFF removes non-workspace agents
  - `setAlwaysShowLabels` message handler for settings persistence                                                                                                                  
  - `settingsLoaded` now includes `watchAllSessions` and `alwaysShowLabels`  

 ## Backward compatibility

  > [!IMPORTANT]
  > Watch All Sessions is **off by default**. No behavior changes unless the user explicitly opts in.
                                                                                                                                                                                    
  - **Single-folder workspaces:** No behavior change, one dir is registered and scanned as before                                                                                   
  - **No workspace open:** No behavior change, the extension handles `null` project dir gracefully                                                                                  
  - **Multi-folder workspaces:** All folders' project dirs are now scanned                                                                                                          
  - The `ensureProjectScan` function signature is unchanged, existing callers in `agentManager.ts` work without modification

Relation to previous PRs
Issues: Closes #30
PRs: Supersedes #103, supersedes #157

 ## Test plan
                                                                                                                                                                                    
  - [ ] **Single-root workspace:** Verify agents are detected as before (no regression)
  - [ ] **Multi-root workspace:** Create one with 2+ folders (`File > Add Folder to Workspace`)
  - [ ] Start Claude Code in each folder, verify all agents appear                                                                                                                  
  - [ ] Check Developer Console for `[Pixel Agents] Registering additional project dir:` log messages
  - [ ] **Watch All Sessions OFF (default):** Only workspace agents visible                                                                                                         
  - [ ] **Watch All Sessions ON:** Agents from other projects appear within ~3s with folder name labels                                                                             
  - [ ] Start `claude` in an external terminal for a different project: character appears
  - [ ] **Toggle OFF:** All global agents removed immediately                                                                                                                       
  - [ ] **Toggle ON again:** Global agents re-adopted
  - [ ] **Settings persist:** Watch All Sessions and Always Show Labels survive F5 restart                                                                                          
  - [ ] Remove a folder from the workspace, verify existing agents continue working
                                                                                                                                       
  > [!TIP]        
  > To test global scanning: open a separate terminal outside VS Code, `cd` into a different project, and run `claude`. With "Watch All Sessions" enabled, the agent should appear in the office within ~3 seconds. 