### PR TITLE
feat: standalone web app mode without VS Code

### DIFF
--- a/standalone/build.js
+++ b/standalone/build.js
@@ -1,0 +1,24 @@
+import esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/server.ts'],
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+  target: 'node20',
+  outfile: 'dist/server.js',
+  sourcemap: true,
+  banner: {
+    js: `
+import { createRequire } from 'module';
+import { fileURLToPath as ___fileURLToPath } from 'url';
+import { dirname as ___dirname } from 'path';
+const require = createRequire(import.meta.url);
+const __filename = ___fileURLToPath(import.meta.url);
+const __dirname = ___dirname(__filename);
+`,
+  },
+  external: [],
+});
+
+console.log('Build complete: dist/server.js');

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -1,0 +1,577 @@
+{
+  "name": "pixel-agents-standalone",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pixel-agents-standalone",
+      "version": "1.0.0",
+      "dependencies": {
+        "pngjs": "^7.0.0",
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.0",
+        "esbuild": "^0.27.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pixel-agents-standalone",
+  "version": "1.0.0",
+  "description": "Standalone web app for Pixel Agents - visualize Claude Code sessions without VS Code",
+  "type": "module",
+  "scripts": {
+    "build": "node build.js",
+    "start": "node dist/server.js",
+    "dev": "node --watch dist/server.js"
+  },
+  "dependencies": {
+    "pngjs": "^7.0.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
+    "esbuild": "^0.27.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/standalone/src/assetLoader.ts
+++ b/standalone/src/assetLoader.ts
@@ -1,0 +1,391 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PNG } from 'pngjs';
+
+import {
+  CHAR_COUNT,
+  CHAR_FRAME_H,
+  CHAR_FRAME_W,
+  CHAR_FRAMES_PER_ROW,
+  CHARACTER_DIRECTIONS,
+  FLOOR_TILE_SIZE,
+  LAYOUT_REVISION_KEY,
+  PNG_ALPHA_THRESHOLD,
+  WALL_BITMASK_COUNT,
+  WALL_GRID_COLS,
+  WALL_PIECE_HEIGHT,
+  WALL_PIECE_WIDTH,
+} from './constants.js';
+
+function rgbaToHex(r: number, g: number, b: number, a: number): string {
+  if (a < PNG_ALPHA_THRESHOLD) return '';
+  const rgb =
+    `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`.toUpperCase();
+  if (a >= 255) return rgb;
+  return `${rgb}${a.toString(16).padStart(2, '0').toUpperCase()}`;
+}
+
+function pngToSpriteData(pngBuffer: Buffer, width: number, height: number): string[][] {
+  try {
+    const png = PNG.sync.read(pngBuffer);
+    const sprite: string[][] = [];
+    const data = png.data;
+
+    for (let y = 0; y < height; y++) {
+      const row: string[] = [];
+      for (let x = 0; x < width; x++) {
+        const pixelIndex = (y * png.width + x) * 4;
+        row.push(
+          rgbaToHex(
+            data[pixelIndex],
+            data[pixelIndex + 1],
+            data[pixelIndex + 2],
+            data[pixelIndex + 3],
+          ),
+        );
+      }
+      sprite.push(row);
+    }
+    return sprite;
+  } catch {
+    const sprite: string[][] = [];
+    for (let y = 0; y < height; y++) {
+      sprite.push(new Array(width).fill(''));
+    }
+    return sprite;
+  }
+}
+
+// -- Manifest types (same as extension) --
+
+interface ManifestAsset {
+  type: 'asset';
+  id: string;
+  file: string;
+  width: number;
+  height: number;
+  footprintW: number;
+  footprintH: number;
+  orientation?: string;
+  state?: string;
+  frame?: number;
+  mirrorSide?: boolean;
+}
+
+interface ManifestGroup {
+  type: 'group';
+  groupType: 'rotation' | 'state' | 'animation';
+  rotationScheme?: string;
+  orientation?: string;
+  state?: string;
+  members: ManifestNode[];
+}
+
+type ManifestNode = ManifestAsset | ManifestGroup;
+
+interface FurnitureManifest {
+  id: string;
+  name: string;
+  category: string;
+  canPlaceOnWalls: boolean;
+  canPlaceOnSurfaces: boolean;
+  backgroundTiles: number;
+  type: 'asset' | 'group';
+  file?: string;
+  width?: number;
+  height?: number;
+  footprintW?: number;
+  footprintH?: number;
+  groupType?: string;
+  rotationScheme?: string;
+  members?: ManifestNode[];
+}
+
+export interface FurnitureAsset {
+  id: string;
+  name: string;
+  label: string;
+  category: string;
+  file: string;
+  width: number;
+  height: number;
+  footprintW: number;
+  footprintH: number;
+  isDesk: boolean;
+  canPlaceOnWalls: boolean;
+  canPlaceOnSurfaces?: boolean;
+  backgroundTiles?: number;
+  groupId?: string;
+  orientation?: string;
+  state?: string;
+  mirrorSide?: boolean;
+  rotationScheme?: string;
+  animationGroup?: string;
+  frame?: number;
+}
+
+interface InheritedProps {
+  groupId: string;
+  name: string;
+  category: string;
+  canPlaceOnWalls: boolean;
+  canPlaceOnSurfaces: boolean;
+  backgroundTiles: number;
+  orientation?: string;
+  state?: string;
+  rotationScheme?: string;
+  animationGroup?: string;
+}
+
+function flattenManifest(node: ManifestNode, inherited: InheritedProps): FurnitureAsset[] {
+  if (node.type === 'asset') {
+    const asset = node as ManifestAsset;
+    const orientation = asset.orientation ?? inherited.orientation;
+    const state = asset.state ?? inherited.state;
+    return [
+      {
+        id: asset.id,
+        name: inherited.name,
+        label: inherited.name,
+        category: inherited.category,
+        file: asset.file,
+        width: asset.width,
+        height: asset.height,
+        footprintW: asset.footprintW,
+        footprintH: asset.footprintH,
+        isDesk: inherited.category === 'desks',
+        canPlaceOnWalls: inherited.canPlaceOnWalls,
+        canPlaceOnSurfaces: inherited.canPlaceOnSurfaces,
+        backgroundTiles: inherited.backgroundTiles,
+        groupId: inherited.groupId,
+        ...(orientation ? { orientation } : {}),
+        ...(state ? { state } : {}),
+        ...(asset.mirrorSide ? { mirrorSide: true } : {}),
+        ...(inherited.rotationScheme ? { rotationScheme: inherited.rotationScheme } : {}),
+        ...(inherited.animationGroup ? { animationGroup: inherited.animationGroup } : {}),
+        ...(asset.frame !== undefined ? { frame: asset.frame } : {}),
+      },
+    ];
+  }
+
+  const group = node as ManifestGroup;
+  const results: FurnitureAsset[] = [];
+  for (const member of group.members) {
+    const childProps: InheritedProps = { ...inherited };
+    if (group.groupType === 'rotation' && group.rotationScheme) {
+      childProps.rotationScheme = group.rotationScheme;
+    }
+    if (group.groupType === 'state') {
+      if (group.orientation) childProps.orientation = group.orientation;
+      if (group.state) childProps.state = group.state;
+    }
+    if (group.groupType === 'animation') {
+      const orient = group.orientation ?? inherited.orientation ?? '';
+      const st = group.state ?? inherited.state ?? '';
+      childProps.animationGroup = `${inherited.groupId}_${orient}_${st}`.toUpperCase();
+      if (group.state) childProps.state = group.state;
+    }
+    if (group.orientation && !childProps.orientation) {
+      childProps.orientation = group.orientation;
+    }
+    results.push(...flattenManifest(member, childProps));
+  }
+  return results;
+}
+
+export function loadAllAssets(assetsRoot: string): {
+  catalog: FurnitureAsset[];
+  sprites: Record<string, string[][]>;
+  characters: Array<{ down: string[][][]; up: string[][][]; right: string[][][] }>;
+  floorTiles: string[][][];
+  wallSets: string[][][][];
+  defaultLayout: Record<string, unknown> | null;
+} {
+  const assetsDir = path.join(assetsRoot, 'assets');
+
+  // Load furniture
+  const catalog: FurnitureAsset[] = [];
+  const sprites: Record<string, string[][]> = {};
+  const furnitureDir = path.join(assetsDir, 'furniture');
+  if (fs.existsSync(furnitureDir)) {
+    const entries = fs.readdirSync(furnitureDir, { withFileTypes: true });
+    for (const dir of entries.filter((e) => e.isDirectory())) {
+      const manifestPath = path.join(furnitureDir, dir.name, 'manifest.json');
+      if (!fs.existsSync(manifestPath)) continue;
+      try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as FurnitureManifest;
+        const inherited: InheritedProps = {
+          groupId: manifest.id,
+          name: manifest.name,
+          category: manifest.category,
+          canPlaceOnWalls: manifest.canPlaceOnWalls,
+          canPlaceOnSurfaces: manifest.canPlaceOnSurfaces,
+          backgroundTiles: manifest.backgroundTiles,
+        };
+
+        let assets: FurnitureAsset[];
+        if (manifest.type === 'asset') {
+          assets = [
+            {
+              id: manifest.id,
+              name: manifest.name,
+              label: manifest.name,
+              category: manifest.category,
+              file: manifest.file ?? `${manifest.id}.png`,
+              width: manifest.width!,
+              height: manifest.height!,
+              footprintW: manifest.footprintW!,
+              footprintH: manifest.footprintH!,
+              isDesk: manifest.category === 'desks',
+              canPlaceOnWalls: manifest.canPlaceOnWalls,
+              canPlaceOnSurfaces: manifest.canPlaceOnSurfaces,
+              backgroundTiles: manifest.backgroundTiles,
+              groupId: manifest.id,
+            },
+          ];
+        } else {
+          if (manifest.rotationScheme) inherited.rotationScheme = manifest.rotationScheme;
+          const rootGroup: ManifestGroup = {
+            type: 'group',
+            groupType: manifest.groupType as 'rotation' | 'state' | 'animation',
+            rotationScheme: manifest.rotationScheme,
+            members: manifest.members!,
+          };
+          assets = flattenManifest(rootGroup, inherited);
+        }
+
+        for (const asset of assets) {
+          const assetPath = path.join(furnitureDir, dir.name, asset.file);
+          if (fs.existsSync(assetPath)) {
+            sprites[asset.id] = pngToSpriteData(
+              fs.readFileSync(assetPath),
+              asset.width,
+              asset.height,
+            );
+          }
+        }
+        catalog.push(...assets);
+      } catch {
+        /* skip broken manifests */
+      }
+    }
+  }
+
+  // Load characters
+  const characters: Array<{ down: string[][][]; up: string[][][]; right: string[][][] }> = [];
+  const charDir = path.join(assetsDir, 'characters');
+  for (let ci = 0; ci < CHAR_COUNT; ci++) {
+    const filePath = path.join(charDir, `char_${ci}.png`);
+    if (!fs.existsSync(filePath)) break;
+    const png = PNG.sync.read(fs.readFileSync(filePath));
+    const charData: { down: string[][][]; up: string[][][]; right: string[][][] } = {
+      down: [],
+      up: [],
+      right: [],
+    };
+    for (let dirIdx = 0; dirIdx < CHARACTER_DIRECTIONS.length; dirIdx++) {
+      const dir = CHARACTER_DIRECTIONS[dirIdx];
+      const rowOffsetY = dirIdx * CHAR_FRAME_H;
+      const frames: string[][][] = [];
+      for (let f = 0; f < CHAR_FRAMES_PER_ROW; f++) {
+        const sprite: string[][] = [];
+        const frameOffsetX = f * CHAR_FRAME_W;
+        for (let y = 0; y < CHAR_FRAME_H; y++) {
+          const row: string[] = [];
+          for (let x = 0; x < CHAR_FRAME_W; x++) {
+            const idx = ((rowOffsetY + y) * png.width + (frameOffsetX + x)) * 4;
+            row.push(
+              rgbaToHex(png.data[idx], png.data[idx + 1], png.data[idx + 2], png.data[idx + 3]),
+            );
+          }
+          sprite.push(row);
+        }
+        frames.push(sprite);
+      }
+      charData[dir] = frames;
+    }
+    characters.push(charData);
+  }
+
+  // Load floor tiles
+  const floorTiles: string[][][] = [];
+  const floorsDir = path.join(assetsDir, 'floors');
+  if (fs.existsSync(floorsDir)) {
+    const floorFiles = fs
+      .readdirSync(floorsDir)
+      .filter((f) => /^floor_\d+\.png$/i.test(f))
+      .sort((a, b) => parseInt(a.match(/\d+/)![0]) - parseInt(b.match(/\d+/)![0]));
+    for (const filename of floorFiles) {
+      floorTiles.push(
+        pngToSpriteData(
+          fs.readFileSync(path.join(floorsDir, filename)),
+          FLOOR_TILE_SIZE,
+          FLOOR_TILE_SIZE,
+        ),
+      );
+    }
+  }
+
+  // Load wall tiles
+  const wallSets: string[][][][] = [];
+  const wallsDir = path.join(assetsDir, 'walls');
+  if (fs.existsSync(wallsDir)) {
+    const wallFiles = fs
+      .readdirSync(wallsDir)
+      .filter((f) => /^wall_\d+\.png$/i.test(f))
+      .sort((a, b) => parseInt(a.match(/\d+/)![0]) - parseInt(b.match(/\d+/)![0]));
+    for (const filename of wallFiles) {
+      const png = PNG.sync.read(fs.readFileSync(path.join(wallsDir, filename)));
+      const sprites: string[][][] = [];
+      for (let mask = 0; mask < WALL_BITMASK_COUNT; mask++) {
+        const ox = (mask % WALL_GRID_COLS) * WALL_PIECE_WIDTH;
+        const oy = Math.floor(mask / WALL_GRID_COLS) * WALL_PIECE_HEIGHT;
+        const sprite: string[][] = [];
+        for (let r = 0; r < WALL_PIECE_HEIGHT; r++) {
+          const row: string[] = [];
+          for (let c = 0; c < WALL_PIECE_WIDTH; c++) {
+            const idx = ((oy + r) * png.width + (ox + c)) * 4;
+            row.push(
+              rgbaToHex(png.data[idx], png.data[idx + 1], png.data[idx + 2], png.data[idx + 3]),
+            );
+          }
+          sprite.push(row);
+        }
+        sprites.push(sprite);
+      }
+      wallSets.push(sprites);
+    }
+  }
+
+  // Load default layout
+  let defaultLayout: Record<string, unknown> | null = null;
+  if (fs.existsSync(assetsDir)) {
+    let bestRevision = 0;
+    let bestPath: string | null = null;
+    for (const file of fs.readdirSync(assetsDir)) {
+      const match = /^default-layout-(\d+)\.json$/.exec(file);
+      if (match) {
+        const rev = parseInt(match[1], 10);
+        if (rev > bestRevision) {
+          bestRevision = rev;
+          bestPath = path.join(assetsDir, file);
+        }
+      }
+    }
+    if (!bestPath) {
+      const fallback = path.join(assetsDir, 'default-layout.json');
+      if (fs.existsSync(fallback)) bestPath = fallback;
+    }
+    if (bestPath) {
+      defaultLayout = JSON.parse(fs.readFileSync(bestPath, 'utf-8'));
+      if (bestRevision > 0 && defaultLayout && !defaultLayout[LAYOUT_REVISION_KEY]) {
+        defaultLayout[LAYOUT_REVISION_KEY] = bestRevision;
+      }
+    }
+  }
+
+  console.log(
+    `[Assets] Loaded: ${catalog.length} furniture, ${characters.length} characters, ${floorTiles.length} floor tiles, ${wallSets.length} wall sets`,
+  );
+  return { catalog, sprites, characters, floorTiles, wallSets, defaultLayout };
+}

--- a/standalone/src/constants.ts
+++ b/standalone/src/constants.ts
@@ -1,0 +1,32 @@
+// Timing (ms)
+export const JSONL_POLL_INTERVAL_MS = 1000;
+export const FILE_WATCHER_POLL_INTERVAL_MS = 1000;
+export const PROJECT_SCAN_INTERVAL_MS = 2000;
+export const TOOL_DONE_DELAY_MS = 300;
+export const PERMISSION_TIMER_DELAY_MS = 7000;
+export const TEXT_IDLE_DELAY_MS = 5000;
+
+// Display truncation
+export const BASH_COMMAND_DISPLAY_MAX_LENGTH = 30;
+export const TASK_DESCRIPTION_DISPLAY_MAX_LENGTH = 40;
+
+// PNG / Asset parsing
+export const PNG_ALPHA_THRESHOLD = 2;
+export const WALL_PIECE_WIDTH = 16;
+export const WALL_PIECE_HEIGHT = 32;
+export const WALL_GRID_COLS = 4;
+export const WALL_BITMASK_COUNT = 16;
+export const FLOOR_TILE_SIZE = 16;
+export const CHARACTER_DIRECTIONS = ['down', 'up', 'right'] as const;
+export const CHAR_FRAME_W = 16;
+export const CHAR_FRAME_H = 32;
+export const CHAR_FRAMES_PER_ROW = 7;
+export const CHAR_COUNT = 6;
+
+// Layout persistence
+export const LAYOUT_FILE_DIR = '.pixel-agents';
+export const LAYOUT_FILE_NAME = 'layout.json';
+export const LAYOUT_REVISION_KEY = 'layoutRevision';
+
+// Server
+export const DEFAULT_PORT = 3100;

--- a/standalone/src/server.ts
+++ b/standalone/src/server.ts
@@ -1,0 +1,508 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+import { WebSocketServer } from 'ws';
+import type { WebSocket } from 'ws';
+
+import { loadAllAssets } from './assetLoader.js';
+import {
+  DEFAULT_PORT,
+  FILE_WATCHER_POLL_INTERVAL_MS,
+  LAYOUT_FILE_DIR,
+  LAYOUT_FILE_NAME,
+  LAYOUT_REVISION_KEY,
+  PROJECT_SCAN_INTERVAL_MS,
+} from './constants.js';
+import {
+  cancelPermissionTimer,
+  cancelWaitingTimer,
+  clearAgentActivity,
+  processTranscriptLine,
+} from './transcriptParser.js';
+import type { AgentState } from './types.js';
+
+// -- State --
+
+const agents = new Map<number, AgentState>();
+const fileWatchers = new Map<number, fs.FSWatcher>();
+const pollingTimers = new Map<number, ReturnType<typeof setInterval>>();
+const waitingTimers = new Map<number, ReturnType<typeof setTimeout>>();
+const permissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
+const knownJsonlFiles = new Set<string>();
+const knownProjectDirs = new Set<string>();
+let nextAgentId = 1;
+const clients = new Set<WebSocket>();
+
+// -- Helpers --
+
+function broadcast(msg: Record<string, unknown>): void {
+  const json = JSON.stringify(msg);
+  for (const ws of clients) {
+    if (ws.readyState === 1) {
+      // WebSocket.OPEN
+      ws.send(json);
+    }
+  }
+}
+
+function getProjectName(dirPath: string): string {
+  // Convert ~/.claude/projects/-Users-rolle-Projects-foo back to project name
+  const base = path.basename(dirPath);
+  const parts = base.split('-').filter(Boolean);
+  // Take last meaningful segment as project name
+  return parts[parts.length - 1] || base;
+}
+
+// -- Layout persistence --
+
+function getLayoutFilePath(): string {
+  return path.join(os.homedir(), LAYOUT_FILE_DIR, LAYOUT_FILE_NAME);
+}
+
+function readLayoutFromFile(): Record<string, unknown> | null {
+  const filePath = getLayoutFilePath();
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeLayoutToFile(layout: Record<string, unknown>): void {
+  const filePath = getLayoutFilePath();
+  const dir = path.dirname(filePath);
+  try {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = filePath + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(layout, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    console.error('[Layout] Write error:', err);
+  }
+}
+
+// -- File watching (ported from extension) --
+
+function startFileWatching(agentId: number, filePath: string): void {
+  try {
+    const watcher = fs.watch(filePath, () => {
+      readNewLines(agentId);
+    });
+    fileWatchers.set(agentId, watcher);
+  } catch {
+    /* fs.watch can fail */
+  }
+
+  try {
+    fs.watchFile(filePath, { interval: FILE_WATCHER_POLL_INTERVAL_MS }, () => {
+      readNewLines(agentId);
+    });
+  } catch {
+    /* ignore */
+  }
+
+  const interval = setInterval(() => {
+    if (!agents.has(agentId)) {
+      clearInterval(interval);
+      try {
+        fs.unwatchFile(filePath);
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    readNewLines(agentId);
+  }, FILE_WATCHER_POLL_INTERVAL_MS);
+  pollingTimers.set(agentId, interval);
+}
+
+function readNewLines(agentId: number): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+  try {
+    const stat = fs.statSync(agent.jsonlFile);
+    if (stat.size <= agent.fileOffset) return;
+
+    const buf = Buffer.alloc(stat.size - agent.fileOffset);
+    const fd = fs.openSync(agent.jsonlFile, 'r');
+    fs.readSync(fd, buf, 0, buf.length, agent.fileOffset);
+    fs.closeSync(fd);
+    agent.fileOffset = stat.size;
+
+    const text = agent.lineBuffer + buf.toString('utf-8');
+    const lines = text.split('\n');
+    agent.lineBuffer = lines.pop() || '';
+
+    const hasLines = lines.some((l) => l.trim());
+    if (hasLines) {
+      cancelWaitingTimer(agentId, waitingTimers);
+      cancelPermissionTimer(agentId, permissionTimers);
+      if (agent.permissionSent) {
+        agent.permissionSent = false;
+        broadcast({ type: 'agentToolPermissionClear', id: agentId });
+      }
+    }
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      processTranscriptLine(agentId, line, agents, waitingTimers, permissionTimers, broadcast);
+    }
+  } catch {
+    // Read error - file may have been removed
+  }
+}
+
+function removeAgent(agentId: number): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+
+  fileWatchers.get(agentId)?.close();
+  fileWatchers.delete(agentId);
+  const pt = pollingTimers.get(agentId);
+  if (pt) clearInterval(pt);
+  pollingTimers.delete(agentId);
+  try {
+    fs.unwatchFile(agent.jsonlFile);
+  } catch {
+    /* ignore */
+  }
+
+  cancelWaitingTimer(agentId, waitingTimers);
+  cancelPermissionTimer(agentId, permissionTimers);
+
+  agents.delete(agentId);
+  broadcast({ type: 'agentClosed', id: agentId });
+}
+
+// -- Session discovery --
+
+function isFileActive(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    // Consider a file active if modified in the last 30 minutes
+    return Date.now() - stat.mtimeMs < 30 * 60 * 1000;
+  } catch {
+    return false;
+  }
+}
+
+function isFileGrowing(filePath: string): boolean {
+  // Check if file has grown recently (last 60 seconds) - sign of active session
+  try {
+    const stat = fs.statSync(filePath);
+    return Date.now() - stat.mtimeMs < 60 * 1000;
+  } catch {
+    return false;
+  }
+}
+
+function adoptJsonlFile(filePath: string, projectDir: string): void {
+  if (knownJsonlFiles.has(filePath)) return;
+  knownJsonlFiles.add(filePath);
+
+  if (!isFileActive(filePath)) return;
+
+  const id = nextAgentId++;
+  const projectName = getProjectName(projectDir);
+  const agent: AgentState = {
+    id,
+    projectDir,
+    projectName,
+    jsonlFile: filePath,
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    folderName: projectName,
+  };
+
+  // Skip to near end of file - only read recent activity
+  try {
+    const stat = fs.statSync(filePath);
+    // Start reading from max 50KB before end to catch recent activity
+    agent.fileOffset = Math.max(0, stat.size - 50 * 1024);
+  } catch {
+    /* start from beginning */
+  }
+
+  agents.set(id, agent);
+  console.log(`[Agent ${id}] Adopted session in ${projectName}: ${path.basename(filePath)}`);
+  broadcast({ type: 'agentCreated', id, folderName: projectName });
+
+  startFileWatching(id, filePath);
+  readNewLines(id);
+}
+
+function scanProjectDir(projectDir: string): void {
+  try {
+    const files = fs
+      .readdirSync(projectDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => path.join(projectDir, f));
+
+    for (const file of files) {
+      if (!knownJsonlFiles.has(file)) {
+        adoptJsonlFile(file, projectDir);
+      }
+    }
+  } catch {
+    /* dir may not exist */
+  }
+}
+
+function scanAllProjects(): void {
+  const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
+  try {
+    if (!fs.existsSync(claudeProjectsDir)) return;
+    const entries = fs.readdirSync(claudeProjectsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const projectDir = path.join(claudeProjectsDir, entry.name);
+      knownProjectDirs.add(projectDir);
+      scanProjectDir(projectDir);
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+function cleanupStaleAgents(): void {
+  for (const [id, agent] of agents) {
+    if (!fs.existsSync(agent.jsonlFile)) {
+      console.log(`[Agent ${id}] Session file removed, cleaning up`);
+      removeAgent(id);
+      continue;
+    }
+    // Remove agents whose sessions haven't been active for 30 minutes
+    if (!isFileActive(agent.jsonlFile) && !isFileGrowing(agent.jsonlFile)) {
+      console.log(`[Agent ${id}] Session inactive, cleaning up`);
+      removeAgent(id);
+    }
+  }
+}
+
+// -- Send full state to new client --
+
+function sendInitialState(ws: WebSocket, assets: ReturnType<typeof loadAllAssets>): void {
+  const send = (msg: Record<string, unknown>) => {
+    if (ws.readyState === 1) ws.send(JSON.stringify(msg));
+  };
+
+  // Send assets first
+  send({ type: 'characterSpritesLoaded', characters: assets.characters });
+  send({ type: 'floorTilesLoaded', sprites: assets.floorTiles });
+  send({ type: 'wallTilesLoaded', sets: assets.wallSets });
+  send({ type: 'furnitureAssetsLoaded', catalog: assets.catalog, sprites: assets.sprites });
+
+  // Send settings
+  send({ type: 'settingsLoaded', soundEnabled: true });
+
+  // Send standalone mode flag
+  send({ type: 'standaloneMode', enabled: true });
+
+  // Send existing agents - these get buffered in pendingAgents by the webview
+  const agentIds = [...agents.keys()].sort((a, b) => a - b);
+  const folderNames: Record<number, string> = {};
+  for (const [id, agent] of agents) {
+    if (agent.folderName) folderNames[id] = agent.folderName;
+  }
+  send({ type: 'existingAgents', agents: agentIds, agentMeta: {}, folderNames });
+
+  // Send layout LAST - this triggers the webview to flush pendingAgents into OfficeState
+  const savedLayout = readLayoutFromFile();
+  const layout = savedLayout ?? assets.defaultLayout;
+  if (layout) {
+    if (savedLayout && assets.defaultLayout) {
+      const fileRevision = (savedLayout[LAYOUT_REVISION_KEY] as number) ?? 0;
+      const defaultRevision = (assets.defaultLayout[LAYOUT_REVISION_KEY] as number) ?? 0;
+      if (defaultRevision > fileRevision) {
+        writeLayoutToFile(assets.defaultLayout);
+        send({ type: 'layoutLoaded', layout: assets.defaultLayout, wasReset: true });
+      } else {
+        send({ type: 'layoutLoaded', layout: savedLayout });
+      }
+    } else if (savedLayout) {
+      send({ type: 'layoutLoaded', layout: savedLayout });
+    } else if (assets.defaultLayout) {
+      writeLayoutToFile(assets.defaultLayout);
+      send({ type: 'layoutLoaded', layout: assets.defaultLayout });
+    }
+  } else {
+    send({ type: 'layoutLoaded', layout: null });
+  }
+
+  // Re-send current tool states
+  for (const [agentId, agent] of agents) {
+    for (const [toolId, status] of agent.activeToolStatuses) {
+      send({ type: 'agentToolStart', id: agentId, toolId, status });
+    }
+    if (agent.isWaiting) {
+      send({ type: 'agentStatus', id: agentId, status: 'waiting' });
+    }
+  }
+}
+
+// -- Static file server --
+
+function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  const mimes: Record<string, string> = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+    '.ttf': 'font/ttf',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.ico': 'image/x-icon',
+  };
+  return mimes[ext] || 'application/octet-stream';
+}
+
+// -- Main --
+
+function main(): void {
+  const port = parseInt(process.env.PORT || '', 10) || DEFAULT_PORT;
+
+  // Find assets - check dist/assets first, then webview-ui/public/assets
+  const projectRoot = path.resolve(__dirname, '..');
+  const repoRoot = path.resolve(projectRoot, '..');
+  let assetsRoot: string | null = null;
+
+  const distAssets = path.join(projectRoot, 'dist', 'assets');
+  const repoDistAssets = path.join(repoRoot, 'dist', 'assets');
+  const publicAssets = path.join(repoRoot, 'webview-ui', 'public', 'assets');
+
+  if (fs.existsSync(distAssets)) {
+    assetsRoot = path.join(projectRoot, 'dist');
+  } else if (fs.existsSync(repoDistAssets)) {
+    assetsRoot = path.join(repoRoot, 'dist');
+  } else if (fs.existsSync(publicAssets)) {
+    assetsRoot = path.join(repoRoot, 'webview-ui', 'public');
+  }
+
+  if (!assetsRoot) {
+    console.error(
+      'Could not find assets directory. Run the main project build first: npm run build',
+    );
+    process.exit(1);
+  }
+
+  console.log(`[Server] Loading assets from: ${assetsRoot}`);
+  const assets = loadAllAssets(assetsRoot);
+
+  // Find webview dist
+  const webviewDist = path.join(repoRoot, 'dist', 'webview');
+  if (!fs.existsSync(webviewDist)) {
+    console.error(`Webview not built. Run from repo root: npm run build`);
+    process.exit(1);
+  }
+
+  // Create HTTP server for static files
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${port}`);
+    let filePath = path.join(webviewDist, url.pathname === '/' ? 'index.html' : url.pathname);
+
+    // Also serve fonts from public dir
+    if (url.pathname.startsWith('/fonts/')) {
+      const fontPath = path.join(repoRoot, 'webview-ui', 'public', url.pathname);
+      if (fs.existsSync(fontPath)) {
+        filePath = fontPath;
+      }
+    }
+
+    if (!fs.existsSync(filePath)) {
+      // SPA fallback
+      filePath = path.join(webviewDist, 'index.html');
+    }
+
+    try {
+      const content = fs.readFileSync(filePath);
+      res.writeHead(200, { 'Content-Type': getMimeType(filePath) });
+      res.end(content);
+    } catch {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  });
+
+  // WebSocket server
+  const wss = new WebSocketServer({ server });
+
+  wss.on('connection', (ws) => {
+    clients.add(ws);
+    console.log(`[WS] Client connected (${clients.size} total)`);
+
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        console.log(`[WS] Received: ${msg.type}`);
+        if (msg.type === 'webviewReady') {
+          // Send initial state only after React app is mounted and listening
+          sendInitialState(ws, assets);
+        } else {
+          handleClientMessage(msg, assets);
+        }
+      } catch {
+        /* ignore bad messages */
+      }
+    });
+
+    ws.on('close', () => {
+      clients.delete(ws);
+      console.log(`[WS] Client disconnected (${clients.size} total)`);
+    });
+  });
+
+  // Start scanning for sessions
+  scanAllProjects();
+  setInterval(() => {
+    scanAllProjects();
+    cleanupStaleAgents();
+  }, PROJECT_SCAN_INTERVAL_MS);
+
+  server.listen(port, () => {
+    console.log(`\n  Pixel Agents standalone server running at:`);
+    console.log(`  http://localhost:${port}\n`);
+    console.log(`  Watching all Claude Code sessions in ~/.claude/projects/`);
+    console.log(`  Found ${agents.size} active session(s)\n`);
+  });
+}
+
+function handleClientMessage(
+  msg: Record<string, unknown>,
+  assets: ReturnType<typeof loadAllAssets>,
+): void {
+  if (msg.type === 'webviewReady') {
+    // Already handled on connection
+  } else if (msg.type === 'saveLayout') {
+    writeLayoutToFile(msg.layout as Record<string, unknown>);
+  } else if (msg.type === 'saveAgentSeats') {
+    // In standalone mode, seats are handled client-side (localStorage)
+  } else if (msg.type === 'openClaude') {
+    // Cannot spawn terminals in standalone mode - ignore
+    console.log(
+      '[Server] "Open Claude" not available in standalone mode - start claude from your terminal',
+    );
+  } else if (msg.type === 'focusAgent') {
+    // Cannot focus terminal in standalone mode
+  } else if (msg.type === 'closeAgent') {
+    // Cannot close external terminal sessions
+  } else if (msg.type === 'setSoundEnabled') {
+    // Client-side only
+  }
+}
+
+main();

--- a/standalone/src/transcriptParser.ts
+++ b/standalone/src/transcriptParser.ts
@@ -1,0 +1,372 @@
+import * as path from 'path';
+
+import {
+  BASH_COMMAND_DISPLAY_MAX_LENGTH,
+  PERMISSION_TIMER_DELAY_MS,
+  TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+  TEXT_IDLE_DELAY_MS,
+  TOOL_DONE_DELAY_MS,
+} from './constants.js';
+import type { AgentState } from './types.js';
+
+export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
+
+type Broadcast = (msg: Record<string, unknown>) => void;
+
+export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+  switch (toolName) {
+    case 'Read':
+      return `Reading ${base(input.file_path)}`;
+    case 'Edit':
+      return `Editing ${base(input.file_path)}`;
+    case 'Write':
+      return `Writing ${base(input.file_path)}`;
+    case 'Bash': {
+      const cmd = (input.command as string) || '';
+      return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : cmd}`;
+    }
+    case 'Glob':
+      return 'Searching files';
+    case 'Grep':
+      return 'Searching code';
+    case 'WebFetch':
+      return 'Fetching web content';
+    case 'WebSearch':
+      return 'Searching the web';
+    case 'Task':
+    case 'Agent': {
+      const desc = typeof input.description === 'string' ? input.description : '';
+      return desc
+        ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}`
+        : 'Running subtask';
+    }
+    case 'AskUserQuestion':
+      return 'Waiting for your answer';
+    case 'EnterPlanMode':
+      return 'Planning';
+    case 'NotebookEdit':
+      return 'Editing notebook';
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+export function clearAgentActivity(
+  agent: AgentState | undefined,
+  agentId: number,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  broadcast: Broadcast,
+): void {
+  if (!agent) return;
+  agent.activeToolIds.clear();
+  agent.activeToolStatuses.clear();
+  agent.activeToolNames.clear();
+  agent.activeSubagentToolIds.clear();
+  agent.activeSubagentToolNames.clear();
+  agent.isWaiting = false;
+  agent.permissionSent = false;
+  cancelPermissionTimer(agentId, permissionTimers);
+  broadcast({ type: 'agentToolsClear', id: agentId });
+  broadcast({ type: 'agentStatus', id: agentId, status: 'active' });
+}
+
+export function cancelWaitingTimer(
+  agentId: number,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+): void {
+  const timer = waitingTimers.get(agentId);
+  if (timer) {
+    clearTimeout(timer);
+    waitingTimers.delete(agentId);
+  }
+}
+
+export function startWaitingTimer(
+  agentId: number,
+  delayMs: number,
+  agents: Map<number, AgentState>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  broadcast: Broadcast,
+): void {
+  cancelWaitingTimer(agentId, waitingTimers);
+  const timer = setTimeout(() => {
+    waitingTimers.delete(agentId);
+    const agent = agents.get(agentId);
+    if (agent) {
+      agent.isWaiting = true;
+    }
+    broadcast({ type: 'agentStatus', id: agentId, status: 'waiting' });
+  }, delayMs);
+  waitingTimers.set(agentId, timer);
+}
+
+export function cancelPermissionTimer(
+  agentId: number,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+): void {
+  const timer = permissionTimers.get(agentId);
+  if (timer) {
+    clearTimeout(timer);
+    permissionTimers.delete(agentId);
+  }
+}
+
+export function startPermissionTimer(
+  agentId: number,
+  agents: Map<number, AgentState>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  broadcast: Broadcast,
+): void {
+  cancelPermissionTimer(agentId, permissionTimers);
+  const timer = setTimeout(() => {
+    permissionTimers.delete(agentId);
+    const agent = agents.get(agentId);
+    if (!agent) return;
+
+    let hasNonExempt = false;
+    for (const toolId of agent.activeToolIds) {
+      const toolName = agent.activeToolNames.get(toolId);
+      if (!PERMISSION_EXEMPT_TOOLS.has(toolName || '')) {
+        hasNonExempt = true;
+        break;
+      }
+    }
+
+    const stuckSubagentParentToolIds: string[] = [];
+    for (const [parentToolId, subToolNames] of agent.activeSubagentToolNames) {
+      for (const [, toolName] of subToolNames) {
+        if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+          stuckSubagentParentToolIds.push(parentToolId);
+          hasNonExempt = true;
+          break;
+        }
+      }
+    }
+
+    if (hasNonExempt) {
+      agent.permissionSent = true;
+      broadcast({ type: 'agentToolPermission', id: agentId });
+      for (const parentToolId of stuckSubagentParentToolIds) {
+        broadcast({ type: 'subagentToolPermission', id: agentId, parentToolId });
+      }
+    }
+  }, PERMISSION_TIMER_DELAY_MS);
+  permissionTimers.set(agentId, timer);
+}
+
+export function processTranscriptLine(
+  agentId: number,
+  line: string,
+  agents: Map<number, AgentState>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  broadcast: Broadcast,
+): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+  try {
+    const record = JSON.parse(line);
+
+    if (record.type === 'assistant' && Array.isArray(record.message?.content)) {
+      const blocks = record.message.content as Array<{
+        type: string;
+        id?: string;
+        name?: string;
+        input?: Record<string, unknown>;
+      }>;
+      const hasToolUse = blocks.some((b) => b.type === 'tool_use');
+
+      if (hasToolUse) {
+        cancelWaitingTimer(agentId, waitingTimers);
+        agent.isWaiting = false;
+        agent.hadToolsInTurn = true;
+        broadcast({ type: 'agentStatus', id: agentId, status: 'active' });
+        let hasNonExemptTool = false;
+        for (const block of blocks) {
+          if (block.type === 'tool_use' && block.id) {
+            const toolName = block.name || '';
+            const status = formatToolStatus(toolName, block.input || {});
+            agent.activeToolIds.add(block.id);
+            agent.activeToolStatuses.set(block.id, status);
+            agent.activeToolNames.set(block.id, toolName);
+            if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+              hasNonExemptTool = true;
+            }
+            broadcast({ type: 'agentToolStart', id: agentId, toolId: block.id, status });
+          }
+        }
+        if (hasNonExemptTool) {
+          startPermissionTimer(agentId, agents, permissionTimers, broadcast);
+        }
+      } else if (blocks.some((b) => b.type === 'text') && !agent.hadToolsInTurn) {
+        startWaitingTimer(agentId, TEXT_IDLE_DELAY_MS, agents, waitingTimers, broadcast);
+      }
+    } else if (record.type === 'progress') {
+      processProgressRecord(agentId, record, agents, waitingTimers, permissionTimers, broadcast);
+    } else if (record.type === 'user') {
+      const content = record.message?.content;
+      if (Array.isArray(content)) {
+        const blocks = content as Array<{ type: string; tool_use_id?: string }>;
+        const hasToolResult = blocks.some((b) => b.type === 'tool_result');
+        if (hasToolResult) {
+          for (const block of blocks) {
+            if (block.type === 'tool_result' && block.tool_use_id) {
+              const completedToolId = block.tool_use_id;
+              const completedToolName = agent.activeToolNames.get(completedToolId);
+              if (completedToolName === 'Task' || completedToolName === 'Agent') {
+                agent.activeSubagentToolIds.delete(completedToolId);
+                agent.activeSubagentToolNames.delete(completedToolId);
+                broadcast({ type: 'subagentClear', id: agentId, parentToolId: completedToolId });
+              }
+              agent.activeToolIds.delete(completedToolId);
+              agent.activeToolStatuses.delete(completedToolId);
+              agent.activeToolNames.delete(completedToolId);
+              const toolId = completedToolId;
+              setTimeout(() => {
+                broadcast({ type: 'agentToolDone', id: agentId, toolId });
+              }, TOOL_DONE_DELAY_MS);
+            }
+          }
+          if (agent.activeToolIds.size === 0) {
+            agent.hadToolsInTurn = false;
+          }
+        } else {
+          cancelWaitingTimer(agentId, waitingTimers);
+          clearAgentActivity(agent, agentId, permissionTimers, broadcast);
+          agent.hadToolsInTurn = false;
+        }
+      } else if (typeof content === 'string' && content.trim()) {
+        cancelWaitingTimer(agentId, waitingTimers);
+        clearAgentActivity(agent, agentId, permissionTimers, broadcast);
+        agent.hadToolsInTurn = false;
+      }
+    } else if (record.type === 'system' && record.subtype === 'turn_duration') {
+      cancelWaitingTimer(agentId, waitingTimers);
+      cancelPermissionTimer(agentId, permissionTimers);
+
+      if (agent.activeToolIds.size > 0) {
+        agent.activeToolIds.clear();
+        agent.activeToolStatuses.clear();
+        agent.activeToolNames.clear();
+        agent.activeSubagentToolIds.clear();
+        agent.activeSubagentToolNames.clear();
+        broadcast({ type: 'agentToolsClear', id: agentId });
+      }
+
+      agent.isWaiting = true;
+      agent.permissionSent = false;
+      agent.hadToolsInTurn = false;
+      broadcast({ type: 'agentStatus', id: agentId, status: 'waiting' });
+    }
+  } catch {
+    // Ignore malformed lines
+  }
+}
+
+function processProgressRecord(
+  agentId: number,
+  record: Record<string, unknown>,
+  agents: Map<number, AgentState>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  broadcast: Broadcast,
+): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+
+  const parentToolId = record.parentToolUseID as string | undefined;
+  if (!parentToolId) return;
+
+  const data = record.data as Record<string, unknown> | undefined;
+  if (!data) return;
+
+  const dataType = data.type as string | undefined;
+  if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
+    if (agent.activeToolIds.has(parentToolId)) {
+      startPermissionTimer(agentId, agents, permissionTimers, broadcast);
+    }
+    return;
+  }
+
+  const parentToolName = agent.activeToolNames.get(parentToolId);
+  if (parentToolName !== 'Task' && parentToolName !== 'Agent') return;
+
+  const msg = data.message as Record<string, unknown> | undefined;
+  if (!msg) return;
+
+  const msgType = msg.type as string;
+  const innerMsg = msg.message as Record<string, unknown> | undefined;
+  const content = innerMsg?.content;
+  if (!Array.isArray(content)) return;
+
+  if (msgType === 'assistant') {
+    let hasNonExemptSubTool = false;
+    for (const block of content) {
+      if (block.type === 'tool_use' && block.id) {
+        const toolName = block.name || '';
+        const status = formatToolStatus(toolName, block.input || {});
+
+        let subTools = agent.activeSubagentToolIds.get(parentToolId);
+        if (!subTools) {
+          subTools = new Set();
+          agent.activeSubagentToolIds.set(parentToolId, subTools);
+        }
+        subTools.add(block.id);
+
+        let subNames = agent.activeSubagentToolNames.get(parentToolId);
+        if (!subNames) {
+          subNames = new Map();
+          agent.activeSubagentToolNames.set(parentToolId, subNames);
+        }
+        subNames.set(block.id, toolName);
+
+        if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+          hasNonExemptSubTool = true;
+        }
+
+        broadcast({
+          type: 'subagentToolStart',
+          id: agentId,
+          parentToolId,
+          toolId: block.id,
+          status,
+        });
+      }
+    }
+    if (hasNonExemptSubTool) {
+      startPermissionTimer(agentId, agents, permissionTimers, broadcast);
+    }
+  } else if (msgType === 'user') {
+    for (const block of content) {
+      if (block.type === 'tool_result' && block.tool_use_id) {
+        const subTools = agent.activeSubagentToolIds.get(parentToolId);
+        if (subTools) {
+          subTools.delete(block.tool_use_id);
+        }
+        const subNames = agent.activeSubagentToolNames.get(parentToolId);
+        if (subNames) {
+          subNames.delete(block.tool_use_id);
+        }
+
+        const toolId = block.tool_use_id;
+        setTimeout(() => {
+          broadcast({ type: 'subagentToolDone', id: agentId, parentToolId, toolId });
+        }, 300);
+      }
+    }
+    let stillHasNonExempt = false;
+    for (const [, subNames] of agent.activeSubagentToolNames) {
+      for (const [, toolName] of subNames) {
+        if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
+          stillHasNonExempt = true;
+          break;
+        }
+      }
+      if (stillHasNonExempt) break;
+    }
+    if (stillHasNonExempt) {
+      startPermissionTimer(agentId, agents, permissionTimers, broadcast);
+    }
+  }
+}

--- a/standalone/src/types.ts
+++ b/standalone/src/types.ts
@@ -1,0 +1,25 @@
+export interface AgentState {
+  id: number;
+  projectDir: string;
+  projectName: string;
+  jsonlFile: string;
+  fileOffset: number;
+  lineBuffer: string;
+  activeToolIds: Set<string>;
+  activeToolStatuses: Map<string, string>;
+  activeToolNames: Map<string, string>;
+  activeSubagentToolIds: Map<string, Set<string>>;
+  activeSubagentToolNames: Map<string, Map<string, string>>;
+  isWaiting: boolean;
+  permissionSent: boolean;
+  hadToolsInTurn: boolean;
+  folderName?: string;
+}
+
+export interface PersistedAgent {
+  id: number;
+  jsonlFile: string;
+  projectDir: string;
+  projectName: string;
+  folderName?: string;
+}

--- a/standalone/tsconfig.json
+++ b/standalone/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "noEmit": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"webview-ui",
 		"dist",
 		"out",
-		"scripts"
+		"scripts",
+		"standalone"
 	]
 }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -138,6 +138,7 @@ function App() {
     layoutWasReset,
     loadedAssets,
     workspaceFolders,
+    isStandalone,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -278,6 +279,7 @@ function App() {
         alwaysShowOverlay={alwaysShowOverlay}
         onToggleAlwaysShowOverlay={handleToggleAlwaysShowOverlay}
         workspaceFolders={workspaceFolders}
+        isStandalone={isStandalone}
       />
 
       {editor.isEditMode && editor.isDirty && (

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -13,6 +13,7 @@ interface BottomToolbarProps {
   alwaysShowOverlay: boolean;
   onToggleAlwaysShowOverlay: () => void;
   workspaceFolders: WorkspaceFolder[];
+  isStandalone?: boolean;
 }
 
 const panelStyle: React.CSSProperties = {
@@ -55,6 +56,7 @@ export function BottomToolbar({
   alwaysShowOverlay,
   onToggleAlwaysShowOverlay,
   workspaceFolders,
+  isStandalone,
 }: BottomToolbarProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -91,65 +93,67 @@ export function BottomToolbar({
 
   return (
     <div style={panelStyle}>
-      <div ref={folderPickerRef} style={{ position: 'relative' }}>
-        <button
-          onClick={handleAgentClick}
-          onMouseEnter={() => setHovered('agent')}
-          onMouseLeave={() => setHovered(null)}
-          style={{
-            ...btnBase,
-            padding: '5px 12px',
-            background:
-              hovered === 'agent' || isFolderPickerOpen
-                ? 'var(--pixel-agent-hover-bg)'
-                : 'var(--pixel-agent-bg)',
-            border: '2px solid var(--pixel-agent-border)',
-            color: 'var(--pixel-agent-text)',
-          }}
-        >
-          + Agent
-        </button>
-        {isFolderPickerOpen && (
-          <div
+      {!isStandalone && (
+        <div ref={folderPickerRef} style={{ position: 'relative' }}>
+          <button
+            onClick={handleAgentClick}
+            onMouseEnter={() => setHovered('agent')}
+            onMouseLeave={() => setHovered(null)}
             style={{
-              position: 'absolute',
-              bottom: '100%',
-              left: 0,
-              marginBottom: 4,
-              background: 'var(--pixel-bg)',
-              border: '2px solid var(--pixel-border)',
-              borderRadius: 0,
-              boxShadow: 'var(--pixel-shadow)',
-              minWidth: 160,
-              zIndex: 'var(--pixel-controls-z)',
+              ...btnBase,
+              padding: '5px 12px',
+              background:
+                hovered === 'agent' || isFolderPickerOpen
+                  ? 'var(--pixel-agent-hover-bg)'
+                  : 'var(--pixel-agent-bg)',
+              border: '2px solid var(--pixel-agent-border)',
+              color: 'var(--pixel-agent-text)',
             }}
           >
-            {workspaceFolders.map((folder, i) => (
-              <button
-                key={folder.path}
-                onClick={() => handleFolderSelect(folder)}
-                onMouseEnter={() => setHoveredFolder(i)}
-                onMouseLeave={() => setHoveredFolder(null)}
-                style={{
-                  display: 'block',
-                  width: '100%',
-                  textAlign: 'left',
-                  padding: '6px 10px',
-                  fontSize: '22px',
-                  color: 'var(--pixel-text)',
-                  background: hoveredFolder === i ? 'var(--pixel-btn-hover-bg)' : 'transparent',
-                  border: 'none',
-                  borderRadius: 0,
-                  cursor: 'pointer',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {folder.name}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+            + Agent
+          </button>
+          {isFolderPickerOpen && (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: '100%',
+                left: 0,
+                marginBottom: 4,
+                background: 'var(--pixel-bg)',
+                border: '2px solid var(--pixel-border)',
+                borderRadius: 0,
+                boxShadow: 'var(--pixel-shadow)',
+                minWidth: 160,
+                zIndex: 'var(--pixel-controls-z)',
+              }}
+            >
+              {workspaceFolders.map((folder, i) => (
+                <button
+                  key={folder.path}
+                  onClick={() => handleFolderSelect(folder)}
+                  onMouseEnter={() => setHoveredFolder(i)}
+                  onMouseLeave={() => setHoveredFolder(null)}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '6px 10px',
+                    fontSize: '22px',
+                    color: 'var(--pixel-text)',
+                    background: hoveredFolder === i ? 'var(--pixel-btn-hover-bg)' : 'transparent',
+                    border: 'none',
+                    borderRadius: 0,
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {folder.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
       <button
         onClick={onToggleEditMode}
         onMouseEnter={() => setHovered('edit')}

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -57,6 +57,7 @@ export interface ExtensionMessageState {
   layoutWasReset: boolean;
   loadedAssets?: { catalog: FurnitureAsset[]; sprites: Record<string, string[][]> };
   workspaceFolders: WorkspaceFolder[];
+  isStandalone: boolean;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -87,6 +88,7 @@ export function useExtensionMessages(
     { catalog: FurnitureAsset[]; sprites: Record<string, string[][]> } | undefined
   >();
   const [workspaceFolders, setWorkspaceFolders] = useState<WorkspaceFolder[]>([]);
+  const [isStandalone, setIsStandalone] = useState(false);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -384,6 +386,8 @@ export function useExtensionMessages(
       } else if (msg.type === 'settingsLoaded') {
         const soundOn = msg.soundEnabled as boolean;
         setSoundEnabled(soundOn);
+      } else if (msg.type === 'standaloneMode') {
+        setIsStandalone(true);
       } else if (msg.type === 'furnitureAssetsLoaded') {
         try {
           const catalog = msg.catalog as FurnitureAsset[];
@@ -413,5 +417,6 @@ export function useExtensionMessages(
     layoutWasReset,
     loadedAssets,
     workspaceFolders,
+    isStandalone,
   };
 }

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -42,9 +42,12 @@
   /* Vignette */
   --pixel-vignette: radial-gradient(ellipse at center, transparent 50%, rgba(0, 0, 0, 0.6) 100%);
 
-  /* Status dot colors */
+  /* Status dot colors (fallbacks for standalone mode) */
   --pixel-status-permission: var(--vscode-charts-yellow, #cca700);
   --pixel-status-active: var(--vscode-charts-blue, #3794ff);
+
+  /* Standalone mode - override VS Code vars that don't exist outside */
+  --vscode-foreground: #cccccc;
 
   /* ToolOverlay z-index layers */
   --pixel-overlay-z: 41;

--- a/webview-ui/src/vscodeApi.ts
+++ b/webview-ui/src/vscodeApi.ts
@@ -1,3 +1,71 @@
 declare function acquireVsCodeApi(): { postMessage(msg: unknown): void };
 
-export const vscode = acquireVsCodeApi();
+interface VsCodeLike {
+  postMessage(msg: unknown): void;
+}
+
+function createStandaloneApi(): VsCodeLike {
+  let ws: WebSocket | null = null;
+  let pendingMessages: unknown[] = [];
+  let connected = false;
+
+  function connect(): void {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(`${protocol}//${window.location.host}`);
+
+    ws.onopen = () => {
+      connected = true;
+      console.log('[Standalone] WebSocket connected');
+      // Flush pending messages
+      for (const msg of pendingMessages) {
+        ws!.send(JSON.stringify(msg));
+      }
+      pendingMessages = [];
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        // Dispatch as a MessageEvent on window, matching VS Code webview protocol
+        window.dispatchEvent(new MessageEvent('message', { data }));
+      } catch {
+        /* ignore bad messages */
+      }
+    };
+
+    ws.onclose = () => {
+      connected = false;
+      console.log('[Standalone] WebSocket disconnected, reconnecting...');
+      setTimeout(connect, 2000);
+    };
+
+    ws.onerror = () => {
+      ws?.close();
+    };
+  }
+
+  connect();
+
+  return {
+    postMessage(msg: unknown): void {
+      if (connected && ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(msg));
+      } else {
+        pendingMessages.push(msg);
+      }
+    },
+  };
+}
+
+function createApi(): VsCodeLike {
+  if (typeof acquireVsCodeApi === 'function') {
+    try {
+      return acquireVsCodeApi();
+    } catch {
+      // Not in VS Code webview
+    }
+  }
+  return createStandaloneApi();
+}
+
+export const vscode: VsCodeLike = createApi();


### PR DESCRIPTION
## Summary

Adds a standalone Node.js server that serves the Pixel Agents webview as a regular web app, removing the VS Code dependency entirely. The server auto-discovers all active Claude Code sessions across `~/.claude/projects/`.

Related issues: #46, #120, #8

- Add `standalone/` directory with HTTP + WebSocket server
- `vscodeApi.ts` auto-detects environment: VS Code postMessage or WebSocket
- Hide "+ Agent" button in standalone mode (no terminal spawning)
- Proper message ordering (assets -> agents -> layout) for correct character spawning

### Usage

```sh
npm run build
cd standalone && npm install && node build.js
node dist/server.js    # http://localhost:3100
```

## Test plan

- [ ] Run `npm run build` from repo root, then build and start standalone server
- [ ] Verify all active Claude Code sessions appear as animated characters
- [ ] Verify tool activity (typing, reading) animates correctly in real time
- [ ] Verify VS Code extension still works normally (no regression from vscodeApi.ts change)
- [ ] Verify "+ Agent" button is hidden in standalone mode