### PR TITLE
feat: add Agent Teams teammate detection and visualization

### DIFF
--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -7,6 +7,20 @@ import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from '.
 import { processTranscriptLine } from './transcriptParser.js';
 import type { AgentState } from './types.js';
 
+/** Read teammate name from a .meta.json sidecar file */
+function readTeammateMeta(jsonlFile: string): string | null {
+  try {
+    const metaFile = jsonlFile.replace(/\.jsonl$/, '.meta.json');
+    if (fs.existsSync(metaFile)) {
+      const data = JSON.parse(fs.readFileSync(metaFile, 'utf-8'));
+      return typeof data.agentType === 'string' ? data.agentType : null;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
 export function startFileWatching(
   agentId: number,
   filePath: string,
@@ -128,6 +142,18 @@ export function ensureProjectScan(
       projectDir,
       knownJsonlFiles,
       activeAgentIdRef,
+      nextAgentIdRef,
+      agents,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      webview,
+      persistAgents,
+    );
+    scanForTeammateFiles(
+      projectDir,
+      knownJsonlFiles,
       nextAgentIdRef,
       agents,
       fileWatchers,
@@ -267,6 +293,115 @@ function adoptTerminalForFile(
     webview,
   );
   readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+}
+
+/**
+ * Scan for Agent Teams teammate JSONL files inside subagents/ directories.
+ * Teammates write their transcripts to: {projectDir}/{sessionId}/subagents/agent-{hash}.jsonl
+ * with metadata in agent-{hash}.meta.json containing {"agentType": "teammate-name"}.
+ */
+function scanForTeammateFiles(
+  projectDir: string,
+  knownJsonlFiles: Set<string>,
+  nextAgentIdRef: { current: number },
+  agents: Map<number, AgentState>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+): void {
+  // Look for session directories (UUIDs) that contain a subagents/ folder
+  let sessionDirs: string[];
+  try {
+    sessionDirs = fs
+      .readdirSync(projectDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return;
+  }
+
+  // Find the parent agent for teammate association
+  let parentAgentId: number | null = null;
+  for (const agent of agents.values()) {
+    if (!agent.isTeammate) {
+      parentAgentId = agent.id;
+      break;
+    }
+  }
+
+  for (const sessionDir of sessionDirs) {
+    const subagentsDir = path.join(projectDir, sessionDir, 'subagents');
+    let files: string[];
+    try {
+      files = fs
+        .readdirSync(subagentsDir)
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) => path.join(subagentsDir, f));
+    } catch {
+      continue; // subagents/ doesn't exist for this session
+    }
+
+    for (const file of files) {
+      if (knownJsonlFiles.has(file)) continue;
+      knownJsonlFiles.add(file);
+
+      const teammateName = readTeammateMeta(file);
+      if (!teammateName) continue; // Not a teammate, skip
+
+      console.log(
+        `[Pixel Agents] Teammate JSONL detected: ${teammateName} (${path.basename(file)})`,
+      );
+
+      const id = nextAgentIdRef.current++;
+      // Teammates don't have their own terminal — use a dummy reference
+      const dummyTerminal = { name: `Teammate: ${teammateName}` } as vscode.Terminal;
+      const agent: AgentState = {
+        id,
+        terminalRef: dummyTerminal,
+        projectDir,
+        jsonlFile: file,
+        fileOffset: 0,
+        lineBuffer: '',
+        activeToolIds: new Set(),
+        activeToolStatuses: new Map(),
+        activeToolNames: new Map(),
+        activeSubagentToolIds: new Map(),
+        activeSubagentToolNames: new Map(),
+        isWaiting: false,
+        permissionSent: false,
+        hadToolsInTurn: false,
+        isTeammate: true,
+        teammateName,
+        parentAgentId: parentAgentId ?? undefined,
+      };
+
+      agents.set(id, agent);
+      persistAgents();
+
+      webview?.postMessage({
+        type: 'agentCreated',
+        id,
+        isTeammate: true,
+        teammateName,
+        parentAgentId,
+      });
+
+      startFileWatching(
+        id,
+        file,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        webview,
+      );
+      readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+    }
+  }
 }
 
 export function reassignAgentToFile(

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { FILE_WATCHER_POLL_INTERVAL_MS, PROJECT_SCAN_INTERVAL_MS } from './constants.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
-import type { AgentState } from './types.js';
+import type { AgentState, TeamConfig } from './types.js';
 
 /** Read teammate name from a .meta.json sidecar file */
 function readTeammateMeta(jsonlFile: string): string | null {
@@ -19,6 +20,49 @@ function readTeammateMeta(jsonlFile: string): string | null {
     /* ignore */
   }
   return null;
+}
+
+/**
+ * Read all team configs from ~/.claude/teams/ and find teams whose
+ * leadSessionId matches one of the given session directory names.
+ * Returns a map of teammateName → { teamName, teamDescription, teamColor }.
+ */
+function readTeamConfigs(
+  sessionDirs: string[],
+): Map<string, { teamName: string; teamDescription: string; teamColor?: string }> {
+  const result = new Map<
+    string,
+    { teamName: string; teamDescription: string; teamColor?: string }
+  >();
+  const teamsDir = path.join(os.homedir(), '.claude', 'teams');
+  let teamDirs: string[];
+  try {
+    teamDirs = fs
+      .readdirSync(teamsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return result;
+  }
+
+  for (const teamDir of teamDirs) {
+    try {
+      const configPath = path.join(teamsDir, teamDir, 'config.json');
+      const config: TeamConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // Only include teams whose leader session matches one of our project sessions
+      if (!sessionDirs.includes(config.leadSessionId)) continue;
+      for (const member of config.members) {
+        result.set(`${config.leadSessionId}:${member.name}`, {
+          teamName: config.name,
+          teamDescription: config.description,
+          teamColor: member.color,
+        });
+      }
+    } catch {
+      /* ignore malformed configs */
+    }
+  }
+  return result;
 }
 
 export function startFileWatching(
@@ -323,6 +367,7 @@ function adoptTerminalForFile(
  * Scan for Agent Teams teammate JSONL files inside subagents/ directories.
  * Teammates write their transcripts to: {projectDir}/{sessionId}/subagents/agent-{hash}.jsonl
  * with metadata in agent-{hash}.meta.json containing {"agentType": "teammate-name"}.
+ * Also reads ~/.claude/teams/{name}/config.json for team names, descriptions, and colors.
  */
 function scanForTeammateFiles(
   projectDir: string,
@@ -347,16 +392,22 @@ function scanForTeammateFiles(
     return;
   }
 
-  // Find the parent agent for teammate association and collect existing teammate names
+  // Find the parent agent for teammate association
+  // Deduplicate by session:name key (allows same name in different teams)
   let parentAgentId: number | null = null;
-  const existingTeammateNames = new Set<string>();
+  const existingTeammateKeys = new Set<string>();
   for (const agent of agents.values()) {
     if (agent.isTeammate && agent.teammateName) {
-      existingTeammateNames.add(agent.teammateName);
+      // Use the session dir from the JSONL path as part of the key
+      const sessionFromPath = path.basename(path.dirname(path.dirname(agent.jsonlFile)));
+      existingTeammateKeys.add(`${sessionFromPath}:${agent.teammateName}`);
     } else if (!agent.isTeammate) {
       parentAgentId = agent.id;
     }
   }
+
+  // Read team configs to enrich teammates with team metadata
+  const teamConfigMap = readTeamConfigs(sessionDirs);
 
   for (const sessionDir of sessionDirs) {
     const subagentsDir = path.join(projectDir, sessionDir, 'subagents');
@@ -377,16 +428,21 @@ function scanForTeammateFiles(
       const teammateName = readTeammateMeta(file);
       if (!teammateName) continue; // Not a teammate, skip
 
-      // Skip if we already have a character for this teammate name
-      if (existingTeammateNames.has(teammateName)) continue;
-      existingTeammateNames.add(teammateName);
+      // Deduplicate by session + name (allows same name in different teams)
+      const dedupKey = `${sessionDir}:${teammateName}`;
+      if (existingTeammateKeys.has(dedupKey)) continue;
+      existingTeammateKeys.add(dedupKey);
+
+      // Look up team metadata from config
+      const teamInfo = teamConfigMap.get(`${sessionDir}:${teammateName}`);
 
       console.log(
-        `[Pixel Agents] Teammate JSONL detected: ${teammateName} (${path.basename(file)})`,
+        `[Pixel Agents] Teammate JSONL detected: ${teammateName}` +
+          (teamInfo ? ` (team: ${teamInfo.teamName})` : '') +
+          ` (${path.basename(file)})`,
       );
 
       const id = nextAgentIdRef.current++;
-      // Teammates don't have their own terminal — use a dummy reference
       const dummyTerminal = { name: `Teammate: ${teammateName}` } as vscode.Terminal;
       const agent: AgentState = {
         id,
@@ -406,6 +462,9 @@ function scanForTeammateFiles(
         isTeammate: true,
         teammateName,
         parentAgentId: parentAgentId ?? undefined,
+        teamName: teamInfo?.teamName,
+        teamDescription: teamInfo?.teamDescription,
+        teamColor: teamInfo?.teamColor,
       };
 
       agents.set(id, agent);
@@ -417,6 +476,9 @@ function scanForTeammateFiles(
         isTeammate: true,
         teammateName,
         parentAgentId,
+        teamName: teamInfo?.teamName,
+        teamDescription: teamInfo?.teamDescription,
+        teamColor: teamInfo?.teamColor,
       });
 
       startFileWatching(

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -347,12 +347,14 @@ function scanForTeammateFiles(
     return;
   }
 
-  // Find the parent agent for teammate association
+  // Find the parent agent for teammate association and collect existing teammate names
   let parentAgentId: number | null = null;
+  const existingTeammateNames = new Set<string>();
   for (const agent of agents.values()) {
-    if (!agent.isTeammate) {
+    if (agent.isTeammate && agent.teammateName) {
+      existingTeammateNames.add(agent.teammateName);
+    } else if (!agent.isTeammate) {
       parentAgentId = agent.id;
-      break;
     }
   }
 
@@ -374,6 +376,10 @@ function scanForTeammateFiles(
 
       const teammateName = readTeammateMeta(file);
       if (!teammateName) continue; // Not a teammate, skip
+
+      // Skip if we already have a character for this teammate name
+      if (existingTeammateNames.has(teammateName)) continue;
+      existingTeammateNames.add(teammateName);
 
       console.log(
         `[Pixel Agents] Teammate JSONL detected: ${teammateName} (${path.basename(file)})`,

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -137,6 +137,30 @@ export function ensureProjectScan(
     /* dir may not exist yet */
   }
 
+  // Also seed existing teammate JSONL files in subagents/ directories
+  try {
+    const sessionDirs = fs
+      .readdirSync(projectDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+    for (const sessionDir of sessionDirs) {
+      const subagentsDir = path.join(projectDir, sessionDir, 'subagents');
+      try {
+        const subFiles = fs
+          .readdirSync(subagentsDir)
+          .filter((f) => f.endsWith('.jsonl'))
+          .map((f) => path.join(subagentsDir, f));
+        for (const f of subFiles) {
+          knownJsonlFiles.add(f);
+        }
+      } catch {
+        /* subagents/ may not exist */
+      }
+    }
+  } catch {
+    /* dir may not exist yet */
+  }
+
   projectScanTimerRef.current = setInterval(() => {
     scanForNewJsonlFiles(
       projectDir,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,25 @@ export interface AgentState {
   teammateName?: string;
   /** Parent agent ID if this is a teammate */
   parentAgentId?: number;
+  /** Team name this teammate belongs to */
+  teamName?: string;
+  /** Team description (short summary of the team's goal) */
+  teamDescription?: string;
+  /** Team color from config (e.g. "blue", "green") */
+  teamColor?: string;
+}
+
+/** Team config structure from ~/.claude/teams/{name}/config.json */
+export interface TeamConfig {
+  name: string;
+  description: string;
+  leadSessionId: string;
+  members: Array<{
+    agentId: string;
+    name: string;
+    agentType: string;
+    color?: string;
+  }>;
 }
 
 export interface PersistedAgent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,12 @@ export interface AgentState {
   hadToolsInTurn: boolean;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Whether this agent is an Agent Teams teammate (has its own JSONL in subagents/) */
+  isTeammate?: boolean;
+  /** Teammate name from .meta.json (e.g. "domain-reviewer") */
+  teammateName?: string;
+  /** Parent agent ID if this is a teammate */
+  parentAgentId?: number;
 }
 
 export interface PersistedAgent {

--- a/webview-ui/src/components/AgentLabels.tsx
+++ b/webview-ui/src/components/AgentLabels.tsx
@@ -79,7 +79,7 @@ export function AgentLabels({
           dotColor = 'var(--vscode-charts-blue, #3794ff)';
         }
 
-        const labelText = subLabelMap.get(id) || `Agent #${id}`;
+        const labelText = subLabelMap.get(id) || ch.folderName || `Agent #${id}`;
 
         return (
           <div

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -138,9 +138,20 @@ export function useExtensionMessages(
       } else if (msg.type === 'agentCreated') {
         const id = msg.id as number;
         const folderName = msg.folderName as string | undefined;
+        const isTeammate = msg.isTeammate as boolean | undefined;
+        const teammateName = msg.teammateName as string | undefined;
+        const teammateParentId = msg.parentAgentId as number | undefined;
         setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]));
         setSelectedAgent(id);
-        os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+        if (isTeammate && teammateParentId !== undefined) {
+          // Add teammate as a sub-agent character linked to the parent
+          const parentCh = os.characters.get(teammateParentId);
+          const palette = parentCh ? parentCh.palette : undefined;
+          const hueShift = parentCh ? parentCh.hueShift : undefined;
+          os.addAgent(id, palette, hueShift, undefined, undefined, teammateName);
+        } else {
+          os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+        }
         saveAgentSeats(os);
       } else if (msg.type === 'agentClosed') {
         const id = msg.id as number;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -141,14 +141,22 @@ export function useExtensionMessages(
         const isTeammate = msg.isTeammate as boolean | undefined;
         const teammateName = msg.teammateName as string | undefined;
         const teammateParentId = msg.parentAgentId as number | undefined;
+        const teamName = msg.teamName as string | undefined;
+        const teamDescription = msg.teamDescription as string | undefined;
         setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]));
         setSelectedAgent(id);
         if (isTeammate && teammateParentId !== undefined) {
-          // Add teammate as a sub-agent character linked to the parent
+          // Add teammate character linked to the parent
           const parentCh = os.characters.get(teammateParentId);
           const palette = parentCh ? parentCh.palette : undefined;
           const hueShift = parentCh ? parentCh.hueShift : undefined;
           os.addAgent(id, palette, hueShift, undefined, undefined, teammateName);
+          // Enrich character with team metadata
+          const ch = os.characters.get(id);
+          if (ch) {
+            ch.teamDescription = teamDescription;
+            ch.teamName = teamName;
+          }
         } else {
           os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
         }

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -101,9 +101,10 @@ export function ToolOverlay({
         const screenY =
           (deviceOffsetY + (ch.y + sittingOffset - TOOL_OVERLAY_VERTICAL_OFFSET) * zoom) / dpr;
 
-        // Get activity text
+        // Get activity text and optional subtitle
         const subHasPermission = isSub && ch.bubbleType === 'permission';
         let activityText: string;
+        let subtitleText: string | null = null;
         if (isSub) {
           if (subHasPermission) {
             activityText = 'Needs approval';
@@ -112,7 +113,19 @@ export function ToolOverlay({
             activityText = sub ? sub.label : 'Subtask';
           }
         } else {
-          activityText = getActivityText(id, agentTools, ch.isActive);
+          const rawActivity = getActivityText(id, agentTools, ch.isActive);
+          // For teammates: show name as primary, team/activity as subtitle
+          if (ch.folderName) {
+            activityText = ch.folderName;
+            if (rawActivity !== 'Idle') {
+              subtitleText = rawActivity;
+            } else {
+              // Show team description as subtitle when idle
+              subtitleText = ch.teamDescription ?? ch.teamName ?? null;
+            }
+          } else {
+            activityText = rawActivity;
+          }
         }
 
         // Determine dot color
@@ -185,7 +198,7 @@ export function ToolOverlay({
                 >
                   {activityText}
                 </span>
-                {ch.folderName && (
+                {subtitleText && (
                   <span
                     style={{
                       fontSize: '16px',
@@ -195,7 +208,7 @@ export function ToolOverlay({
                       display: 'block',
                     }}
                   >
-                    {ch.folderName}
+                    {subtitleText || ch.folderName}
                   </span>
                 )}
               </div>

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -116,7 +116,7 @@ export function ToolOverlay({
           const rawActivity = getActivityText(id, agentTools, ch.isActive);
           // Primary label: agent identity (name or "Agent #N")
           // Subtitle: current activity when working, team info when idle
-          const agentName = ch.folderName || `Agent #${id}`;
+          const agentName = ch.folderName || `Leader #${id}`;
           if (rawActivity !== 'Idle') {
             activityText = agentName;
             subtitleText = rawActivity;

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -114,17 +114,15 @@ export function ToolOverlay({
           }
         } else {
           const rawActivity = getActivityText(id, agentTools, ch.isActive);
-          // For teammates: show name as primary, team/activity as subtitle
-          if (ch.folderName) {
-            activityText = ch.folderName;
-            if (rawActivity !== 'Idle') {
-              subtitleText = rawActivity;
-            } else {
-              // Show team description as subtitle when idle
-              subtitleText = ch.teamDescription ?? ch.teamName ?? null;
-            }
+          // Primary label: agent identity (name or "Agent #N")
+          // Subtitle: current activity when working, team info when idle
+          const agentName = ch.folderName || `Agent #${id}`;
+          if (rawActivity !== 'Idle') {
+            activityText = agentName;
+            subtitleText = rawActivity;
           } else {
-            activityText = rawActivity;
+            activityText = agentName;
+            subtitleText = ch.teamDescription ?? ch.teamName ?? null;
           }
         }
 

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -188,6 +188,10 @@ export interface Character {
   matrixEffectTimer: number;
   /** Per-column random seeds (16 values) for staggered rain timing */
   matrixEffectSeeds: number[];
-  /** Workspace folder name (only set for multi-root workspaces) */
+  /** Workspace folder name, or teammate name for Agent Teams teammates */
   folderName?: string;
+  /** Team description for Agent Teams teammates */
+  teamDescription?: string;
+  /** Team name for Agent Teams teammates */
+  teamName?: string;
 }


### PR DESCRIPTION
## Summary

- Adds support for visualizing **Claude Code Agent Teams teammates** as separate characters in the Pixel Agents office
- Teammates are detected by scanning `{sessionId}/subagents/*.jsonl` files and reading `.meta.json` sidecar files for teammate names
- Each teammate gets its own character, linked to the parent agent with the same palette/hue

## Background

Claude Code's [Agent Teams](https://docs.anthropic.com/en/docs/claude-code/agent-teams) feature (experimental) allows a leader agent to spawn teammate agents that communicate with each other. Each teammate writes its own JSONL transcript to:

```
~/.claude/projects/{project}/{sessionId}/subagents/agent-{hash}.jsonl
~/.claude/projects/{project}/{sessionId}/subagents/agent-{hash}.meta.json
```

The `.meta.json` file contains `{"agentType": "teammate-name"}`.

Currently, Pixel Agents only scans `*.jsonl` in the project root directory, so teammates are invisible. This PR adds a second scan path for the `subagents/` subdirectories.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `isTeammate`, `teammateName`, `parentAgentId` fields to `AgentState` |
| `src/fileWatcher.ts` | Add `scanForTeammateFiles()` and `readTeammateMeta()` to detect teammate JSONL files in `subagents/` directories |
| `webview-ui/src/hooks/useExtensionMessages.ts` | Handle teammate `agentCreated` messages, inherit parent palette |
| `webview-ui/src/components/AgentLabels.tsx` | Show teammate name in character label via `folderName` field |

## How it works

1. The existing `ensureProjectScan` timer now also calls `scanForTeammateFiles()` every 1s
2. `scanForTeammateFiles` iterates session directories, looks for `subagents/*.jsonl`
3. For each new JSONL, reads the `.meta.json` sidecar to get the teammate name
4. Creates an `AgentState` with `isTeammate: true` and starts file watching (same as regular agents)
5. The webview creates a character with the parent's palette and the teammate name as label

## Test plan

- [ ] Verify regular agents (non-teams) still work exactly as before
- [ ] Start Claude Code with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
- [ ] Spawn an Agent Team with `TeamCreate` and multiple teammates
- [ ] Verify each teammate appears as a separate character in the office
- [ ] Verify teammate labels show their names (e.g., "domain-reviewer")
- [ ] Verify teammate characters animate based on their JSONL activity
- [ ] Verify teammates are removed/go idle when their process ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)