### PR TITLE
chore: fix README badges and add community links

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,68 @@
+name: Update Badge Stats
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-badges:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch VS Code Marketplace stats
+        id: vscode
+        run: |
+          RESPONSE=$(curl -s -X POST \
+            'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json;api-version=7.2-preview.1' \
+            -d '{
+              "filters": [{
+                "criteria": [{"filterType": 7, "value": "pablodelucca.pixel-agents"}]
+              }],
+              "flags": 914
+            }')
+          INSTALLS=$(echo "$RESPONSE" | jq '[.results[0].extensions[0].statistics[] | select(.statisticName == "install") | .value][0] // 0 | floor')
+          VERSION=$(echo "$RESPONSE" | jq -r '.results[0].extensions[0].versions[0].version // "unknown"')
+          echo "installs=$INSTALLS" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch Open VSX stats
+        id: openvsx
+        run: |
+          DOWNLOADS=$(curl -s 'https://open-vsx.org/api/pablodelucca/pixel-agents' | jq '.downloadCount // 0')
+          echo "downloads=$DOWNLOADS" >> "$GITHUB_OUTPUT"
+
+      - name: Format install count
+        id: format
+        run: |
+          TOTAL=$(( ${{ steps.vscode.outputs.installs }} + ${{ steps.openvsx.outputs.downloads }} ))
+          if [ "$TOTAL" -ge 1000 ]; then
+            MSG="$(awk "BEGIN {printf \"%.1f\", $TOTAL / 1000}")k installs"
+          else
+            MSG="$TOTAL installs"
+          fi
+          echo "message=$MSG" >> "$GITHUB_OUTPUT"
+
+      - name: Update version badge in gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.GIST_ID }}
+          filename: version.json
+          label: version
+          message: v${{ steps.vscode.outputs.version }}
+          color: '0183ff'
+          namedLogo: visualstudiocode
+          logoColor: white
+
+      - name: Update installs badge in gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ secrets.GIST_ID }}
+          filename: installs.json
+          label: marketplaces
+          message: ${{ steps.format.outputs.message }}
+          color: '0183ff'

--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@
 
 <div align="center" style="margin-top: 25px;">
 
-[![vscode-version](https://img.shields.io/visual-studio-marketplace/v/pablodelucca.pixel-agents?logo=visualstudiocode&color=0183ff)](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents)
-[![installs](https://img.shields.io/visual-studio-marketplace/i/pablodelucca.pixel-agents?color=0183ff&style=flat)](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents)
+[![version](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fpablodelucca%2F3cd28398fa4a2c0a636e1d51d41aee39%2Fraw%2Fversion.json)](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents)
+[![marketplaces](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fpablodelucca%2F3cd28398fa4a2c0a636e1d51d41aee39%2Fraw%2Finstalls.json)](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents)
 [![stars](https://img.shields.io/github/stars/pablodelucca/pixel-agents?logo=github&color=0183ff&style=flat)](https://github.com/pablodelucca/pixel-agents/stargazers)
 [![license](https://img.shields.io/github/license/pablodelucca/pixel-agents?color=0183ff&style=flat)](https://github.com/pablodelucca/pixel-agents/blob/main/LICENSE)
+[![good first issues](https://img.shields.io/github/issues/pablodelucca/pixel-agents/good%20first%20issue?color=7057ff&label=good%20first%20issues)](https://github.com/pablodelucca/pixel-agents/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 
 </div>
 
 <div align="center">
-<a href="https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents">🛒 VS Code Marketplace</a> • <a href="https://github.com/pablodelucca/pixel-agents/discussions">💬 Discussions</a> • <a href="https://github.com/pablodelucca/pixel-agents/issues">🐛 Issues</a> • <a href="CONTRIBUTING.md">🤝 Contributing</a>
+<a href="https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents">🛒 VS Code Marketplace</a> • <a href="https://github.com/pablodelucca/pixel-agents/discussions">💬 Discussions</a> • <a href="https://github.com/pablodelucca/pixel-agents/issues">🐛 Issues</a> • <a href="CONTRIBUTING.md">🤝 Contributing</a> • <a href="CHANGELOG.md">📋 Changelog</a>
 </div>
 
 <br/>


### PR DESCRIPTION
## Description
Add GitHub Action for reliable README badges + community links

Replace flaky shields.io VS Marketplace badges (chronic rate limiting) with gist-based endpoint badges updated daily via GitHub Action.
Combined install count from VS Code Marketplace + Open VSX shown as single "marketplaces" badge. Add good first issues badge and changelog link to boost community engagement.

## Type of change
<!-- Check the one that applies -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / build
- [ ] Other: ___

## Test plan
<!-- Check what applies, add your own test steps -->
- [x] PR targets `main` branch
 - [ ] Badge JSON files render correctly via shields.io endpoint
  - [ ] GitHub Action runs successfully via workflow_dispatch
  - [x] Gist secrets (GIST_ID, GIST_SECRET) configured