### PR TITLE
docs: add issue templates, PR template, and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: "Bug report"
+description: "Report a bug to help us improve Pixel Agents."
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the bug"
+      description: "A clear and concise description of what the bug is."
+      placeholder: "e.g., Characters freeze after switching terminals."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "Steps to reproduce"
+      description: "List exact steps to reproduce the behavior."
+      placeholder: |
+        1. Open Pixel Agents panel
+        2. Click '+ Agent'
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behavior"
+      description: "What should happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behavior"
+      description: "What happens instead? Include any error messages."
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "Screenshots / GIFs"
+      description: "If applicable, add screenshots or screen recordings."
+
+  - type: input
+    id: vscode-version
+    attributes:
+      label: "VS Code version"
+      description: "Run 'Help > About' to find your version."
+      placeholder: "e.g., 1.109.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: "Operating System"
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs"
+      description: "Open Developer Tools (Help > Toggle Developer Tools) and paste any relevant console output."
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Feature request"
+    url: "https://github.com/pablodelucca/pixel-agents/discussions/categories/ideas"
+    about: "Suggest new features or ideas in Discussions."
+  - name: "Question"
+    url: "https://github.com/pablodelucca/pixel-agents/discussions/categories/q-a"
+    about: "Ask questions and get help in Discussions."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Description
+<!-- What does this PR do and why? -->
+
+## Type of change
+<!-- Check the one that applies -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code cleanup
+- [ ] Documentation
+- [ ] CI / build
+- [ ] Other: ___
+
+## Related issues
+<!-- Link related issues: Closes #123, Fixes #456 -->
+
+## Screenshots / GIFs
+<!-- Required for UI changes. Delete this section if not applicable. -->
+
+## Test plan
+<!-- Check what applies, add your own test steps -->
+- [ ] PR targets `main` branch
+- [ ] `npm run build` passes locally
+- [ ] Tested in Extension Development Host (F5)
+- [ ] No inline constants (all in `src/constants.ts` or `webview-ui/src/constants.ts`)
+- [ ] UI follows pixel art style (sharp corners, solid borders, pixel font)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,16 +91,15 @@ These rules are set to `warn` — they won't block your PR but will flag violati
 
 ## Reporting Bugs
 
-[Open an issue](https://github.com/pablodelucca/pixel-agents/issues) with:
-
-- What you expected to happen
-- What actually happened
-- Steps to reproduce
-- VS Code version and OS
+[Open a bug report](https://github.com/pablodelucca/pixel-agents/issues/new?template=bug_report.yml) — the form will guide you through providing the details we need.
 
 ## Feature Requests
 
-Have an idea? [Open an issue](https://github.com/pablodelucca/pixel-agents/issues) to discuss it before building. This helps avoid duplicate work and ensures the feature fits the project's direction.
+Have an idea? [Start a discussion](https://github.com/pablodelucca/pixel-agents/discussions/categories/ideas) in the Ideas category. We love hearing new ideas, and discussing them first helps us collaborate on the best approach together.
+
+## Security Issues
+
+Please report security vulnerabilities privately — see [SECURITY.md](SECURITY.md) for details.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through [GitHub's private vulnerability reporting](https://github.com/pablodelucca/pixel-agents/security/advisories/new).
+
+**Do not open a public issue for security vulnerabilities.**
+
+We will acknowledge your report within 7 days and aim to release a fix within 30 days of confirmation.
+
+## Scope
+
+Security issues relevant to this project include:
+
+- Command injection via terminal spawning or JSONL parsing
+- Arbitrary file read/write beyond intended paths
+- Cross-site scripting (XSS) in the webview
+- Sensitive data exposure (e.g., leaking terminal output or session content)


### PR DESCRIPTION
## Summary
  - Add structured GitHub issue templates (bug report with YAML form)
  - Add pull request template with checklist
  - Add SECURITY.md with vulnerability reporting guidelines
  - Update CONTRIBUTING.md with updated contribution workflow

## Test plan
  - [ ] Verify bug report template renders correctly on GitHub (New Issue page)
  - [ ] Verify PR template auto-populates when opening a new PR
  - [ ] Confirm SECURITY.md is linked from GitHub's Security tab