### PR TITLE
Open agent in a specific folder

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -93,7 +93,21 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           this.webview,
           this.persistAgents,
           message.folderPath as string | undefined,
+          message.agentName as string | undefined,
         );
+      } else if (message.type === 'browseFolderForAgent') {
+        const result = await vscode.window.showOpenDialog({
+          canSelectFiles: false,
+          canSelectFolders: true,
+          canSelectMany: false,
+          openLabel: 'Select Folder',
+        });
+        if (result && result.length > 0) {
+          this.webview?.postMessage({
+            type: 'agentFolderChosen',
+            path: result[0].fsPath,
+          });
+        }
       } else if (message.type === 'focusAgent') {
         const agent = this.agents.get(message.id);
         if (agent) {
@@ -134,9 +148,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
         this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
 
-        // Send workspace folders to webview (only when multi-root)
+        // Send workspace folders to webview
         const wsFolders = vscode.workspace.workspaceFolders;
-        if (wsFolders && wsFolders.length > 1) {
+        if (wsFolders && wsFolders.length > 0) {
           this.webview?.postMessage({
             type: 'workspaceFolders',
             folders: wsFolders.map((f) => ({ name: f.name, path: f.uri.fsPath })),

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -38,13 +38,14 @@ export async function launchNewTerminal(
   webview: vscode.Webview | undefined,
   persistAgents: () => void,
   folderPath?: string,
+  agentName?: string,
 ): Promise<void> {
   const folders = vscode.workspace.workspaceFolders;
   const cwd = folderPath || folders?.[0]?.uri.fsPath;
   const isMultiRoot = !!(folders && folders.length > 1);
   const idx = nextTerminalIndexRef.current++;
   const terminal = vscode.window.createTerminal({
-    name: `${TERMINAL_NAME_PREFIX} #${idx}`,
+    name: agentName ?? `${TERMINAL_NAME_PREFIX} #${idx}`,
     cwd,
   });
   terminal.show();
@@ -81,13 +82,14 @@ export async function launchNewTerminal(
     permissionSent: false,
     hadToolsInTurn: false,
     folderName,
+    agentName,
   };
 
   agents.set(id, agent);
   activeAgentIdRef.current = id;
   persistAgents();
   console.log(`[Pixel Agents] Agent ${id}: created for terminal ${terminal.name}`);
-  webview?.postMessage({ type: 'agentCreated', id, folderName });
+  webview?.postMessage({ type: 'agentCreated', id, folderName, agentName });
 
   ensureProjectScan(
     projectDir,
@@ -187,6 +189,7 @@ export function persistAgents(
       jsonlFile: agent.jsonlFile,
       projectDir: agent.projectDir,
       folderName: agent.folderName,
+      agentName: agent.agentName,
     });
   }
   context.workspaceState.update(WORKSPACE_KEY_AGENTS, persisted);
@@ -236,6 +239,7 @@ export function restoreAgents(
       permissionSent: false,
       hadToolsInTurn: false,
       folderName: p.folderName,
+      agentName: p.agentName,
     };
 
     agents.set(p.id, agent);
@@ -346,11 +350,15 @@ export function sendExistingAgents(
     Record<string, { palette?: number; seatId?: string }>
   >(WORKSPACE_KEY_AGENT_SEATS, {});
 
-  // Include folderName per agent
+  // Include folderName and agentName per agent
   const folderNames: Record<number, string> = {};
+  const agentNames: Record<number, string> = {};
   for (const [id, agent] of agents) {
     if (agent.folderName) {
       folderNames[id] = agent.folderName;
+    }
+    if (agent.agentName) {
+      agentNames[id] = agent.agentName;
     }
   }
   console.log(
@@ -362,6 +370,7 @@ export function sendExistingAgents(
     agents: agentIds,
     agentMeta,
     folderNames,
+    agentNames,
   });
 
   sendCurrentAgentStatuses(agents, webview);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface AgentState {
   hadToolsInTurn: boolean;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** User-provided display name for the agent */
+  agentName?: string;
 }
 
 export interface PersistedAgent {
@@ -26,4 +28,6 @@ export interface PersistedAgent {
   projectDir: string;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** User-provided display name for the agent */
+  agentName?: string;
 }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -271,7 +271,6 @@ function App() {
 
       <BottomToolbar
         isEditMode={editor.isEditMode}
-        onOpenClaude={editor.handleOpenClaude}
         onToggleEditMode={editor.handleToggleEditMode}
         isDebugMode={isDebugMode}
         onToggleDebugMode={handleToggleDebugMode}

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -6,7 +6,6 @@ import { SettingsModal } from './SettingsModal.js';
 
 interface BottomToolbarProps {
   isEditMode: boolean;
-  onOpenClaude: () => void;
   onToggleEditMode: () => void;
   isDebugMode: boolean;
   onToggleDebugMode: () => void;
@@ -46,9 +45,54 @@ const btnActive: React.CSSProperties = {
   border: '2px solid var(--pixel-accent)',
 };
 
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 'var(--pixel-modal-z)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,0,0,0.5)',
+};
+
+const modalStyle: React.CSSProperties = {
+  background: 'var(--pixel-bg)',
+  border: '2px solid var(--pixel-border)',
+  borderRadius: 0,
+  boxShadow: '4px 4px 0px #0a0a14',
+  padding: '16px 20px',
+  minWidth: 300,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '18px',
+  color: 'var(--pixel-text-dim)',
+  display: 'block',
+  marginBottom: 4,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '5px 8px',
+  fontSize: '20px',
+  background: 'var(--pixel-input-bg, #2a2a3e)',
+  border: '2px solid var(--pixel-border)',
+  borderRadius: 0,
+  color: 'var(--pixel-text)',
+  boxSizing: 'border-box',
+};
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 6,
+  alignItems: 'center',
+};
+
 export function BottomToolbar({
   isEditMode,
-  onOpenClaude,
   onToggleEditMode,
   isDebugMode,
   onToggleDebugMode,
@@ -58,98 +102,76 @@ export function BottomToolbar({
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [isFolderPickerOpen, setIsFolderPickerOpen] = useState(false);
-  const [hoveredFolder, setHoveredFolder] = useState<number | null>(null);
-  const folderPickerRef = useRef<HTMLDivElement>(null);
+  const [isAgentModalOpen, setIsAgentModalOpen] = useState(false);
+  const [agentName, setAgentName] = useState('');
+  const [folderPath, setFolderPath] = useState('');
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
-  // Close folder picker on outside click
-  useEffect(() => {
-    if (!isFolderPickerOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (folderPickerRef.current && !folderPickerRef.current.contains(e.target as Node)) {
-        setIsFolderPickerOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [isFolderPickerOpen]);
+  // Default folder path when modal opens
+  const defaultFolder = workspaceFolders[0]?.path ?? '';
 
-  const hasMultipleFolders = workspaceFolders.length > 1;
-
-  const handleAgentClick = () => {
-    if (hasMultipleFolders) {
-      setIsFolderPickerOpen((v) => !v);
-    } else {
-      onOpenClaude();
-    }
+  const openModal = () => {
+    setAgentName('');
+    setFolderPath(defaultFolder);
+    setIsAgentModalOpen(true);
   };
 
-  const handleFolderSelect = (folder: WorkspaceFolder) => {
-    setIsFolderPickerOpen(false);
-    vscode.postMessage({ type: 'openClaude', folderPath: folder.path });
+  // Focus name input when modal opens
+  useEffect(() => {
+    if (isAgentModalOpen) {
+      setTimeout(() => nameInputRef.current?.focus(), 50);
+    }
+  }, [isAgentModalOpen]);
+
+  // Listen for folder chosen from extension
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type === 'agentFolderChosen') {
+        setFolderPath(e.data.path as string);
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  const handleBrowse = () => {
+    vscode.postMessage({ type: 'browseFolderForAgent' });
+  };
+
+  const handleSubmit = () => {
+    if (!folderPath.trim()) return;
+    vscode.postMessage({
+      type: 'openClaude',
+      folderPath: folderPath.trim(),
+      agentName: agentName.trim() || undefined,
+    });
+    setIsAgentModalOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSubmit();
+    if (e.key === 'Escape') setIsAgentModalOpen(false);
   };
 
   return (
     <div style={panelStyle}>
-      <div ref={folderPickerRef} style={{ position: 'relative' }}>
-        <button
-          onClick={handleAgentClick}
-          onMouseEnter={() => setHovered('agent')}
-          onMouseLeave={() => setHovered(null)}
-          style={{
-            ...btnBase,
-            padding: '5px 12px',
-            background:
-              hovered === 'agent' || isFolderPickerOpen
-                ? 'var(--pixel-agent-hover-bg)'
-                : 'var(--pixel-agent-bg)',
-            border: '2px solid var(--pixel-agent-border)',
-            color: 'var(--pixel-agent-text)',
-          }}
-        >
-          + Agent
-        </button>
-        {isFolderPickerOpen && (
-          <div
-            style={{
-              position: 'absolute',
-              bottom: '100%',
-              left: 0,
-              marginBottom: 4,
-              background: 'var(--pixel-bg)',
-              border: '2px solid var(--pixel-border)',
-              borderRadius: 0,
-              boxShadow: 'var(--pixel-shadow)',
-              minWidth: 160,
-              zIndex: 'var(--pixel-controls-z)',
-            }}
-          >
-            {workspaceFolders.map((folder, i) => (
-              <button
-                key={folder.path}
-                onClick={() => handleFolderSelect(folder)}
-                onMouseEnter={() => setHoveredFolder(i)}
-                onMouseLeave={() => setHoveredFolder(null)}
-                style={{
-                  display: 'block',
-                  width: '100%',
-                  textAlign: 'left',
-                  padding: '6px 10px',
-                  fontSize: '22px',
-                  color: 'var(--pixel-text)',
-                  background: hoveredFolder === i ? 'var(--pixel-btn-hover-bg)' : 'transparent',
-                  border: 'none',
-                  borderRadius: 0,
-                  cursor: 'pointer',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {folder.name}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      <button
+        onClick={openModal}
+        onMouseEnter={() => setHovered('agent')}
+        onMouseLeave={() => setHovered(null)}
+        style={{
+          ...btnBase,
+          padding: '5px 12px',
+          background:
+            hovered === 'agent' || isAgentModalOpen
+              ? 'var(--pixel-agent-hover-bg)'
+              : 'var(--pixel-agent-bg)',
+          border: '2px solid var(--pixel-agent-border)',
+          color: 'var(--pixel-agent-text)',
+        }}
+      >
+        + Agent
+      </button>
       <button
         onClick={onToggleEditMode}
         onMouseEnter={() => setHovered('edit')}
@@ -193,6 +215,74 @@ export function BottomToolbar({
           onToggleAlwaysShowOverlay={onToggleAlwaysShowOverlay}
         />
       </div>
+
+      {isAgentModalOpen && (
+        <div style={overlayStyle} onMouseDown={() => setIsAgentModalOpen(false)}>
+          <div
+            style={modalStyle}
+            onMouseDown={(e) => e.stopPropagation()}
+            onKeyDown={handleKeyDown}
+          >
+            <div style={{ fontSize: '22px', color: 'var(--pixel-text)', fontWeight: 'bold' }}>
+              New Agent
+            </div>
+            <div>
+              <label style={labelStyle}>Name (optional)</label>
+              <input
+                ref={nameInputRef}
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder="e.g. Alice"
+                style={inputStyle}
+              />
+            </div>
+            <div>
+              <label style={labelStyle}>Folder</label>
+              <div style={rowStyle}>
+                <input
+                  value={folderPath}
+                  onChange={(e) => setFolderPath(e.target.value)}
+                  placeholder="Select a folder..."
+                  style={{ ...inputStyle, flex: 1 }}
+                />
+                <button
+                  onClick={handleBrowse}
+                  style={{
+                    ...btnBase,
+                    padding: '5px 10px',
+                    fontSize: '20px',
+                    flexShrink: 0,
+                  }}
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
+            <div style={{ ...rowStyle, justifyContent: 'flex-end', marginTop: 4 }}>
+              <button
+                onClick={() => setIsAgentModalOpen(false)}
+                style={{ ...btnBase, fontSize: '20px' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={!folderPath.trim()}
+                style={{
+                  ...btnBase,
+                  fontSize: '20px',
+                  background: folderPath.trim() ? 'var(--pixel-agent-bg)' : 'var(--pixel-btn-bg)',
+                  border: '2px solid var(--pixel-agent-border)',
+                  color: folderPath.trim() ? 'var(--pixel-agent-text)' : 'var(--pixel-text-dim)',
+                  cursor: folderPath.trim() ? 'pointer' : 'not-allowed',
+                }}
+              >
+                Launch
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/webview-ui/src/hooks/useEditorActions.ts
+++ b/webview-ui/src/hooks/useEditorActions.ts
@@ -40,7 +40,6 @@ export interface EditorActions {
   panRef: React.MutableRefObject<{ x: number; y: number }>;
   saveTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
   setLastSavedLayout: (layout: OfficeLayout) => void;
-  handleOpenClaude: () => void;
   handleToggleEditMode: () => void;
   handleToolChange: (tool: EditToolType) => void;
   handleTileTypeChange: (type: TileTypeVal) => void;
@@ -102,10 +101,6 @@ export function useEditorActions(
     },
     [getOfficeState, editorState, saveLayout],
   );
-
-  const handleOpenClaude = useCallback(() => {
-    vscode.postMessage({ type: 'openClaude' });
-  }, []);
 
   const handleToggleEditMode = useCallback(() => {
     setIsEditMode((prev) => {
@@ -611,7 +606,6 @@ export function useEditorActions(
     panRef,
     saveTimerRef,
     setLastSavedLayout,
-    handleOpenClaude,
     handleToggleEditMode,
     handleToolChange,
     handleTileTypeChange,

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -99,6 +99,7 @@ export function useExtensionMessages(
       hueShift?: number;
       seatId?: string;
       folderName?: string;
+      agentName?: string;
     }> = [];
 
     const handler = (e: MessageEvent) => {
@@ -122,7 +123,7 @@ export function useExtensionMessages(
         }
         // Add buffered agents now that layout (and seats) are correct
         for (const p of pendingAgents) {
-          os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+          os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName, p.agentName);
         }
         pendingAgents = [];
         layoutReadyRef.current = true;
@@ -136,9 +137,10 @@ export function useExtensionMessages(
       } else if (msg.type === 'agentCreated') {
         const id = msg.id as number;
         const folderName = msg.folderName as string | undefined;
+        const agentName = msg.agentName as string | undefined;
         setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]));
         setSelectedAgent(id);
-        os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+        os.addAgent(id, undefined, undefined, undefined, undefined, folderName, agentName);
         saveAgentSeats(os);
       } else if (msg.type === 'agentClosed') {
         const id = msg.id as number;
@@ -173,6 +175,7 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
+        const agentNames = (msg.agentNames || {}) as Record<number, string>;
         // Buffer agents — they'll be added in layoutLoaded after seats are built
         for (const id of incoming) {
           const m = meta[id];
@@ -182,6 +185,7 @@ export function useExtensionMessages(
             hueShift: m?.hueShift,
             seatId: m?.seatId,
             folderName: folderNames[id],
+            agentName: agentNames[id],
           });
         }
         setAgents((prev) => {

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -185,7 +185,7 @@ export function ToolOverlay({
                 >
                   {activityText}
                 </span>
-                {ch.folderName && (
+                {(ch.agentName || ch.folderName) && (
                   <span
                     style={{
                       fontSize: '16px',
@@ -195,7 +195,7 @@ export function ToolOverlay({
                       display: 'block',
                     }}
                   >
-                    {ch.folderName}
+                    {ch.agentName || ch.folderName}
                   </span>
                 )}
               </div>

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -215,6 +215,7 @@ export class OfficeState {
     preferredSeatId?: string,
     skipSpawnEffect?: boolean,
     folderName?: string,
+    agentName?: string,
   ): void {
     if (this.characters.has(id)) return;
 
@@ -261,6 +262,9 @@ export class OfficeState {
 
     if (folderName) {
       ch.folderName = folderName;
+    }
+    if (agentName) {
+      ch.agentName = agentName;
     }
     if (!skipSpawnEffect) {
       ch.matrixEffect = 'spawn';

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -190,4 +190,6 @@ export interface Character {
   matrixEffectSeeds: number[];
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** User-provided display name for the agent */
+  agentName?: string;
 }


### PR DESCRIPTION
## Description
Adds `name` and `folder` fields when opening a new pixel agent, and updates the logic to check the correct folder for the `.jsonl` status file of the project.

## Why
When working with git worktree, or having agents working in different domains in a monorepo, it is good to run claude in that specific folder. Right now, if you stop claude and move to the new folder, the pixel agent loses the sync with the claude in the correct folder

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ___


## Screenshots / GIFs
![Mar-17-2026 20-39-41](https://github.com/user-attachments/assets/cbef560a-392b-4cde-a551-c63378e7c9a1)


## Test plan
- [x] PR targets `main` branch
- [x] `npm run build` passes locally
- [ ] Tested in Extension Development Host (F5)
- [x] No inline constants (all in `src/constants.ts` or `webview-ui/src/constants.ts`)
- [x] UI follows pixel art style (sharp corners, solid borders, pixel font)