### PR TITLE
fix: prevent duplicate restores, fix tool status reconnect, and improve agent tool detection

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -9,6 +9,7 @@ import {
   persistAgents,
   removeAgent,
   restoreAgents,
+  sendCurrentAgentStatuses,
   sendExistingAgents,
   sendLayout,
 } from './agentManager.js';
@@ -261,6 +262,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // Ensure project scan runs even with no restored agents (to adopt external terminals)
         const projectDir = getProjectDirPath();
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        console.log(`[Pixel Agents] Platform: ${process.platform}, arch: ${process.arch}`);
         console.log('[Extension] workspaceRoot:', workspaceRoot);
         console.log('[Extension] projectDir:', projectDir);
         ensureProjectScan(
@@ -359,6 +361,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
               console.log('[Extension] ⚠️  No assets directory found');
               if (this.webview) {
                 sendLayout(this.context, this.webview, this.defaultLayout);
+                // Send agent statuses AFTER layoutLoaded so characters exist when messages arrive
+                sendCurrentAgentStatuses(this.agents, this.webview);
                 this.startLayoutWatcher();
               }
               return;
@@ -403,6 +407,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           if (this.webview) {
             console.log('[Extension] Sending saved layout');
             sendLayout(this.context, this.webview, this.defaultLayout);
+            // Send agent statuses AFTER layoutLoaded so characters exist when messages arrive
+            sendCurrentAgentStatuses(this.agents, this.webview);
             this.startLayoutWatcher();
           }
         })();

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -277,6 +277,13 @@ export function restoreAgents(
   let restoredProjectDir: string | null = null;
 
   for (const p of persisted) {
+    // Skip agents already in the map — prevents duplicate file watchers on re-entry
+    // (webviewReady fires on every panel focus, re-calling restoreAgents each time)
+    if (agents.has(p.id)) {
+      knownJsonlFiles.add(p.jsonlFile);
+      continue;
+    }
+
     let terminal: vscode.Terminal | undefined;
     const isExternal = p.isExternal ?? false;
 
@@ -479,8 +486,8 @@ export function sendExistingAgents(
     folderNames,
     externalAgents,
   });
-
-  sendCurrentAgentStatuses(agents, webview);
+  // Note: sendCurrentAgentStatuses is called separately AFTER layoutLoaded
+  // so that agentStatus/agentToolStart messages arrive after characters are created.
 }
 
 export function sendCurrentAgentStatuses(
@@ -491,11 +498,13 @@ export function sendCurrentAgentStatuses(
   for (const [agentId, agent] of agents) {
     // Re-send active tools
     for (const [toolId, status] of agent.activeToolStatuses) {
+      const toolName = agent.activeToolNames.get(toolId) ?? '';
       webview.postMessage({
         type: 'agentToolStart',
         id: agentId,
         toolId,
         status,
+        toolName,
       });
     }
     // Re-send waiting status

--- a/src/layoutPersistence.ts
+++ b/src/layoutPersistence.ts
@@ -153,8 +153,9 @@ export function watchLayoutFile(
       fsWatcher = fs.watch(filePath, () => {
         checkForChange();
       });
-      fsWatcher.on('error', () => {
-        // fs.watch can be unreliable — polling backup handles it
+      fsWatcher.on('error', (err) => {
+        // fs.watch can be unreliable on macOS (kqueue) and may hit inotify limits on Linux
+        console.log(`[Pixel Agents] Layout fs.watch error: ${err.message}`);
         fsWatcher?.close();
         fsWatcher = null;
       });

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -107,6 +107,7 @@ export function processTranscriptLine(
               id: agentId,
               toolId: block.id,
               status,
+              toolName,
             });
           }
         }

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -214,13 +214,13 @@ export function useExtensionMessages(
           if (list.some((t) => t.toolId === toolId)) return prev;
           return { ...prev, [id]: [...list, { toolId, status, done: false }] };
         });
-        const toolName = extractToolName(status);
+        const toolName = (msg.toolName as string | undefined) ?? extractToolName(status);
         os.setAgentTool(id, toolName);
         os.setAgentActive(id, true);
         os.clearPermissionBubble(id);
-        // Create sub-agent character for Task tool subtasks
-        if (status.startsWith('Subtask:')) {
-          const label = status.slice('Subtask:'.length).trim();
+        // Create sub-agent character for Task/Agent tool subtasks
+        if (toolName === 'Task' || toolName === 'Agent') {
+          const label = status.startsWith('Subtask:') ? status.slice('Subtask:'.length).trim() : '';
           const subId = os.addSubagent(id, toolId);
           setSubagentCharacters((prev) => {
             if (prev.some((s) => s.id === subId)) return prev;


### PR DESCRIPTION
## Summary                                                                                                                                                                                            
                                                        
Cherry-picked fixes from #95 and #141 (where the other changes from those PRs are already merged in main via #115 and #102), plus a reconnect race condition fix and improved Agent tool sub-agent  detection.
                                                                                                                                                                                                        
  ## What was cherry-picked                                                                                                                                                                             
  
  ### From PR #95 (@mitre88 -- cross-platform compatibility)                                                                                                                                            
  - **Platform logging on startup** (`PixelAgentsViewProvider.ts`) -- logs `process.platform` and `process.arch` for debugging platform-specific issues
  - **Layout watcher error logging** (`layoutPersistence.ts`) -- `fs.watch` error handler now logs the actual error message instead of silently swallowing it                                           
 The other fixes from #95 (fs.watch error handling in fileWatcher.ts, asset path normalization) are already in main via #115 which rewrote file watching.
                                                                                                                                                                                                        
  ### From PR #141 (@noam971 -- external agent detection, macOS fixes)
  - **Duplicate file watcher prevention** (`agentManager.ts`) -- `restoreAgents()` skips agents already in the map, preventing duplicate file watchers when `webviewReady` fires on every panel focus   
The other features from #141 (external agent detection, worktree agents, PID matching) are already in main via #115 which implemented external session support with a different approach.           

Partially supersedes #95
Partially supersedes #141
                                                                                                                                     
  ## Additional fixes
                                                                                                                                                                                                        
  ### Tool status reconnect race condition              
  `sendCurrentAgentStatuses()` moved to run AFTER `sendLayout()` instead of inside `sendExistingAgents()`. Previously, `agentToolStart`/`agentStatus` messages arrived before `layoutLoaded`, so the webview dropped them because characters didn't exist yet. 
                                                                                                                                                                                                        
  ### Pass `toolName` in `agentToolStart` messages                                                                                                                                                      
  - `agentToolStart` now includes the actual `toolName` from the parser, instead of the webview reverse-engineering it from the display status string via `extractToolName()`
  - Sub-agent character creation now triggers on `toolName === 'Task' || toolName === 'Agent'` instead of `status.startsWith('Subtask:')`, so the `Agent` tool also spawns sub-agent characters         
  - `sendCurrentAgentStatuses()` also includes `toolName` for consistent behavior on reconnect     
                                                                                                       
Co-Authored-By: @mitre88
Co-Authored-By: @noam971
                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                          
                                                                                                                                                                                                        
  - [ ] Launch agent, run tools (Read, Edit, Bash) -- tool status shows correctly
  - [ ] Agent uses Task tool -- sub-agent character spawns with label
  - [ ] Agent uses Agent tool -- sub-agent character spawns
  - [ ] Close panel, reopen -- agent appears once (not duplicated)
  - [ ] Agent active with tools, reload panel (F5) -- tools restore correctly after layout loads                                                                                                        
  - [ ] Agent waiting, reload panel -- waiting bubble appears after restore
  - [ ] Internal `/clear` (no externals) -- reassigns correctly, no regression                                                                                                                          
  - [ ] External session detection still works                                                                                                                                                          
  - [ ] Watch All Sessions toggle still works