### PR TITLE
ci: add GitHub Actions workflow for build, lint, and audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install webview dependencies
+        run: npm ci
+        working-directory: webview-ui
+
+      - name: Lint
+        run: npm run lint && npm run lint:webview
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit root
+        run: npm audit --audit-level=high
+
+      - name: Audit webview
+        run: npm audit --audit-level=high
+        working-directory: webview-ui


### PR DESCRIPTION
## Summary

This repo currently has no CI. This PR adds a basic GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on every push and PR to `main`.

**What it checks:**
- **Lint** — `eslint` on both `src/` and `webview-ui/` via `npm run lint && npm run lint:webview`
- **Build** — full type-check + esbuild (extension) + Vite (webview) via `npm run build`
- **Security audit** — `npm audit --audit-level=high` on both root and `webview-ui`

The audit threshold is set to `high` to filter known false-positive moderate advisories (e.g. `ajv` ReDoS and `minimatch` — actual installed versions are already patched, the advisory version range descriptions are inaccurate). High/critical issues will still fail the build.

## Test plan

- [ ] Workflow file parses correctly (no YAML syntax errors)
- [ ] CI passes on this PR itself once merged
- [ ] Future PRs that break the build or introduce lint errors will be caught automatically