### PR TITLE
chore: add always show overlay as setting

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -140,8 +140,13 @@ function App() {
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   const [isDebugMode, setIsDebugMode] = useState(false);
+  const [alwaysShowOverlay, setAlwaysShowOverlay] = useState(false);
 
   const handleToggleDebugMode = useCallback(() => setIsDebugMode((prev) => !prev), []);
+  const handleToggleAlwaysShowOverlay = useCallback(
+    () => setAlwaysShowOverlay((prev) => !prev),
+    [],
+  );
 
   const handleSelectAgent = useCallback((id: number) => {
     vscode.postMessage({ type: 'focusAgent', id });
@@ -264,6 +269,8 @@ function App() {
         onToggleEditMode={editor.handleToggleEditMode}
         isDebugMode={isDebugMode}
         onToggleDebugMode={handleToggleDebugMode}
+        alwaysShowOverlay={alwaysShowOverlay}
+        onToggleAlwaysShowOverlay={handleToggleAlwaysShowOverlay}
         workspaceFolders={workspaceFolders}
       />
 
@@ -330,6 +337,7 @@ function App() {
         zoom={editor.zoom}
         panRef={editor.panRef}
         onCloseAgent={handleCloseAgent}
+        alwaysShowOverlay={alwaysShowOverlay}
       />
 
       {isDebugMode && (

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -10,6 +10,8 @@ interface BottomToolbarProps {
   onToggleEditMode: () => void;
   isDebugMode: boolean;
   onToggleDebugMode: () => void;
+  alwaysShowOverlay: boolean;
+  onToggleAlwaysShowOverlay: () => void;
   workspaceFolders: WorkspaceFolder[];
 }
 
@@ -50,6 +52,8 @@ export function BottomToolbar({
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
+  alwaysShowOverlay,
+  onToggleAlwaysShowOverlay,
   workspaceFolders,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null);
@@ -185,6 +189,8 @@ export function BottomToolbar({
           onClose={() => setIsSettingsOpen(false)}
           isDebugMode={isDebugMode}
           onToggleDebugMode={onToggleDebugMode}
+          alwaysShowOverlay={alwaysShowOverlay}
+          onToggleAlwaysShowOverlay={onToggleAlwaysShowOverlay}
         />
       </div>
     </div>

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -8,6 +8,8 @@ interface SettingsModalProps {
   onClose: () => void;
   isDebugMode: boolean;
   onToggleDebugMode: () => void;
+  alwaysShowOverlay: boolean;
+  onToggleAlwaysShowOverlay: () => void;
 }
 
 const menuItemBase: React.CSSProperties = {
@@ -30,6 +32,8 @@ export function SettingsModal({
   onClose,
   isDebugMode,
   onToggleDebugMode,
+  alwaysShowOverlay,
+  onToggleAlwaysShowOverlay,
 }: SettingsModalProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
@@ -172,6 +176,35 @@ export function SettingsModal({
             }}
           >
             {soundLocal ? 'X' : ''}
+          </span>
+        </button>
+        <button
+          onClick={onToggleAlwaysShowOverlay}
+          onMouseEnter={() => setHovered('overlay')}
+          onMouseLeave={() => setHovered(null)}
+          style={{
+            ...menuItemBase,
+            background: hovered === 'overlay' ? 'rgba(255, 255, 255, 0.08)' : 'transparent',
+          }}
+        >
+          <span>Always Show Labels</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              border: '2px solid rgba(255, 255, 255, 0.5)',
+              borderRadius: 0,
+              background: alwaysShowOverlay ? 'rgba(90, 140, 255, 0.8)' : 'transparent',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '12px',
+              lineHeight: 1,
+              color: '#fff',
+            }}
+          >
+            {alwaysShowOverlay ? 'X' : ''}
           </span>
         </button>
         <button

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -15,6 +15,7 @@ interface ToolOverlayProps {
   zoom: number;
   panRef: React.RefObject<{ x: number; y: number }>;
   onCloseAgent: (id: number) => void;
+  alwaysShowOverlay: boolean;
 }
 
 /** Derive a short human-readable activity string from tools/status */
@@ -50,6 +51,7 @@ export function ToolOverlay({
   zoom,
   panRef,
   onCloseAgent,
+  alwaysShowOverlay,
 }: ToolOverlayProps) {
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -90,8 +92,8 @@ export function ToolOverlay({
         const isHovered = hoveredId === id;
         const isSub = ch.isSubagent;
 
-        // Only show for hovered or selected agents
-        if (!isSelected && !isHovered) return null;
+        // Only show for hovered or selected agents (unless always-show is on)
+        if (!alwaysShowOverlay && !isSelected && !isHovered) return null;
 
         // Position above character
         const sittingOffset = ch.state === CharacterState.TYPE ? CHARACTER_SITTING_OFFSET_PX : 0;


### PR DESCRIPTION
## Summary


- Added `alwaysShowOverlay` boolean state to `App.tsx`, wired through `BottomToolbar` → `SettingsModal` → `OfficeCanvas` → `ToolOverlay`
- Added a checkbox in `SettingsModal` to toggle the setting (follows the same pattern as the existing Debug Mode toggle)
- `ToolOverlay` now renders permanently when `alwaysShowOverlay` is `true`, regardless of hover or selection state

Closes #106 

## Files changed

| File | Change |
|---|---|
| `webview-ui/src/App.tsx` | Added `alwaysShowOverlay` state + `handleToggleAlwaysShowOverlay` callback; passed props down |
| `webview-ui/src/components/BottomToolbar.tsx` | Added `alwaysShowOverlay` / `onToggleAlwaysShowOverlay` to props and forwarded to `SettingsModal` |
| `webview-ui/src/components/SettingsModal.tsx` | Added checkbox UI for the new setting |
| `webview-ui/src/office/components/ToolOverlay.tsx` | Reads `alwaysShowOverlay` prop; shows overlay unconditionally when true |

## How to test

1. Open Pixel Agents in VS Code
2. Open Settings (gear icon in bottom toolbar)
3. Check **"Always Show Overlay"**
4. Confirm that all active agent status labels are permanently visible without hovering
5. Uncheck the setting — confirm overlays return to hover-only behavior

## Notes

- No backend changes; this is purely a webview/UI setting
- Follows existing pixel art UI styling conventions (no style changes needed)
- Build passes: `npm run build` completes with no type errors or lint warnings
