### PR TITLE
fix: add shared/ to lint, format, and lint-staged

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "tags": ["-internal"],
   "ignoreDependencies": ["tailwindcss", "pngjs", "@types/pngjs"],
   "ignore": [
     "server/src/providers/file/hooks/claude-hook.ts",

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "package": "npm run check-types && npm run lint && node esbuild.js --production && npm run build:webview",
     "check-types": "tsc --noEmit && tsc --noEmit -p server/tsconfig.test.json",
     "prepare": "husky",
-    "lint": "eslint src server && cd webview-ui && eslint .",
-    "lint:fix": "eslint src server --fix && cd webview-ui && eslint . --fix",
+    "lint": "eslint src server shared && cd webview-ui && eslint .",
+    "lint:fix": "eslint src server shared --fix && cd webview-ui && eslint . --fix",
     "import-tileset": "tsx scripts/import-tileset-cli.ts",
-    "format": "prettier --write \"src/**/*.ts\" \"server/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
-    "format:check": "prettier --check \"src/**/*.ts\" \"server/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
+    "format": "prettier --write \"src/**/*.ts\" \"server/**/*.ts\" \"shared/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"server/**/*.ts\" \"shared/**/*.ts\" \"webview-ui/src/**/*.{ts,tsx,css}\" \"*.{js,mjs}\" \"webview-ui/*.{js,ts}\"",
     "test:webview": "cd webview-ui && npm test",
     "test:server": "cd server && npm test",
     "test": "npm run test:webview && npm run test:server",
@@ -94,6 +94,7 @@
   "lint-staged": {
     "src/**/*.ts": "eslint --fix",
     "server/**/*.ts": "eslint --fix",
+    "shared/**/*.ts": "eslint --fix",
     "webview-ui/src/**/*.{ts,tsx}": "eslint --fix",
     "*.{ts,tsx,js,mjs,css,json,md}": "prettier --write",
     "webview-ui/**/*.{ts,tsx,js,css,json}": "prettier --write"

--- a/shared/assets/build.ts
+++ b/shared/assets/build.ts
@@ -9,9 +9,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { CatalogEntry } from './types.js';
 import type { FurnitureManifest, InheritedProps, ManifestGroup } from './manifestUtils.js';
 import { flattenManifest } from './manifestUtils.js';
+import type { CatalogEntry } from './types.js';
 
 // ── Furniture catalog ─────────────────────────────────────────────────────────
 
@@ -35,10 +35,14 @@ export function buildFurnitureCatalog(assetsDir: string): CatalogEntry[] {
       if (manifest.type === 'asset') {
         // Single-asset manifest — validate required fields
         if (
-          manifest.width == null ||
-          manifest.height == null ||
-          manifest.footprintW == null ||
-          manifest.footprintH == null
+          manifest.width === undefined ||
+          manifest.width === null ||
+          manifest.height === undefined ||
+          manifest.height === null ||
+          manifest.footprintW === undefined ||
+          manifest.footprintW === null ||
+          manifest.footprintH === undefined ||
+          manifest.footprintH === null
         ) {
           continue;
         }

--- a/shared/assets/colorUtils.ts
+++ b/shared/assets/colorUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * Pure color conversion utilities — no external dependencies.
+ */
+
+import { PNG_ALPHA_THRESHOLD } from './constants.js';
+
+export function rgbaToHex(r: number, g: number, b: number, a: number): string {
+  if (a < PNG_ALPHA_THRESHOLD) return '';
+  const rgb =
+    `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`.toUpperCase();
+  if (a >= 255) return rgb;
+  return `${rgb}${a.toString(16).padStart(2, '0').toUpperCase()}`;
+}

--- a/shared/assets/pngDecoder.ts
+++ b/shared/assets/pngDecoder.ts
@@ -20,7 +20,6 @@ import {
   WALL_PIECE_WIDTH,
 } from './constants.js';
 import type { CharacterDirectionSprites } from './types.js';
-export type { CharacterDirectionSprites } from './types.js';
 
 // ── Sprite decoding ──────────────────────────────────────────
 

--- a/shared/assets/pngDecoder.ts
+++ b/shared/assets/pngDecoder.ts
@@ -7,13 +7,13 @@
 
 import { PNG } from 'pngjs';
 
+import { rgbaToHex } from './colorUtils.js';
 import {
   CHAR_FRAME_H,
   CHAR_FRAME_W,
   CHAR_FRAMES_PER_ROW,
   CHARACTER_DIRECTIONS,
   FLOOR_TILE_SIZE,
-  PNG_ALPHA_THRESHOLD,
   WALL_BITMASK_COUNT,
   WALL_GRID_COLS,
   WALL_PIECE_HEIGHT,
@@ -21,16 +21,6 @@ import {
 } from './constants.js';
 import type { CharacterDirectionSprites } from './types.js';
 export type { CharacterDirectionSprites } from './types.js';
-
-// ── Pixel conversion ─────────────────────────────────────────
-
-export function rgbaToHex(r: number, g: number, b: number, a: number): string {
-  if (a < PNG_ALPHA_THRESHOLD) return '';
-  const rgb =
-    `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`.toUpperCase();
-  if (a >= 255) return rgb;
-  return `${rgb}${a.toString(16).padStart(2, '0').toUpperCase()}`;
-}
 
 // ── Sprite decoding ──────────────────────────────────────────
 

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -775,7 +775,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   }
 }
 
-export function getWebviewContent(webview: vscode.Webview, extensionUri: vscode.Uri): string {
+function getWebviewContent(webview: vscode.Webview, extensionUri: vscode.Uri): string {
   const distPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview');
   const indexPath = vscode.Uri.joinPath(distPath, 'index.html').fsPath;
 

--- a/src/assetLoader.ts
+++ b/src/assetLoader.ts
@@ -241,7 +241,7 @@ export function loadDefaultLayout(assetsRoot: string): Record<string, unknown> |
 
 // ── Wall tile loading ────────────────────────────────────────
 
-export interface LoadedWallTiles {
+interface LoadedWallTiles {
   /** Array of wall sets, each containing 16 sprites indexed by bitmask (N=1,E=2,S=4,W=8) */
   sets: string[][][][];
 }
@@ -309,7 +309,7 @@ export function sendWallTilesToWebview(webview: vscode.Webview, wallTiles: Loade
   console.log(`📤 Sent ${wallTiles.sets.length} wall tile set(s) to webview`);
 }
 
-export interface LoadedFloorTiles {
+interface LoadedFloorTiles {
   sprites: string[][][]; // N sprites (one per floor_N.png), each 16x16 SpriteData
 }
 

--- a/src/configPersistence.ts
+++ b/src/configPersistence.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { CONFIG_FILE_NAME, LAYOUT_FILE_DIR } from './constants.js';
 
-export interface PixelAgentsConfig {
+interface PixelAgentsConfig {
   externalAssetDirectories: string[];
 }
 

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -197,10 +197,13 @@ export function readNewLines(
 // Track all project directories to scan (supports multi-root workspaces)
 const trackedProjectDirs = new Set<string>();
 
-/** Check if a project dir is tracked by the workspace scanner. */
-export function isTrackedProjectDir(dir: string): boolean {
-  return trackedProjectDirs.has(dir);
-}
+/** Check if a project dir is tracked by the workspace scanner.
+ * Used to prevent adoption of files in untracked dirs before hooks implementation.
+ * TODO: use it or remove it when hooks & heuristic approach are implemented in multi-root workspaces.
+ */
+// export function isTrackedProjectDir(dir: string): boolean {
+//   return trackedProjectDirs.has(dir);
+// }
 
 /**
  * Seed a project directory's known files and register it for periodic scanning.
@@ -855,7 +858,7 @@ export function startStaleExternalAgentCheck(
   }, EXTERNAL_STALE_CHECK_INTERVAL_MS);
 }
 
-export function reassignAgentToFile(
+function reassignAgentToFile(
   agentId: number,
   newFilePath: string,
   agents: Map<number, AgentState>,

--- a/src/layoutPersistence.ts
+++ b/src/layoutPersistence.ts
@@ -48,7 +48,7 @@ export function writeLayoutToFile(layout: Record<string, unknown>): void {
   }
 }
 
-export interface LayoutLoadResult {
+interface LayoutLoadResult {
   layout: Record<string, unknown>;
   /** True when the user's saved layout was replaced by a newer bundled default */
   wasReset: boolean;

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -16,9 +16,9 @@ import {
 } from './timerManager.js';
 import type { AgentState } from './types.js';
 
-export const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
+const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
 
-export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
+function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
   const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
   switch (toolName) {
     case 'Read':

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -2039,9 +2039,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/webview-ui/src/browserMock.ts
+++ b/webview-ui/src/browserMock.ts
@@ -8,13 +8,13 @@
  * Only imported in browser runtime; tree-shaken from VS Code webview runtime.
  */
 
+import { rgbaToHex } from '../../shared/assets/colorUtils.ts';
 import {
   CHAR_FRAME_H,
   CHAR_FRAME_W,
   CHAR_FRAMES_PER_ROW,
   CHARACTER_DIRECTIONS,
   FLOOR_TILE_SIZE,
-  PNG_ALPHA_THRESHOLD,
   WALL_BITMASK_COUNT,
   WALL_GRID_COLS,
   WALL_PIECE_HEIGHT,
@@ -45,14 +45,6 @@ interface DecodedPng {
   width: number;
   height: number;
   data: Uint8ClampedArray;
-}
-
-function rgbaToHex(r: number, g: number, b: number, a: number): string {
-  if (a < PNG_ALPHA_THRESHOLD) return '';
-  const rgb =
-    `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`.toUpperCase();
-  if (a >= 255) return rgb;
-  return `${rgb}${a.toString(16).padStart(2, '0').toUpperCase()}`;
 }
 
 function getPixel(

--- a/webview-ui/src/changelogData.ts
+++ b/webview-ui/src/changelogData.ts
@@ -1,15 +1,15 @@
-export interface ChangelogSection {
+interface ChangelogSection {
   title: string;
   items: string[];
 }
 
-export interface ChangelogContributor {
+interface ChangelogContributor {
   name: string;
   url: string;
   description: string;
 }
 
-export interface ChangelogEntry {
+interface ChangelogEntry {
   version: string;
   sections: ChangelogSection[];
   contributors: ChangelogContributor[];

--- a/webview-ui/src/components/ui/ColorPicker.tsx
+++ b/webview-ui/src/components/ui/ColorPicker.tsx
@@ -1,7 +1,5 @@
 import type { ColorValue } from './types.js';
 
-export type { ColorValue } from './types.js';
-
 function ColorSlider({
   label,
   value,

--- a/webview-ui/src/hooks/useEditorActions.ts
+++ b/webview-ui/src/hooks/useEditorActions.ts
@@ -32,7 +32,7 @@ import { EditTool } from '../office/types.js';
 import { TileType } from '../office/types.js';
 import { vscode } from '../vscodeApi.js';
 
-export interface EditorActions {
+interface EditorActions {
   isEditMode: boolean;
   editorTick: number;
   isDirty: boolean;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -18,7 +18,7 @@ export interface SubagentCharacter {
   label: string;
 }
 
-export interface FurnitureAsset {
+interface FurnitureAsset {
   id: string;
   name: string;
   label: string;
@@ -46,7 +46,7 @@ export interface WorkspaceFolder {
   path: string;
 }
 
-export interface ExtensionMessageState {
+interface ExtensionMessageState {
   agents: number[];
   selectedAgent: number | null;
   agentTools: Record<number, ToolActivity[]>;

--- a/webview-ui/src/office/colorize.ts
+++ b/webview-ui/src/office/colorize.ts
@@ -44,7 +44,7 @@ export function clearColorizeCache(): void {
  * 4. Create HSL color with user's hue + saturation
  * 5. Convert HSL -> RGB -> hex
  */
-export function colorizeSprite(sprite: SpriteData, color: ColorValue): SpriteData {
+function colorizeSprite(sprite: SpriteData, color: ColorValue): SpriteData {
   const { h, s, b, c } = color;
   const result: SpriteData = [];
 

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -17,6 +17,7 @@ import { CharacterState, Direction, TILE_SIZE } from '../types.js';
 /** Tools that show reading animation instead of typing */
 const READING_TOOLS = new Set(['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch']);
 
+/** @internal */
 export function isReadingTool(tool: string | null): boolean {
   if (!tool) return false;
   return READING_TOOLS.has(tool);

--- a/webview-ui/src/office/engine/gameLoop.ts
+++ b/webview-ui/src/office/engine/gameLoop.ts
@@ -1,5 +1,6 @@
 import { MAX_DELTA_TIME_SEC } from '../../constants.js';
 
+/** @internal */
 export interface GameLoopCallbacks {
   update: (dt: number) => void;
   render: (ctx: CanvasRenderingContext2D) => void;

--- a/webview-ui/src/office/engine/renderer.ts
+++ b/webview-ui/src/office/engine/renderer.ts
@@ -54,6 +54,7 @@ import { renderMatrixEffect } from './matrixEffect.js';
 
 // ── Render functions ────────────────────────────────────────────
 
+/** @internal */
 export function renderTileGrid(
   ctx: CanvasRenderingContext2D,
   tileMap: TileTypeVal[][],
@@ -105,6 +106,7 @@ interface ZDrawable {
   draw: (ctx: CanvasRenderingContext2D) => void;
 }
 
+/** @internal */
 export function renderScene(
   ctx: CanvasRenderingContext2D,
   furniture: FurnitureInstance[],
@@ -212,7 +214,7 @@ export function renderScene(
 
 // ── Seat indicators ─────────────────────────────────────────────
 
-export function renderSeatIndicators(
+function renderSeatIndicators(
   ctx: CanvasRenderingContext2D,
   seats: Map<string, Seat>,
   characters: Map<number, Character>,
@@ -251,6 +253,7 @@ export function renderSeatIndicators(
 
 // ── Edit mode overlays ──────────────────────────────────────────
 
+/** @internal */
 export function renderGridOverlay(
   ctx: CanvasRenderingContext2D,
   offsetX: number,
@@ -296,7 +299,7 @@ export function renderGridOverlay(
 }
 
 /** Draw faint expansion placeholders 1 tile outside grid bounds (ghost border). */
-export function renderGhostBorder(
+function renderGhostBorder(
   ctx: CanvasRenderingContext2D,
   offsetX: number,
   offsetY: number,
@@ -339,6 +342,7 @@ export function renderGhostBorder(
   ctx.restore();
 }
 
+/** @internal */
 export function renderGhostPreview(
   ctx: CanvasRenderingContext2D,
   sprite: SpriteData,
@@ -371,6 +375,7 @@ export function renderGhostPreview(
   ctx.restore();
 }
 
+/** @internal */
 export function renderSelectionHighlight(
   ctx: CanvasRenderingContext2D,
   col: number,
@@ -392,6 +397,7 @@ export function renderSelectionHighlight(
   ctx.restore();
 }
 
+/** @internal */
 export function renderDeleteButton(
   ctx: CanvasRenderingContext2D,
   col: number,
@@ -431,7 +437,7 @@ export function renderDeleteButton(
   return { cx, cy, radius };
 }
 
-export function renderRotateButton(
+function renderRotateButton(
   ctx: CanvasRenderingContext2D,
   col: number,
   row: number,
@@ -480,7 +486,7 @@ export function renderRotateButton(
 
 // ── Speech bubbles ──────────────────────────────────────────────
 
-export function renderBubbles(
+function renderBubbles(
   ctx: CanvasRenderingContext2D,
   characters: Character[],
   offsetX: number,

--- a/webview-ui/src/office/floorTiles.ts
+++ b/webview-ui/src/office/floorTiles.ts
@@ -31,7 +31,7 @@ export function setFloorSprites(sprites: SpriteData[]): void {
 
 /** Get the raw (grayscale) floor sprite for a pattern index (1-7 -> array index 0-6).
  *  Falls back to the default solid gray tile when floors.png is not loaded. */
-export function getFloorSprite(patternIndex: number): SpriteData | null {
+function getFloorSprite(patternIndex: number): SpriteData | null {
   const idx = patternIndex - 1;
   if (idx < 0) return null;
   if (idx < floorSprites.length) return floorSprites[idx];
@@ -50,10 +50,10 @@ export function getFloorPatternCount(): number {
   return floorSprites.length > 0 ? floorSprites.length : 1;
 }
 
-/** Get all floor sprites (for preview rendering, falls back to default solid tile) */
-export function getAllFloorSprites(): SpriteData[] {
-  return floorSprites.length > 0 ? floorSprites : [DEFAULT_FLOOR_SPRITE];
-}
+/** Get all floor sprites (for preview rendering, falls back to default solid tile) - unused */
+// function getAllFloorSprites(): SpriteData[] {
+//   return floorSprites.length > 0 ? floorSprites : [DEFAULT_FLOOR_SPRITE];
+// }
 
 /**
  * Get a colorized version of a floor sprite.

--- a/webview-ui/src/office/layout/furnitureCatalog.ts
+++ b/webview-ui/src/office/layout/furnitureCatalog.ts
@@ -33,6 +33,7 @@ export type FurnitureCategory =
   | 'wall'
   | 'misc';
 
+/** @internal */
 export interface CatalogEntryWithCategory extends FurnitureCatalogEntry {
   category: FurnitureCategory;
 }
@@ -325,15 +326,17 @@ export function getCatalogByCategory(category: FurnitureCategory): CatalogEntryW
   return catalog.filter((e) => e.category === category);
 }
 
-export function getActiveCatalog(): CatalogEntryWithCategory[] {
-  return dynamicCatalog ?? [];
-}
+/* Currently unused since the editor palette is organized by category. */
+// function getActiveCatalog(): CatalogEntryWithCategory[] {
+//   return dynamicCatalog ?? [];
+// }
 
 export function getActiveCategories(): Array<{ id: FurnitureCategory; label: string }> {
   const categories = dynamicCategories ?? [];
   return FURNITURE_CATEGORIES.filter((c) => categories.includes(c.id));
 }
 
+/** @internal */
 export const FURNITURE_CATEGORIES: Array<{ id: FurnitureCategory; label: string }> = [
   { id: 'desks', label: 'Desks' },
   { id: 'chairs', label: 'Chairs' },
@@ -368,10 +371,10 @@ export function getOnStateType(currentType: string): string {
   return offToOn.get(currentType) ?? currentType;
 }
 
-/** Returns the "off" variant if this type has one, otherwise returns the type unchanged. */
-export function getOffStateType(currentType: string): string {
-  return onToOff.get(currentType) ?? currentType;
-}
+/** Returns the "off" variant if this type has one, otherwise returns the type unchanged - unused */
+// function getOffStateType(currentType: string): string {
+//   return onToOff.get(currentType) ?? currentType;
+// }
 
 /** Returns true if the given furniture type is part of a rotation group. */
 export function isRotatable(type: string): boolean {

--- a/webview-ui/src/office/layout/layoutSerializer.ts
+++ b/webview-ui/src/office/layout/layoutSerializer.ts
@@ -230,7 +230,8 @@ export function layoutToSeats(furniture: PlacedFurniture[]): Map<string, Seat> {
   return seats;
 }
 
-/** Get the set of tiles occupied by seats (so they can be excluded from blocked tiles) */
+/** Get the set of tiles occupied by seats (so they can be excluded from blocked tiles)
+ * @internal */
 export function getSeatTiles(seats: Map<string, Seat>): Set<string> {
   const tiles = new Set<string>();
   for (const seat of seats.values()) {
@@ -271,7 +272,8 @@ export function createDefaultLayout(): OfficeLayout {
   return { version: 1, cols: DEFAULT_COLS, rows: DEFAULT_ROWS, tiles, tileColors, furniture: [] };
 }
 
-/** Serialize layout to JSON string */
+/** Serialize layout to JSON string
+ * @internal */
 export function serializeLayout(layout: OfficeLayout): string {
   return JSON.stringify(layout);
 }
@@ -307,7 +309,8 @@ function migrateFurnitureTypes(furniture: PlacedFurniture[]): PlacedFurniture[] 
   return migrated;
 }
 
-/** Deserialize layout from JSON string, migrating old tile types if needed */
+/** Deserialize layout from JSON string, migrating old tile types if needed
+ * @internal */
 export function deserializeLayout(json: string): OfficeLayout | null {
   try {
     const obj = JSON.parse(json);

--- a/webview-ui/src/office/sprites/spriteData.ts
+++ b/webview-ui/src/office/sprites/spriteData.ts
@@ -48,7 +48,7 @@ export function getLoadedCharacterCount(): number {
 }
 
 /** Flip a SpriteData horizontally (for generating left sprites from right) */
-export function flipSpriteHorizontal(sprite: SpriteData): SpriteData {
+function flipSpriteHorizontal(sprite: SpriteData): SpriteData {
   return sprite.map((row) => [...row].reverse());
 }
 

--- a/webview-ui/src/office/toolUtils.ts
+++ b/webview-ui/src/office/toolUtils.ts
@@ -1,5 +1,5 @@
 /** Map status prefixes back to tool names for animation selection */
-export const STATUS_TO_TOOL: Record<string, string> = {
+const STATUS_TO_TOOL: Record<string, string> = {
   Reading: 'Read',
   Searching: 'Grep',
   Globbing: 'Glob',

--- a/webview-ui/src/office/wallTiles.ts
+++ b/webview-ui/src/office/wallTiles.ts
@@ -59,7 +59,7 @@ function buildWallMask(col: number, row: number, tileMap: TileTypeVal[][]): numb
  * Get the wall sprite for a tile based on its cardinal neighbors.
  * Returns the sprite + Y offset, or null to fall back to solid WALL_COLOR.
  */
-export function getWallSprite(
+function getWallSprite(
   col: number,
   row: number,
   tileMap: TileTypeVal[][],
@@ -81,7 +81,7 @@ export function getWallSprite(
  * Uses Colorize mode (grayscale → HSL) like floor tiles.
  * Returns the colorized sprite + Y offset, or null if no wall sprites loaded.
  */
-export function getColorizedWallSprite(
+function getColorizedWallSprite(
   col: number,
   row: number,
   tileMap: TileTypeVal[][],

--- a/webview-ui/src/runtime.ts
+++ b/webview-ui/src/runtime.ts
@@ -8,9 +8,9 @@
 
 declare function acquireVsCodeApi(): unknown;
 
-export type Runtime = 'vscode' | 'browser';
+type Runtime = 'vscode' | 'browser';
 // Future: 'cursor' | 'windsurf' | 'electron' | etc.
 
-export const runtime: Runtime = typeof acquireVsCodeApi !== 'undefined' ? 'vscode' : 'browser';
+const runtime: Runtime = typeof acquireVsCodeApi !== 'undefined' ? 'vscode' : 'browser';
 
 export const isBrowserRuntime = runtime === 'browser';


### PR DESCRIPTION
## Description
  - Add `shared/` directory to `lint`, `lint:fix`, `format`, `format:check`, and `lint-staged` scripts so CI and pre-commit hooks cover all TypeScript sources
    - Remove unused exports and tag barrel-reexported symbols as `@internal` for knip                                                                                                         

## Type of change
- [x] Refactor / code cleanup
- [x] CI / build