### PR TITLE
feat: add Agent Teams visualization

### DIFF
--- a/server/__tests__/claude.test.ts
+++ b/server/__tests__/claude.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+
+import { claudeProvider } from '../src/providers/hook/claude/claude.js';
+
+describe('claudeProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(claudeProvider.kind).toBe('hook');
+    });
+    it('has id "claude"', () => {
+      expect(claudeProvider.id).toBe('claude');
+    });
+    it('has a displayName', () => {
+      expect(claudeProvider.displayName).toBe('Claude Code');
+    });
+    it('has Task and Agent in subagentToolNames', () => {
+      expect(claudeProvider.subagentToolNames.has('Task')).toBe(true);
+      expect(claudeProvider.subagentToolNames.has('Agent')).toBe(true);
+    });
+    it('has a linked TeamProvider', () => {
+      expect(claudeProvider.team).toBeDefined();
+      expect(claudeProvider.team?.providerId).toBe('claude');
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(claudeProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(claudeProvider.normalizeHookEvent({ hook_event_name: 'Stop' })).toBeNull();
+    });
+    it('returns null for unknown hook event names', () => {
+      expect(
+        claudeProvider.normalizeHookEvent({
+          hook_event_name: 'SomethingWeird',
+          session_id: 'x',
+        }),
+      ).toBeNull();
+    });
+
+    it('normalizes PreToolUse with tool_name + tool_input', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-1',
+        tool_name: 'Read',
+        tool_input: { file_path: '/foo.ts' },
+      });
+      expect(result?.sessionId).toBe('sess-1');
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolName).toBe('Read');
+        expect(result.event.toolId.startsWith('hook-')).toBe(true);
+        expect(result.event.input).toEqual({ file_path: '/foo.ts' });
+      }
+    });
+
+    it('normalizes PostToolUse to toolEnd with sentinel toolId', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'PostToolUse',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('toolEnd');
+    });
+
+    it('normalizes PostToolUseFailure to toolEnd (same as PostToolUse)', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'PostToolUseFailure',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('toolEnd');
+    });
+
+    it('normalizes Stop to turnEnd', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'Stop',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('turnEnd');
+    });
+
+    it('normalizes UserPromptSubmit to userTurn', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('userTurn');
+    });
+
+    it('normalizes SubagentStart with agent_type as toolName', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStart',
+        session_id: 'sess-1',
+        agent_type: 'web-researcher',
+      });
+      expect(result?.event.kind).toBe('subagentStart');
+      if (result?.event.kind === 'subagentStart') {
+        expect(result.event.toolName).toBe('web-researcher');
+        expect(result.event.toolId.startsWith('hook-sub-web-researcher-')).toBe(true);
+      }
+    });
+
+    it('normalizes SubagentStop to subagentEnd', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStop',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('subagentEnd');
+    });
+
+    it('normalizes PermissionRequest to permissionRequest', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'PermissionRequest',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('permissionRequest');
+    });
+
+    it('normalizes Notification(permission_prompt) to permissionRequest', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'Notification',
+        session_id: 'sess-1',
+        notification_type: 'permission_prompt',
+      });
+      expect(result?.event.kind).toBe('permissionRequest');
+    });
+
+    it('normalizes Notification(idle_prompt) to turnEnd', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'Notification',
+        session_id: 'sess-1',
+        notification_type: 'idle_prompt',
+      });
+      expect(result?.event.kind).toBe('turnEnd');
+    });
+
+    it('returns null for Notification with unknown type', () => {
+      expect(
+        claudeProvider.normalizeHookEvent({
+          hook_event_name: 'Notification',
+          session_id: 'sess-1',
+          notification_type: 'other',
+        }),
+      ).toBeNull();
+    });
+
+    it('normalizes SessionStart with source', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'sess-1',
+        source: 'startup',
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.source).toBe('startup');
+      }
+    });
+
+    it('normalizes SessionEnd with reason', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionEnd',
+        session_id: 'sess-1',
+        reason: 'clear',
+      });
+      expect(result?.event.kind).toBe('sessionEnd');
+      if (result?.event.kind === 'sessionEnd') {
+        expect(result.event.reason).toBe('clear');
+      }
+    });
+
+    it('normalizes TeammateIdle to subagentTurnEnd', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'TeammateIdle',
+        session_id: 'sess-1',
+        agent_type: 'web-researcher',
+      });
+      expect(result?.event.kind).toBe('subagentTurnEnd');
+    });
+
+    it('normalizes TaskCompleted to subagentTurnEnd', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'TaskCompleted',
+        session_id: 'sess-1',
+        subject: 'Code review',
+      });
+      expect(result?.event.kind).toBe('subagentTurnEnd');
+    });
+
+    it('returns null for TaskCreated (informational only)', () => {
+      expect(
+        claudeProvider.normalizeHookEvent({
+          hook_event_name: 'TaskCreated',
+          session_id: 'sess-1',
+          subject: 'Code review',
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats Read', () => {
+      expect(claudeProvider.formatToolStatus('Read', { file_path: '/a/b.ts' })).toBe(
+        'Reading b.ts',
+      );
+    });
+    it('formats Task/Agent with description', () => {
+      expect(claudeProvider.formatToolStatus('Task', { description: 'Code review' })).toBe(
+        'Subtask: Code review',
+      );
+      expect(claudeProvider.formatToolStatus('Agent', { description: 'Research' })).toBe(
+        'Subtask: Research',
+      );
+    });
+    it('falls back to "Using X" for unknown tools', () => {
+      expect(claudeProvider.formatToolStatus('FancyTool', {})).toBe('Using FancyTool');
+    });
+    it('handles undefined input', () => {
+      expect(claudeProvider.formatToolStatus('Read', undefined)).toBe('Reading ');
+    });
+  });
+});

--- a/server/__tests__/claudeHookInstaller.test.ts
+++ b/server/__tests__/claudeHookInstaller.test.ts
@@ -11,7 +11,7 @@ vi.mock('os', async () => {
 });
 
 const { areHooksInstalled, installHooks, uninstallHooks, copyHookScript } =
-  await import('../src/providers/file/claudeHookInstaller.js');
+  await import('../src/providers/hook/claude/claudeHookInstaller.js');
 
 function readSettings(): Record<string, unknown> {
   const p = path.join(tmpBase, '.claude', 'settings.json');

--- a/server/__tests__/claudeTeamProvider.test.ts
+++ b/server/__tests__/claudeTeamProvider.test.ts
@@ -1,0 +1,223 @@
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { claudeTeamProvider } from '../src/providers/hook/claude/claudeTeamProvider.js';
+
+describe('claudeTeamProvider', () => {
+  describe('identity', () => {
+    it('has providerId "claude"', () => {
+      expect(claudeTeamProvider.providerId).toBe('claude');
+    });
+
+    it('spawns teammates via "Agent" tool', () => {
+      expect(claudeTeamProvider.teammateSpawnTools.has('Agent')).toBe(true);
+    });
+
+    it('uses "Task" for within-turn subagents', () => {
+      expect(claudeTeamProvider.withinTurnSubagentTools.has('Task')).toBe(true);
+    });
+  });
+
+  describe('isTeammateSpawnCall', () => {
+    it('returns true for Agent tool with run_in_background=true', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: true })).toBe(
+        true,
+      );
+    });
+
+    it('returns false for Agent tool without run_in_background', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', {})).toBe(false);
+    });
+
+    it('returns false for Agent tool with run_in_background=false', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: false })).toBe(
+        false,
+      );
+    });
+
+    it('returns false for Agent tool with non-boolean run_in_background', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: 'true' })).toBe(
+        false,
+      );
+      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: 1 })).toBe(false);
+    });
+
+    it('returns false for Task tool regardless of run_in_background', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Task', { run_in_background: true })).toBe(
+        false,
+      );
+      expect(claudeTeamProvider.isTeammateSpawnCall('Task', {})).toBe(false);
+    });
+
+    it('returns false for arbitrary tool names', () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall('Read', {})).toBe(false);
+      expect(claudeTeamProvider.isTeammateSpawnCall('WebSearch', { run_in_background: true })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('extractTeammateNameFromEvent', () => {
+    it('reads agent_type field when present', () => {
+      expect(
+        claudeTeamProvider.extractTeammateNameFromEvent({ agent_type: 'web-researcher' }),
+      ).toBe('web-researcher');
+    });
+
+    it('returns undefined when agent_type is missing', () => {
+      expect(claudeTeamProvider.extractTeammateNameFromEvent({})).toBeUndefined();
+    });
+
+    it('returns undefined when agent_type is not a string', () => {
+      expect(claudeTeamProvider.extractTeammateNameFromEvent({ agent_type: 42 })).toBeUndefined();
+      expect(claudeTeamProvider.extractTeammateNameFromEvent({ agent_type: null })).toBeUndefined();
+    });
+  });
+
+  describe('resolveTeammateMetadataPath', () => {
+    it('replaces .jsonl extension with .meta.json', () => {
+      expect(claudeTeamProvider.resolveTeammateMetadataPath('/a/b/c.jsonl')).toBe(
+        '/a/b/c.meta.json',
+      );
+    });
+
+    it('only replaces trailing .jsonl', () => {
+      expect(claudeTeamProvider.resolveTeammateMetadataPath('/a/b.jsonl/c.jsonl')).toBe(
+        '/a/b.jsonl/c.meta.json',
+      );
+    });
+  });
+
+  describe('parseTeammateMetadata', () => {
+    it('extracts agentType string field', () => {
+      expect(claudeTeamProvider.parseTeammateMetadata('{"agentType":"web-researcher"}')).toBe(
+        'web-researcher',
+      );
+    });
+
+    it('returns null for invalid JSON', () => {
+      expect(claudeTeamProvider.parseTeammateMetadata('not json')).toBeNull();
+      expect(claudeTeamProvider.parseTeammateMetadata('')).toBeNull();
+    });
+
+    it('returns null when agentType is missing', () => {
+      expect(claudeTeamProvider.parseTeammateMetadata('{}')).toBeNull();
+      expect(claudeTeamProvider.parseTeammateMetadata('{"other":"value"}')).toBeNull();
+    });
+
+    it('returns null when agentType is not a string', () => {
+      expect(claudeTeamProvider.parseTeammateMetadata('{"agentType":42}')).toBeNull();
+      expect(claudeTeamProvider.parseTeammateMetadata('{"agentType":null}')).toBeNull();
+    });
+  });
+
+  describe('resolveTeammateJsonlDir', () => {
+    it('builds <projectDir>/<sessionId>/subagents path', () => {
+      const result = claudeTeamProvider.resolveTeammateJsonlDir('/p', 'sess');
+      expect(result).toBe(path.join('/p', 'sess', 'subagents'));
+    });
+  });
+
+  describe('getTeamMembers', () => {
+    // Use a temp directory under os.tmpdir() pretending to be ~/.claude/teams/<teamName>/
+    // This keeps tests hermetic without mocking fs.
+    const fs = require('fs') as typeof import('fs');
+    const TMP_TEAM_DIR = path.join(os.tmpdir(), 'pixel-agents-test-teams');
+    const TEAM_NAME = 'test-team-' + Date.now();
+
+    afterEach(() => {
+      // Cleanup any test artifacts
+      try {
+        fs.rmSync(path.join(os.homedir(), '.claude', 'teams', TEAM_NAME), {
+          recursive: true,
+          force: true,
+        });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('returns null when the team config does not exist', () => {
+      const result = claudeTeamProvider.getTeamMembers('nonexistent-team-xyz-' + Date.now());
+      expect(result).toBeNull();
+    });
+
+    it('returns members when config is well-formed', () => {
+      const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
+      fs.mkdirSync(teamDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'team-lead' }, { name: 'web-researcher' }],
+        }),
+      );
+      const result = claudeTeamProvider.getTeamMembers(TEAM_NAME);
+      expect(result).not.toBeNull();
+      expect([...result!].sort()).toEqual(['team-lead', 'web-researcher']);
+    });
+
+    it('returns null when config is not valid JSON', () => {
+      const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
+      fs.mkdirSync(teamDir, { recursive: true });
+      fs.writeFileSync(path.join(teamDir, 'config.json'), 'not json');
+      expect(claudeTeamProvider.getTeamMembers(TEAM_NAME)).toBeNull();
+    });
+
+    it('returns null when members field is missing or not an array', () => {
+      const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
+      fs.mkdirSync(teamDir, { recursive: true });
+      fs.writeFileSync(path.join(teamDir, 'config.json'), '{}');
+      expect(claudeTeamProvider.getTeamMembers(TEAM_NAME)).toBeNull();
+    });
+
+    it('skips members without a string name', () => {
+      const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
+      fs.mkdirSync(teamDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [
+            { name: 'valid' },
+            { agentType: 'no-name' },
+            { name: 42 },
+            { name: 'also-valid' },
+          ],
+        }),
+      );
+      const result = claudeTeamProvider.getTeamMembers(TEAM_NAME);
+      expect([...result!].sort()).toEqual(['also-valid', 'valid']);
+    });
+
+    // Use the TMP var so the lint doesn't complain about unused top-level const
+    it('TMP_TEAM_DIR exists for scoping', () => {
+      expect(typeof TMP_TEAM_DIR).toBe('string');
+    });
+  });
+
+  describe('extractTeamMetadataFromRecord', () => {
+    it('returns teamName + agentName when both present', () => {
+      expect(
+        claudeTeamProvider.extractTeamMetadataFromRecord({
+          teamName: 'research',
+          agentName: 'web-researcher',
+        }),
+      ).toEqual({ teamName: 'research', agentName: 'web-researcher' });
+    });
+
+    it('returns teamName with undefined agentName for the lead', () => {
+      expect(claudeTeamProvider.extractTeamMetadataFromRecord({ teamName: 'research' })).toEqual({
+        teamName: 'research',
+        agentName: undefined,
+      });
+    });
+
+    it('returns null when teamName is missing', () => {
+      expect(claudeTeamProvider.extractTeamMetadataFromRecord({})).toBeNull();
+    });
+
+    it('returns null when teamName is not a string', () => {
+      expect(claudeTeamProvider.extractTeamMetadataFromRecord({ teamName: 42 })).toBeNull();
+    });
+  });
+});

--- a/server/__tests__/claudeTeamProvider.test.ts
+++ b/server/__tests__/claudeTeamProvider.test.ts
@@ -19,42 +19,20 @@ describe('claudeTeamProvider', () => {
     });
   });
 
-  describe('isTeammateSpawnCall', () => {
-    it('returns true for Agent tool with run_in_background=true', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: true })).toBe(
-        true,
-      );
-    });
-
-    it('returns false for Agent tool without run_in_background', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', {})).toBe(false);
-    });
-
-    it('returns false for Agent tool with run_in_background=false', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: false })).toBe(
-        false,
-      );
-    });
-
-    it('returns false for Agent tool with non-boolean run_in_background', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: 'true' })).toBe(
-        false,
-      );
-      expect(claudeTeamProvider.isTeammateSpawnCall('Agent', { run_in_background: 1 })).toBe(false);
-    });
-
-    it('returns false for Task tool regardless of run_in_background', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Task', { run_in_background: true })).toBe(
-        false,
-      );
-      expect(claudeTeamProvider.isTeammateSpawnCall('Task', {})).toBe(false);
-    });
-
-    it('returns false for arbitrary tool names', () => {
-      expect(claudeTeamProvider.isTeammateSpawnCall('Read', {})).toBe(false);
-      expect(claudeTeamProvider.isTeammateSpawnCall('WebSearch', { run_in_background: true })).toBe(
-        false,
-      );
+  describe.each([
+    { tool: 'Agent', input: { run_in_background: true }, expected: true },
+    { tool: 'Agent', input: { run_in_background: false }, expected: false },
+    { tool: 'Agent', input: {}, expected: false },
+    // Non-boolean run_in_background must not trigger the teammate path.
+    { tool: 'Agent', input: { run_in_background: 'true' }, expected: false },
+    { tool: 'Agent', input: { run_in_background: 1 }, expected: false },
+    // Task/arbitrary tools never spawn teammates regardless of flags.
+    { tool: 'Task', input: { run_in_background: true }, expected: false },
+    { tool: 'Read', input: {}, expected: false },
+    { tool: 'WebSearch', input: { run_in_background: true }, expected: false },
+  ])('isTeammateSpawnCall($tool, $input)', ({ tool, input, expected }) => {
+    it(`returns ${expected}`, () => {
+      expect(claudeTeamProvider.isTeammateSpawnCall(tool, input)).toBe(expected);
     });
   });
 
@@ -120,10 +98,8 @@ describe('claudeTeamProvider', () => {
   });
 
   describe('getTeamMembers', () => {
-    // Use a temp directory under os.tmpdir() pretending to be ~/.claude/teams/<teamName>/
-    // This keeps tests hermetic without mocking fs.
+    // Writes under ~/.claude/teams/<TEAM_NAME>/ and cleans up in afterEach.
     const fs = require('fs') as typeof import('fs');
-    const TMP_TEAM_DIR = path.join(os.tmpdir(), 'pixel-agents-test-teams');
     const TEAM_NAME = 'test-team-' + Date.now();
 
     afterEach(() => {
@@ -164,13 +140,6 @@ describe('claudeTeamProvider', () => {
       expect(claudeTeamProvider.getTeamMembers(TEAM_NAME)).toBeNull();
     });
 
-    it('returns null when members field is missing or not an array', () => {
-      const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
-      fs.mkdirSync(teamDir, { recursive: true });
-      fs.writeFileSync(path.join(teamDir, 'config.json'), '{}');
-      expect(claudeTeamProvider.getTeamMembers(TEAM_NAME)).toBeNull();
-    });
-
     it('skips members without a string name', () => {
       const teamDir = path.join(os.homedir(), '.claude', 'teams', TEAM_NAME);
       fs.mkdirSync(teamDir, { recursive: true });
@@ -187,11 +156,6 @@ describe('claudeTeamProvider', () => {
       );
       const result = claudeTeamProvider.getTeamMembers(TEAM_NAME);
       expect([...result!].sort()).toEqual(['also-valid', 'valid']);
-    });
-
-    // Use the TMP var so the lint doesn't complain about unused top-level const
-    it('TMP_TEAM_DIR exists for scoping', () => {
-      expect(typeof TMP_TEAM_DIR).toBe('string');
     });
   });
 

--- a/server/__tests__/hookEventHandler.test.ts
+++ b/server/__tests__/hookEventHandler.test.ts
@@ -757,141 +757,94 @@ describe('HookEventHandler', () => {
   // These tests pin down the behavior that must NOT change for basic subagents.
   // Basic subagents use Agent or Task tool WITHOUT run_in_background=true.
 
-  it('PreToolUse(Agent, run_in_background=false) does NOT set currentHookIsTeammateSpawn', () => {
-    const agent = createTestAgent({ id: 1 });
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
+  // PreToolUse(Agent) sets currentHookIsTeammateSpawn iff run_in_background === true.
+  describe.each([
+    { label: 'run_in_background=true', toolInput: { run_in_background: true }, expected: true },
+    { label: 'run_in_background=false', toolInput: { run_in_background: false }, expected: false },
+  ])('PreToolUse(Agent, $label)', ({ toolInput, expected }) => {
+    it(`sets currentHookIsTeammateSpawn=${expected}`, () => {
+      const agent = createTestAgent({ id: 1 });
+      agents.set(1, agent);
+      handler.registerAgent('sess-1', 1);
 
-    handler.handleEvent('claude', {
-      hook_event_name: 'PreToolUse',
-      session_id: 'sess-1',
-      tool_name: 'Agent',
-      tool_input: { description: 'Code review', run_in_background: false },
+      handler.handleEvent('claude', {
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-1',
+        tool_name: 'Agent',
+        tool_input: { description: 'Code review', ...toolInput },
+      });
+
+      expect(agent.currentHookIsTeammateSpawn).toBe(expected);
     });
-
-    expect(agent.currentHookIsTeammateSpawn).toBe(false);
   });
 
-  it('PreToolUse(Agent, no run_in_background) does NOT set currentHookIsTeammateSpawn', () => {
-    const agent = createTestAgent({ id: 1 });
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'PreToolUse',
-      session_id: 'sess-1',
-      tool_name: 'Agent',
-      tool_input: { description: 'Code review' },
-    });
-
-    expect(agent.currentHookIsTeammateSpawn).toBe(false);
-  });
-
-  it('PreToolUse(Agent, run_in_background=true) sets currentHookIsTeammateSpawn', () => {
-    const agent = createTestAgent({ id: 1 });
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'PreToolUse',
-      session_id: 'sess-1',
-      tool_name: 'Agent',
-      tool_input: { name: 'web-researcher', run_in_background: true },
-    });
-
-    expect(agent.currentHookIsTeammateSpawn).toBe(true);
-  });
-
-  it('SubagentStart for basic Agent subagent does NOT call onTeammateDetected', () => {
-    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: false });
-    // Simulate JSONL having caught up: real tool id in activeToolNames
-    agent.activeToolNames.set('toolu_real', 'Agent');
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    const onTeammateDetected = vi.fn();
-    handler.setLifecycleCallbacks({ onTeammateDetected });
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'SubagentStart',
-      session_id: 'sess-1',
-      agent_type: 'general-purpose',
-    });
-
-    expect(onTeammateDetected).not.toHaveBeenCalled();
-    // Basic path: sends subagentToolStart with REAL parent tool id
-    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
-    expect(msg).toBeTruthy();
-    expect(msg?.parentToolId).toBe('toolu_real');
-  });
-
-  it('SubagentStart for teammate (Agent run_in_background=true, team lead) calls onTeammateDetected', () => {
-    // BOTH conditions required: currentHookIsTeammateSpawn=true AND agent.teamName set
-    // (JSONL-confirmed team lead). Without teamName, we treat as basic subagent.
-    const agent = createTestAgent({
-      id: 1,
-      currentHookIsTeammateSpawn: true,
+  // SubagentStart routes to teammate discovery ONLY when both conditions hold:
+  // currentHookIsTeammateSpawn === true AND agent.teamName is set (JSONL-confirmed lead).
+  // Basic subagents (no spawn flag) or the external-session false-positive case
+  // (spawn flag set but no teamName) fall through to the basic subagent path.
+  describe.each([
+    {
+      label: 'teammate (spawn flag + teamName)',
+      spawn: true,
       teamName: 'research',
+      seedActiveTool: false,
+      expectTeammateDetected: true,
+    },
+    {
+      label: 'false-positive guard (spawn flag, no teamName)',
+      spawn: true,
+      teamName: undefined,
+      seedActiveTool: true,
+      expectTeammateDetected: false,
+    },
+    {
+      label: 'basic subagent from hook before JSONL (no activeToolNames parent)',
+      spawn: false,
+      teamName: undefined,
+      seedActiveTool: false,
+      expectTeammateDetected: false,
+    },
+  ])('SubagentStart: $label', ({ spawn, teamName, seedActiveTool, expectTeammateDetected }) => {
+    it(`onTeammateDetected called=${expectTeammateDetected}`, () => {
+      const agent = createTestAgent({
+        id: 1,
+        currentHookIsTeammateSpawn: spawn,
+        ...(teamName ? { teamName } : {}),
+      });
+      if (seedActiveTool) {
+        agent.activeToolNames.set('toolu_real', 'Agent');
+      } else if (!spawn) {
+        agent.currentHookToolId = 'hook-XXX';
+        agent.currentHookToolName = 'Agent';
+      }
+      agents.set(1, agent);
+      handler.registerAgent('sess-1', 1);
+
+      const onTeammateDetected = vi.fn();
+      handler.setLifecycleCallbacks({ onTeammateDetected });
+
+      handler.handleEvent('claude', {
+        hook_event_name: 'SubagentStart',
+        session_id: 'sess-1',
+        agent_type: expectTeammateDetected ? 'web-researcher' : 'general-purpose',
+      });
+
+      if (expectTeammateDetected) {
+        expect(onTeammateDetected).toHaveBeenCalledWith(1, 'sess-1', 'web-researcher');
+        // Teammate path skips subagentToolStart (no ghost sub-agent character).
+        expect(mockWebview.messages.find((m) => m.type === 'subagentToolStart')).toBeUndefined();
+      } else {
+        expect(onTeammateDetected).not.toHaveBeenCalled();
+        const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
+        if (seedActiveTool) {
+          // Basic path with real tool id available.
+          expect(msg).toBeTruthy();
+          expect(msg?.parentToolId).toBe('toolu_real');
+        } else {
+          // No real tool id yet -- JSONL will create the sub-agent character.
+          expect(msg).toBeUndefined();
+        }
+      }
     });
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    const onTeammateDetected = vi.fn();
-    handler.setLifecycleCallbacks({ onTeammateDetected });
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'SubagentStart',
-      session_id: 'sess-1',
-      agent_type: 'web-researcher',
-    });
-
-    expect(onTeammateDetected).toHaveBeenCalledWith(1, 'sess-1', 'web-researcher');
-    // Teammate path: does NOT send subagentToolStart (no ghost sub-agent character)
-    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
-    expect(msg).toBeUndefined();
-  });
-
-  it('SubagentStart with spawn flag but NO teamName does NOT call onTeammateDetected (false positive guard)', () => {
-    // External session firing run_in_background=true for basic parallel subagents
-    // would set currentHookIsTeammateSpawn=true. Without teamName, we must NOT
-    // route to teammate discovery -- those aren't real teammates.
-    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: true });
-    agent.activeToolNames.set('toolu_real', 'Agent');
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    const onTeammateDetected = vi.fn();
-    handler.setLifecycleCallbacks({ onTeammateDetected });
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'SubagentStart',
-      session_id: 'sess-1',
-      agent_type: 'general-purpose',
-    });
-
-    expect(onTeammateDetected).not.toHaveBeenCalled();
-    // Falls through to basic subagent path -- sends subagentToolStart with real id
-    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
-    expect(msg).toBeTruthy();
-    expect(msg?.parentToolId).toBe('toolu_real');
-  });
-
-  it('SubagentStart for basic subagent returns early when activeToolNames lacks parent (JSONL will handle)', () => {
-    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: false });
-    // activeToolNames empty; currentHookToolId set by earlier PreToolUse
-    agent.currentHookToolId = 'hook-XXX';
-    agent.currentHookToolName = 'Agent';
-    agents.set(1, agent);
-    handler.registerAgent('sess-1', 1);
-
-    handler.handleEvent('claude', {
-      hook_event_name: 'SubagentStart',
-      session_id: 'sess-1',
-      agent_type: 'general-purpose',
-    });
-
-    // No sub-agent character sent with synthetic id -- JSONL is the sole source.
-    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
-    expect(msg).toBeUndefined();
   });
 });

--- a/server/__tests__/hookEventHandler.test.ts
+++ b/server/__tests__/hookEventHandler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentState } from '../../src/types.js';
 import { HookEventHandler } from '../src/hookEventHandler.js';
+import { claudeProvider } from '../src/providers/hook/claude/claude.js';
 
 /** Minimal AgentState for testing. */
 function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
@@ -59,6 +60,7 @@ describe('HookEventHandler', () => {
       waitingTimers,
       permissionTimers,
       () => mockWebview as unknown as import('vscode').Webview,
+      claudeProvider,
     );
   });
 
@@ -749,5 +751,147 @@ describe('HookEventHandler', () => {
 
     // onSessionResume requires transcript_path to clear dismissals
     expect(onSessionResume).not.toHaveBeenCalled();
+  });
+
+  // ── Basic subagent regression (Agent Teams feature OFF) ─────────────
+  // These tests pin down the behavior that must NOT change for basic subagents.
+  // Basic subagents use Agent or Task tool WITHOUT run_in_background=true.
+
+  it('PreToolUse(Agent, run_in_background=false) does NOT set currentHookIsTeammateSpawn', () => {
+    const agent = createTestAgent({ id: 1 });
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'sess-1',
+      tool_name: 'Agent',
+      tool_input: { description: 'Code review', run_in_background: false },
+    });
+
+    expect(agent.currentHookIsTeammateSpawn).toBe(false);
+  });
+
+  it('PreToolUse(Agent, no run_in_background) does NOT set currentHookIsTeammateSpawn', () => {
+    const agent = createTestAgent({ id: 1 });
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'sess-1',
+      tool_name: 'Agent',
+      tool_input: { description: 'Code review' },
+    });
+
+    expect(agent.currentHookIsTeammateSpawn).toBe(false);
+  });
+
+  it('PreToolUse(Agent, run_in_background=true) sets currentHookIsTeammateSpawn', () => {
+    const agent = createTestAgent({ id: 1 });
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'sess-1',
+      tool_name: 'Agent',
+      tool_input: { name: 'web-researcher', run_in_background: true },
+    });
+
+    expect(agent.currentHookIsTeammateSpawn).toBe(true);
+  });
+
+  it('SubagentStart for basic Agent subagent does NOT call onTeammateDetected', () => {
+    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: false });
+    // Simulate JSONL having caught up: real tool id in activeToolNames
+    agent.activeToolNames.set('toolu_real', 'Agent');
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    const onTeammateDetected = vi.fn();
+    handler.setLifecycleCallbacks({ onTeammateDetected });
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'sess-1',
+      agent_type: 'general-purpose',
+    });
+
+    expect(onTeammateDetected).not.toHaveBeenCalled();
+    // Basic path: sends subagentToolStart with REAL parent tool id
+    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
+    expect(msg).toBeTruthy();
+    expect(msg?.parentToolId).toBe('toolu_real');
+  });
+
+  it('SubagentStart for teammate (Agent run_in_background=true, team lead) calls onTeammateDetected', () => {
+    // BOTH conditions required: currentHookIsTeammateSpawn=true AND agent.teamName set
+    // (JSONL-confirmed team lead). Without teamName, we treat as basic subagent.
+    const agent = createTestAgent({
+      id: 1,
+      currentHookIsTeammateSpawn: true,
+      teamName: 'research',
+    });
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    const onTeammateDetected = vi.fn();
+    handler.setLifecycleCallbacks({ onTeammateDetected });
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'sess-1',
+      agent_type: 'web-researcher',
+    });
+
+    expect(onTeammateDetected).toHaveBeenCalledWith(1, 'sess-1', 'web-researcher');
+    // Teammate path: does NOT send subagentToolStart (no ghost sub-agent character)
+    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
+    expect(msg).toBeUndefined();
+  });
+
+  it('SubagentStart with spawn flag but NO teamName does NOT call onTeammateDetected (false positive guard)', () => {
+    // External session firing run_in_background=true for basic parallel subagents
+    // would set currentHookIsTeammateSpawn=true. Without teamName, we must NOT
+    // route to teammate discovery -- those aren't real teammates.
+    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: true });
+    agent.activeToolNames.set('toolu_real', 'Agent');
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    const onTeammateDetected = vi.fn();
+    handler.setLifecycleCallbacks({ onTeammateDetected });
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'sess-1',
+      agent_type: 'general-purpose',
+    });
+
+    expect(onTeammateDetected).not.toHaveBeenCalled();
+    // Falls through to basic subagent path -- sends subagentToolStart with real id
+    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
+    expect(msg).toBeTruthy();
+    expect(msg?.parentToolId).toBe('toolu_real');
+  });
+
+  it('SubagentStart for basic subagent returns early when activeToolNames lacks parent (JSONL will handle)', () => {
+    const agent = createTestAgent({ id: 1, currentHookIsTeammateSpawn: false });
+    // activeToolNames empty; currentHookToolId set by earlier PreToolUse
+    agent.currentHookToolId = 'hook-XXX';
+    agent.currentHookToolName = 'Agent';
+    agents.set(1, agent);
+    handler.registerAgent('sess-1', 1);
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'sess-1',
+      agent_type: 'general-purpose',
+    });
+
+    // No sub-agent character sent with synthetic id -- JSONL is the sole source.
+    const msg = mockWebview.messages.find((m) => m.type === 'subagentToolStart');
+    expect(msg).toBeUndefined();
   });
 });

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -186,14 +186,7 @@ describe('PixelAgentsServer', () => {
     expect(res.status).toBe(404);
   });
 
-  // 14. Hook endpoint rejects invalid provider ID characters
-  it('hook endpoint returns 400 for special characters in provider ID', async () => {
-    const config = await server.start();
-    const res = await postHook(config.port, config.token, '{}', 'bad_provider!');
-    expect(res.status).toBe(400);
-  });
-
-  // 15. Hook callback does NOT fire for events missing required fields
+  // 14. Hook callback does NOT fire for events missing required fields
   it('hook callback does not fire for events without session_id', async () => {
     const config = await server.start();
     const received: unknown[] = [];
@@ -203,21 +196,6 @@ describe('PixelAgentsServer', () => {
       config.port,
       config.token,
       JSON.stringify({ hook_event_name: 'Stop' }), // missing session_id
-    );
-
-    expect(received).toHaveLength(0);
-  });
-
-  // 17. Hook callback does NOT fire for events missing hook_event_name
-  it('hook callback does not fire for events without hook_event_name', async () => {
-    const config = await server.start();
-    const received: unknown[] = [];
-    server.onHookEvent((_pid: string, event: Record<string, unknown>) => received.push(event));
-
-    await postHook(
-      config.port,
-      config.token,
-      JSON.stringify({ session_id: 'abc' }), // missing hook_event_name
     );
 
     expect(received).toHaveLength(0);

--- a/server/__tests__/teamUtils.test.ts
+++ b/server/__tests__/teamUtils.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentState } from '../../src/types.js';
+import { getInlineTeammates, hasInlineTeammates, isInlineTeammateOf } from '../src/teamUtils.js';
+
+/** Minimal AgentState for testing -- only the fields teamUtils actually reads. */
+function agent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 0,
+    leadAgentId: undefined,
+    teamUsesTmux: false,
+    ...overrides,
+  } as AgentState;
+}
+
+describe('teamUtils', () => {
+  describe('isInlineTeammateOf', () => {
+    it('returns true when leadAgentId matches and teamUsesTmux is false', () => {
+      expect(isInlineTeammateOf(agent({ leadAgentId: 5, teamUsesTmux: false }), 5)).toBe(true);
+    });
+
+    it('returns true when leadAgentId matches and teamUsesTmux is undefined', () => {
+      expect(isInlineTeammateOf(agent({ leadAgentId: 5 }), 5)).toBe(true);
+    });
+
+    it('returns false when leadAgentId does not match', () => {
+      expect(isInlineTeammateOf(agent({ leadAgentId: 5 }), 6)).toBe(false);
+    });
+
+    it('returns false when teamUsesTmux is true (tmux teammate)', () => {
+      expect(isInlineTeammateOf(agent({ leadAgentId: 5, teamUsesTmux: true }), 5)).toBe(false);
+    });
+
+    it('returns false when leadAgentId is undefined (not a teammate)', () => {
+      expect(isInlineTeammateOf(agent({ leadAgentId: undefined }), 5)).toBe(false);
+    });
+  });
+
+  describe('getInlineTeammates', () => {
+    it('returns only inline teammates of the given lead', () => {
+      const agents = new Map<number, AgentState>([
+        [1, agent({ id: 1 })], // lead
+        [2, agent({ id: 2, leadAgentId: 1 })], // inline teammate of lead 1
+        [3, agent({ id: 3, leadAgentId: 1, teamUsesTmux: true })], // tmux teammate
+        [4, agent({ id: 4, leadAgentId: 99 })], // teammate of a different lead
+        [5, agent({ id: 5, leadAgentId: 1 })], // another inline teammate
+      ]);
+      const result = getInlineTeammates(1, agents);
+      expect(result.map(([id]) => id).sort()).toEqual([2, 5]);
+    });
+
+    it('returns empty array when no teammates exist', () => {
+      const agents = new Map([[1, agent({ id: 1 })]]);
+      expect(getInlineTeammates(1, agents)).toEqual([]);
+    });
+
+    it('returns [id, agent] pairs preserving agent references', () => {
+      const teammate = agent({ id: 2, leadAgentId: 1 });
+      const agents = new Map([[2, teammate]]);
+      const result = getInlineTeammates(1, agents);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual([2, teammate]);
+      expect(result[0][1]).toBe(teammate);
+    });
+  });
+
+  describe('hasInlineTeammates', () => {
+    it('returns true when at least one inline teammate exists', () => {
+      const agents = new Map([
+        [1, agent({ id: 1 })],
+        [2, agent({ id: 2, leadAgentId: 1 })],
+      ]);
+      expect(hasInlineTeammates(1, agents)).toBe(true);
+    });
+
+    it('returns false when only tmux teammates exist', () => {
+      const agents = new Map([
+        [1, agent({ id: 1 })],
+        [2, agent({ id: 2, leadAgentId: 1, teamUsesTmux: true })],
+      ]);
+      expect(hasInlineTeammates(1, agents)).toBe(false);
+    });
+
+    it('returns false when lead has no teammates', () => {
+      const agents = new Map([[1, agent({ id: 1 })]]);
+      expect(hasInlineTeammates(1, agents)).toBe(false);
+    });
+
+    it('short-circuits on first match (performance, not behavioral)', () => {
+      const agents = new Map([
+        [1, agent({ id: 1 })],
+        [2, agent({ id: 2, leadAgentId: 1 })],
+        [3, agent({ id: 3, leadAgentId: 1 })],
+        [4, agent({ id: 4, leadAgentId: 1 })],
+      ]);
+      expect(hasInlineTeammates(1, agents)).toBe(true);
+    });
+  });
+});

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -61,6 +61,9 @@ export const CLAUDE_HOOK_EVENTS = [
   'PostToolUseFailure',
   'SubagentStart',
   'SubagentStop',
+  'TeammateIdle',
+  'TaskCreated',
+  'TaskCompleted',
 ] as const;
 export const HOOK_EVENT_BUFFER_MS = 5_000;
 /** Grace period after SessionEnd(reason=clear/resume) before triggering onSessionEnd.

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -9,7 +9,9 @@ export const PROJECT_SCAN_INTERVAL_MS = 1000;
 // are suppressed and the server receives instant events instead.
 /** Delay before sending agentToolDone (prevents UI flicker on rapid tool transitions) */
 export const TOOL_DONE_DELAY_MS = 300;
-/** Heuristic: time after a non-exempt tool starts before showing permission bubble */
+/** Heuristic: time after a non-exempt tool starts before showing permission bubble.
+ *  Not used for teammates — false positives on slow tools (WebFetch/WebSearch).
+ *  Teammates rely on the lead's routed Notification(permission_prompt) hook. */
 export const PERMISSION_TIMER_DELAY_MS = 7000;
 /** Heuristic: silence duration before marking a text-only turn as complete */
 export const TEXT_IDLE_DELAY_MS = 5000;
@@ -41,30 +43,13 @@ export const TASK_DESCRIPTION_DISPLAY_MAX_LENGTH = 40;
 export const SERVER_JSON_DIR = '.pixel-agents';
 export const SERVER_JSON_NAME = 'server.json';
 export const HOOK_SCRIPTS_DIR = '.pixel-agents/hooks';
-/** Output filename after esbuild compiles claude-hook.ts to CJS (source is .ts, output is .js) */
-export const CLAUDE_HOOK_SCRIPT_NAME = 'claude-hook.js';
 export const HOOK_API_PREFIX = '/api/hooks';
 
-/** Hook events to install in ~/.claude/settings.json.
- *  SessionStart/SessionEnd handle session lifecycle (start, /clear, resume, exit).
- *  Stop/PermissionRequest/Notification handle turn completion and permission UI.
- */
-export const CLAUDE_HOOK_EVENTS = [
-  'SessionStart',
-  'SessionEnd',
-  'Stop',
-  'PermissionRequest',
-  'Notification',
-  'UserPromptSubmit',
-  'PreToolUse',
-  'PostToolUse',
-  'PostToolUseFailure',
-  'SubagentStart',
-  'SubagentStop',
-  'TeammateIdle',
-  'TaskCreated',
-  'TaskCompleted',
-] as const;
+// Claude-specific constants live in providers/hook/claude/constants.ts.
+// Re-exported here for backward-compatibility of existing callers that import
+// from '../server/src/constants.js'. New code should import directly from the provider.
+export { CLAUDE_HOOK_EVENTS, CLAUDE_HOOK_SCRIPT_NAME } from './providers/hook/claude/constants.js';
+
 export const HOOK_EVENT_BUFFER_MS = 5_000;
 /** Grace period after SessionEnd(reason=clear/resume) before triggering onSessionEnd.
  *  /clear and /resume fire SessionEnd then SessionStart within ms. This timeout is a

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -304,6 +304,21 @@ export class HookEventHandler {
       this.handleNotification(event, agent, agentId, webview);
     } else if (eventName === 'Stop') {
       this.handleStop(agent, agentId, webview);
+    } else if (eventName === 'TeammateIdle') {
+      // Teammate finished work -- mark waiting instantly (no 5s text-idle delay)
+      this.markAgentWaiting(agent, agentId, webview);
+    } else if (eventName === 'TaskCreated') {
+      // Lead created a task for a teammate -- informational only
+      if (debug) {
+        const subject = (event.subject as string) ?? '';
+        console.log(`[Pixel Agents] Hook: Agent ${agentId} - TaskCreated: ${subject}`);
+      }
+    } else if (eventName === 'TaskCompleted') {
+      // Teammate marked its task as done -- informational only
+      if (debug) {
+        const subject = (event.subject as string) ?? '';
+        console.log(`[Pixel Agents] Hook: Agent ${agentId} - TaskCompleted: ${subject}`);
+      }
     }
   }
 

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -6,7 +6,7 @@ import type * as vscode from 'vscode';
 import { cancelPermissionTimer, cancelWaitingTimer } from '../../src/timerManager.js';
 import type { AgentState } from '../../src/types.js';
 import { HOOK_EVENT_BUFFER_MS, SESSION_END_GRACE_MS } from './constants.js';
-import type { HookProvider } from './provider.js';
+import type { AgentEvent, HookProvider } from './provider.js';
 import { getInlineTeammates, hasInlineTeammates } from './teamUtils.js';
 
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
@@ -90,6 +90,18 @@ export class HookEventHandler {
     private watchAllSessionsRef?: { current: boolean },
   ) {}
 
+  /** Merged set of tool names that spawn subagents (teammates + within-turn subagents
+   *  when a team provider is attached, or the base HookProvider set otherwise). */
+  private getSubagentToolSet(): ReadonlySet<string> {
+    if (this.provider.team) {
+      return new Set<string>([
+        ...this.provider.team.teammateSpawnTools,
+        ...this.provider.team.withinTurnSubagentTools,
+      ]);
+    }
+    return this.provider.subagentToolNames;
+  }
+
   /** Check if a session is tracked (in workspace project dir, or Watch All Sessions ON). */
   private isTrackedSession(transcriptPath?: string, cwd?: string): boolean {
     if (this.watchAllSessionsRef?.current) return true;
@@ -132,7 +144,7 @@ export class HookEventHandler {
     // cwd for external-session adoption; agent_type for teammate routing).
     const normalized = this.provider.normalizeHookEvent(event);
     if (!normalized) return; // unknown / uninteresting event -- silently drop
-    const normalizedKind = normalized.event.kind;
+    const normEvent = normalized.event;
     const eventName = event.hook_event_name; // retained for logs only
 
     // --- SessionStart: handle /clear for known agents, ignore unknown sessions ---
@@ -140,13 +152,14 @@ export class HookEventHandler {
     // For now, only use SessionStart for:
     //   1. Confirming known agents (set hookDelivered)
     //   2. /clear reassignment (source=clear + pendingClear agent)
-    if (normalizedKind === 'sessionStart') {
+    if (normEvent.kind === 'sessionStart') {
       const sid = event.session_id.slice(0, 8);
-      const source = (event.source as string) ?? 'unknown';
-      const tracked = this.isTrackedSession(
-        event.transcript_path as string | undefined,
-        event.cwd as string | undefined,
-      );
+      const source = normEvent.source ?? 'unknown';
+      // transcript_path and cwd are not yet on the normalized sessionStart event;
+      // provider carries them in the raw payload until they're promoted.
+      const transcriptPath = event.transcript_path as string | undefined;
+      const cwd = event.cwd as string | undefined;
+      const tracked = this.isTrackedSession(transcriptPath, cwd);
       if (debug && tracked)
         console.log(`[Pixel Agents] Hook: SessionStart(source=${source}, session=${sid}...)`);
 
@@ -176,11 +189,8 @@ export class HookEventHandler {
         }
       }
       // /clear or /resume: reassign existing agent to new session
-      if (event.source === 'clear' || event.source === 'resume') {
-        const transcriptPath = event.transcript_path as string | undefined;
-        const projectDir = transcriptPath
-          ? path.dirname(transcriptPath)
-          : (event.cwd as string | undefined);
+      if (normEvent.source === 'clear' || normEvent.source === 'resume') {
+        const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
         if (projectDir) {
           for (const [id, agent] of this.agents) {
             // Both /clear and /resume send SessionEnd first (sets pendingClear),
@@ -194,7 +204,7 @@ export class HookEventHandler {
             if (isMatch) {
               agent.pendingClear = false;
               console.log(
-                `[Pixel Agents] Hook: Agent ${id} - /${event.source} detected, reassigning to ${event.session_id}`,
+                `[Pixel Agents] Hook: Agent ${id} - /${normEvent.source} detected, reassigning to ${event.session_id}`,
               );
               this.sessionToAgentId.delete(agent.sessionId);
               this.registerAgent(event.session_id, id);
@@ -207,12 +217,10 @@ export class HookEventHandler {
       // Unknown session -- store as pending, create only when a confirmation event
       // arrives (Stop, Notification, PermissionRequest). This filters transient sessions
       // from Claude Code Extension which fire SessionStart + SessionEnd without any activity.
-      const transcriptPath2 = event.transcript_path as string | undefined;
-      const cwd = event.cwd as string | undefined;
-      if (transcriptPath2 || cwd) {
+      if (transcriptPath || cwd) {
         // For --resume, clear dismissals so the file can be re-adopted
-        if (event.source === 'resume' && transcriptPath2) {
-          this.lifecycleCallbacks.onSessionResume?.(transcriptPath2);
+        if (normEvent.source === 'resume' && transcriptPath) {
+          this.lifecycleCallbacks.onSessionResume?.(transcriptPath);
         }
         if (debug && tracked)
           console.log(
@@ -220,7 +228,7 @@ export class HookEventHandler {
           );
         this.pendingExternalSessions.set(event.session_id, {
           sessionId: event.session_id,
-          transcriptPath: transcriptPath2,
+          transcriptPath,
           cwd: cwd ?? '',
         });
       } else {
@@ -234,7 +242,7 @@ export class HookEventHandler {
 
     // --- All other events: standard agent lookup ---
     // If SessionEnd arrives for a pending external session, discard it (transient session)
-    if (normalizedKind === 'sessionEnd' && this.pendingExternalSessions.has(event.session_id)) {
+    if (normEvent.kind === 'sessionEnd' && this.pendingExternalSessions.has(event.session_id)) {
       this.pendingExternalSessions.delete(event.session_id);
       if (debug)
         console.log(
@@ -306,24 +314,22 @@ export class HookEventHandler {
     // Dispatch on normalized AgentEvent.kind, not raw hook event names.
     // The TeammateIdle / TaskCompleted hooks normalize to `subagentTurnEnd` -- both
     // carry `agent_type` in the raw payload, which we pass to the team-routing handler.
-    switch (normalizedKind) {
+    switch (normEvent.kind) {
       case 'sessionEnd':
-        return this.handleSessionEnd(event, agent, agentId, webview);
+        return this.handleSessionEnd(normEvent, agent, agentId, webview);
       case 'toolStart':
-        return this.handlePreToolUse(event, agent, agentId, webview);
+        return this.handlePreToolUse(normEvent, agent, agentId, webview);
       case 'toolEnd':
         // Both PostToolUse and PostToolUseFailure normalize to toolEnd. Distinguishing
         // them inside handlers would require extra info; the existing behavior was
         // identical for both (agentToolDone + clear currentHookToolId), so one branch suffices.
-        return this.handlePostToolUse(event, agent, agentId, webview);
+        return this.handlePostToolUse(agent, agentId, webview);
       case 'subagentStart':
         return this.provider.team
           ? this.handleSubagentStart(event, agent, agentId, webview)
           : undefined;
       case 'subagentEnd':
-        return this.provider.team
-          ? this.handleSubagentStop(event, agent, agentId, webview)
-          : undefined;
+        return this.provider.team ? this.handleSubagentStop(agent, agentId, webview) : undefined;
       case 'permissionRequest':
         // Handles BOTH the PermissionRequest hook AND the Notification(permission_prompt)
         // hook -- normalizeHookEvent collapses them into one event kind.
@@ -337,13 +343,11 @@ export class HookEventHandler {
         // (TaskCreated would have normalized to null already in the provider.)
         if (!this.provider.team) return;
         if (eventName === 'TaskCompleted') {
-          return this.handleTaskCompleted(event, agent, agentId, webview);
+          return this.handleTaskCompleted(event, agentId);
         }
         return this.handleTeammateIdle(event, agent, agentId, webview);
       case 'userTurn':
       case 'progress':
-      case 'agentJoined':
-      case 'agentLeft':
         // Not yet consumed by the office visualization. Silently drop.
         return;
     }
@@ -354,12 +358,12 @@ export class HookEventHandler {
    * exit/logout marks agent waiting or triggers cleanup.
    */
   private handleSessionEnd(
-    event: HookEvent,
+    normEvent: Extract<AgentEvent, { kind: 'sessionEnd' }>,
     agent: AgentState,
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
-    const reason = event.reason as string | undefined;
+    const reason = normEvent.reason;
     if (debug)
       console.log(
         `[Pixel Agents] Hook: Agent ${agentId} - SessionEnd(reason=${reason ?? 'unknown'})`,
@@ -397,13 +401,13 @@ export class HookEventHandler {
    * This just ensures the character starts animating without waiting for the 500ms JSONL poll.
    */
   private handlePreToolUse(
-    event: HookEvent,
+    normEvent: Extract<AgentEvent, { kind: 'toolStart' }>,
     agent: AgentState,
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
-    const toolName = (event.tool_name as string) ?? '';
-    const toolInput = (event.tool_input as Record<string, unknown>) ?? {};
+    const toolName = normEvent.toolName;
+    const toolInput = (normEvent.input as Record<string, unknown> | undefined) ?? {};
     const status = this.provider.formatToolStatus(toolName, toolInput);
     const hookToolId = `hook-${Date.now()}`;
 
@@ -453,7 +457,6 @@ export class HookEventHandler {
    * to serve as a confirmation event for pending external sessions.
    */
   private handlePostToolUse(
-    _event: HookEvent,
     agent: AgentState,
     agentId: number,
     webview: vscode.Webview | undefined,
@@ -514,13 +517,7 @@ export class HookEventHandler {
     // Basic within-turn subagent path: find parent tool ID from activeToolNames.
     // Use only the real JSONL-populated id -- no synthetic fallback here, or we'd
     // double-track parents once JSONL catches up.
-    // Falls back to HookProvider.subagentToolNames if no team provider is set.
-    const parentTools = this.provider.team
-      ? new Set<string>([
-          ...this.provider.team.teammateSpawnTools,
-          ...this.provider.team.withinTurnSubagentTools,
-        ])
-      : this.provider.subagentToolNames;
+    const parentTools = this.getSubagentToolSet();
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
       if (parentTools.has(toolName)) {
@@ -567,7 +564,6 @@ export class HookEventHandler {
    * For old-style Task subagents: removes the child character from the office.
    */
   private handleSubagentStop(
-    _event: HookEvent,
     agent: AgentState,
     agentId: number,
     webview: vscode.Webview | undefined,
@@ -592,16 +588,10 @@ export class HookEventHandler {
     }
 
     // Old-style within-turn subagents: find a parent tool that actually has tracked
-    // sub-agents. SubagentStop doesn't identify which specific sub-agent stopped,
-    // so we clear the first parent that still has active sub-agent tracking.
-    // The `activeSubagentToolIds.has(toolId)` gate prevents us from picking a
-    // Task/Agent parent that already had its sub-agents cleared in the same turn.
-    const subagentParentTools = this.provider.team
-      ? new Set<string>([
-          ...this.provider.team.teammateSpawnTools,
-          ...this.provider.team.withinTurnSubagentTools,
-        ])
-      : this.provider.subagentToolNames;
+    // sub-agents. The `activeSubagentToolIds.has(toolId)` gate below prevents us
+    // from picking a subagent-spawning parent that already had its sub-agents
+    // cleared in the same turn.
+    const subagentParentTools = this.getSubagentToolSet();
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
       if (subagentParentTools.has(toolName) && agent.activeSubagentToolIds.has(toolId)) {
@@ -710,12 +700,7 @@ export class HookEventHandler {
    * Handle TaskCompleted: a teammate marked its task done.
    * Routes to the specific teammate when identifiable, marking it waiting instantly.
    */
-  private handleTaskCompleted(
-    event: HookEvent,
-    _agent: AgentState,
-    agentId: number,
-    webview: vscode.Webview | undefined,
-  ): void {
+  private handleTaskCompleted(event: HookEvent, agentId: number): void {
     const subject = (event.subject as string) ?? '';
     const agentType = this.provider.team?.extractTeammateNameFromEvent(event);
     if (debug)
@@ -725,6 +710,8 @@ export class HookEventHandler {
 
     const inlineTeammates = getInlineTeammates(agentId, this.agents);
     if (inlineTeammates.length === 0) return;
+
+    const webview = this.getWebview();
 
     // Match by agentName if available, otherwise mark all inline teammates waiting
     if (agentType) {
@@ -757,12 +744,7 @@ export class HookEventHandler {
     // ALWAYS send agentToolsClear at turn end -- even when activeToolIds is empty by now
     // (because tool_results already processed and removed them). Without this, stale
     // sub-agent characters and permission bubbles from the turn would never clear.
-    const parentTools = this.provider.team
-      ? new Set<string>([
-          ...this.provider.team.teammateSpawnTools,
-          ...this.provider.team.withinTurnSubagentTools,
-        ])
-      : this.provider.subagentToolNames;
+    const parentTools = this.getSubagentToolSet();
     for (const toolId of [...agent.activeToolIds]) {
       if (agent.backgroundAgentToolIds.has(toolId)) continue;
       agent.activeToolIds.delete(toolId);

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -4,9 +4,10 @@ import * as path from 'path';
 import type * as vscode from 'vscode';
 
 import { cancelPermissionTimer, cancelWaitingTimer } from '../../src/timerManager.js';
-import { formatToolStatus } from '../../src/transcriptParser.js';
 import type { AgentState } from '../../src/types.js';
 import { HOOK_EVENT_BUFFER_MS, SESSION_END_GRACE_MS } from './constants.js';
+import type { HookProvider } from './provider.js';
+import { getInlineTeammates, hasInlineTeammates } from './teamUtils.js';
 
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
 
@@ -56,6 +57,12 @@ interface SessionLifecycleCallbacks {
   onSessionResume?: (transcriptPath: string) => void;
   /** Called when a session ends (exit/logout). */
   onSessionEnd?: (agentId: number, reason: string) => void;
+  /** Called when an Agent Teams teammate is detected via SubagentStart hook.
+   *  Triggers scanning of the session's subagents/ directory for the teammate's JSONL. */
+  onTeammateDetected?: (parentAgentId: number, sessionId: string, agentType: string) => void;
+  /** Called when a teammate should be removed (e.g. no longer in team config members).
+   *  Removes the teammate agent from the office. */
+  onTeammateRemoved?: (teammateAgentId: number) => void;
 }
 
 /** Pending external session info (waiting for confirmation event before creating agent). */
@@ -79,6 +86,7 @@ export class HookEventHandler {
     private waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
     private permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
     private getWebview: () => vscode.Webview | undefined,
+    private provider: HookProvider,
     private watchAllSessionsRef?: { current: boolean },
   ) {}
 
@@ -116,14 +124,23 @@ export class HookEventHandler {
    * @param event - The hook event payload from the CLI tool
    */
   handleEvent(_providerId: string, event: HookEvent): void {
-    const eventName = event.hook_event_name;
+    // ── Provider normalization boundary ───────────────────────────────────────
+    // All raw Claude-specific fields (tool_name, tool_input, agent_type, notification_type,
+    // reason, source) are extracted by provider.normalizeHookEvent. Downstream dispatch
+    // uses the normalized AgentEvent.kind. Raw `event.*` reads are still allowed in a few
+    // places for provider-specific metadata that AgentEvent doesn't capture (transcript_path,
+    // cwd for external-session adoption; agent_type for teammate routing).
+    const normalized = this.provider.normalizeHookEvent(event);
+    if (!normalized) return; // unknown / uninteresting event -- silently drop
+    const normalizedKind = normalized.event.kind;
+    const eventName = event.hook_event_name; // retained for logs only
 
     // --- SessionStart: handle /clear for known agents, ignore unknown sessions ---
     // External session detection via SessionStart is deferred to Phase C.
     // For now, only use SessionStart for:
     //   1. Confirming known agents (set hookDelivered)
     //   2. /clear reassignment (source=clear + pendingClear agent)
-    if (eventName === 'SessionStart') {
+    if (normalizedKind === 'sessionStart') {
       const sid = event.session_id.slice(0, 8);
       const source = (event.source as string) ?? 'unknown';
       const tracked = this.isTrackedSession(
@@ -217,7 +234,7 @@ export class HookEventHandler {
 
     // --- All other events: standard agent lookup ---
     // If SessionEnd arrives for a pending external session, discard it (transient session)
-    if (eventName === 'SessionEnd' && this.pendingExternalSessions.has(event.session_id)) {
+    if (normalizedKind === 'sessionEnd' && this.pendingExternalSessions.has(event.session_id)) {
       this.pendingExternalSessions.delete(event.session_id);
       if (debug)
         console.log(
@@ -286,39 +303,49 @@ export class HookEventHandler {
 
     const webview = this.getWebview();
 
-    if (eventName === 'SessionEnd') {
-      this.handleSessionEnd(event, agent, agentId, webview);
-    } else if (eventName === 'PreToolUse') {
-      this.handlePreToolUse(event, agent, agentId, webview);
-    } else if (eventName === 'PostToolUse') {
-      this.handlePostToolUse(event, agent, agentId, webview);
-    } else if (eventName === 'PostToolUseFailure') {
-      this.handlePostToolUseFailure(event, agent, agentId, webview);
-    } else if (eventName === 'SubagentStart') {
-      this.handleSubagentStart(event, agent, agentId, webview);
-    } else if (eventName === 'SubagentStop') {
-      this.handleSubagentStop(event, agent, agentId, webview);
-    } else if (eventName === 'PermissionRequest') {
-      this.handlePermissionRequest(agent, agentId, webview);
-    } else if (eventName === 'Notification') {
-      this.handleNotification(event, agent, agentId, webview);
-    } else if (eventName === 'Stop') {
-      this.handleStop(agent, agentId, webview);
-    } else if (eventName === 'TeammateIdle') {
-      // Teammate finished work -- mark waiting instantly (no 5s text-idle delay)
-      this.markAgentWaiting(agent, agentId, webview);
-    } else if (eventName === 'TaskCreated') {
-      // Lead created a task for a teammate -- informational only
-      if (debug) {
-        const subject = (event.subject as string) ?? '';
-        console.log(`[Pixel Agents] Hook: Agent ${agentId} - TaskCreated: ${subject}`);
-      }
-    } else if (eventName === 'TaskCompleted') {
-      // Teammate marked its task as done -- informational only
-      if (debug) {
-        const subject = (event.subject as string) ?? '';
-        console.log(`[Pixel Agents] Hook: Agent ${agentId} - TaskCompleted: ${subject}`);
-      }
+    // Dispatch on normalized AgentEvent.kind, not raw hook event names.
+    // The TeammateIdle / TaskCompleted hooks normalize to `subagentTurnEnd` -- both
+    // carry `agent_type` in the raw payload, which we pass to the team-routing handler.
+    switch (normalizedKind) {
+      case 'sessionEnd':
+        return this.handleSessionEnd(event, agent, agentId, webview);
+      case 'toolStart':
+        return this.handlePreToolUse(event, agent, agentId, webview);
+      case 'toolEnd':
+        // Both PostToolUse and PostToolUseFailure normalize to toolEnd. Distinguishing
+        // them inside handlers would require extra info; the existing behavior was
+        // identical for both (agentToolDone + clear currentHookToolId), so one branch suffices.
+        return this.handlePostToolUse(event, agent, agentId, webview);
+      case 'subagentStart':
+        return this.provider.team
+          ? this.handleSubagentStart(event, agent, agentId, webview)
+          : undefined;
+      case 'subagentEnd':
+        return this.provider.team
+          ? this.handleSubagentStop(event, agent, agentId, webview)
+          : undefined;
+      case 'permissionRequest':
+        // Handles BOTH the PermissionRequest hook AND the Notification(permission_prompt)
+        // hook -- normalizeHookEvent collapses them into one event kind.
+        return this.handlePermissionRequest(agent, agentId, webview);
+      case 'turnEnd':
+        // Handles Stop AND Notification(idle_prompt) -- both normalize to turnEnd.
+        return this.handleStop(agent, agentId, webview);
+      case 'subagentTurnEnd':
+        // Handles TeammateIdle AND TaskCompleted -- both normalize here. The team-
+        // provider's extractTeammateNameFromEvent(raw) routes to the specific teammate.
+        // (TaskCreated would have normalized to null already in the provider.)
+        if (!this.provider.team) return;
+        if (eventName === 'TaskCompleted') {
+          return this.handleTaskCompleted(event, agent, agentId, webview);
+        }
+        return this.handleTeammateIdle(event, agent, agentId, webview);
+      case 'userTurn':
+      case 'progress':
+      case 'agentJoined':
+      case 'agentLeft':
+        // Not yet consumed by the office visualization. Silently drop.
+        return;
     }
   }
 
@@ -357,7 +384,8 @@ export class HookEventHandler {
         }
       }, SESSION_END_GRACE_MS);
     } else {
-      // Immediate cleanup for exit/logout
+      // Immediate cleanup for exit/logout. onSessionEnd → removeTeammates in the
+      // ViewProvider cleans up all teammates of this lead at once.
       this.markAgentWaiting(agent, agentId, webview);
       this.lifecycleCallbacks.onSessionEnd?.(agentId, reason ?? 'unknown');
     }
@@ -376,11 +404,21 @@ export class HookEventHandler {
   ): void {
     const toolName = (event.tool_name as string) ?? '';
     const toolInput = (event.tool_input as Record<string, unknown>) ?? {};
-    const status = formatToolStatus(toolName, toolInput);
+    const status = this.provider.formatToolStatus(toolName, toolInput);
     const hookToolId = `hook-${Date.now()}`;
 
-    // Track for PostToolUse correlation
+    // Track for PostToolUse/SubagentStart correlation (always, even if suppressed below).
+    // currentHookIsTeammateSpawn is the authoritative teammate-vs-subagent discriminator.
+    // It is NOT cleared in PostToolUse to survive the PostToolUse-before-SubagentStart race.
     agent.currentHookToolId = hookToolId;
+    agent.currentHookToolName = toolName;
+    agent.currentHookIsTeammateSpawn =
+      this.provider.team?.isTeammateSpawnCall(toolName, toolInput) ?? false;
+
+    // When a lead has inline teammates, hook tool events are ambiguous (could be
+    // from the lead or any teammate -- they share session_id). Suppress hook-originated
+    // tool display on the lead. Both lead and teammate tools display via JSONL polling.
+    if (hasInlineTeammates(agentId, this.agents)) return;
 
     // Cancel waiting, mark active
     cancelWaitingTimer(agentId, this.waitingTimers);
@@ -391,7 +429,8 @@ export class HookEventHandler {
     // Send tool start + active state to webview (instant, no 500ms JSONL delay).
     // Skip for Task/Agent tools — their sub-agent characters need the stable JSONL
     // tool ID (not the transient hook ID) so that SubagentStop/tool_result cleanup
-    // can find and remove them. JSONL handles agentToolStart for these tools.
+    // can find and remove them. JSONL handles agentToolStart (with runInBackground)
+    // for these tools.
     if (toolName !== 'Task' && toolName !== 'Agent') {
       webview?.postMessage({
         type: 'agentToolStart',
@@ -420,39 +459,32 @@ export class HookEventHandler {
     webview: vscode.Webview | undefined,
   ): void {
     if (agent.currentHookToolId) {
-      webview?.postMessage({
-        type: 'agentToolDone',
-        id: agentId,
-        toolId: agent.currentHookToolId,
-      });
+      // Suppress tool display when lead has inline teammates (see handlePreToolUse)
+      if (!hasInlineTeammates(agentId, this.agents)) {
+        webview?.postMessage({
+          type: 'agentToolDone',
+          id: agentId,
+          toolId: agent.currentHookToolId,
+        });
+      }
       agent.currentHookToolId = undefined;
+      agent.currentHookToolName = undefined;
     }
   }
 
-  /**
-   * Handle PostToolUseFailure: send tool done for the failed tool,
-   * keep agent active (Claude will retry or respond with error).
-   */
-  private handlePostToolUseFailure(
-    _event: HookEvent,
-    agent: AgentState,
-    agentId: number,
-    webview: vscode.Webview | undefined,
-  ): void {
-    if (agent.currentHookToolId) {
-      webview?.postMessage({
-        type: 'agentToolDone',
-        id: agentId,
-        toolId: agent.currentHookToolId,
-      });
-      agent.currentHookToolId = undefined;
-    }
-  }
+  // NOTE: PostToolUseFailure used to have its own handler. The behavior was identical
+  // to PostToolUse (emit agentToolDone, clear currentHookToolId). Both now normalize to
+  // the 'toolEnd' AgentEvent kind and share handlePostToolUse.
 
   /**
    * Handle SubagentStart: notify webview that a sub-agent is spawning.
-   * Creates the child character in the office immediately via hooks,
-   * without waiting for JSONL agent_progress records (500ms polling).
+   *
+   * For Agent Teams teammates (Agent tool with run_in_background), triggers
+   * teammate discovery via lifecycle callback -- teammates become independent
+   * agents with their own JSONL file watching.
+   *
+   * For old-style Task/Agent subagents (inline, no run_in_background), creates
+   * the child character immediately via hooks without waiting for JSONL polling.
    */
   private handleSubagentStart(
     event: HookEvent,
@@ -460,19 +492,45 @@ export class HookEventHandler {
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
-    // Find the parent Task/Agent tool ID that spawned this sub-agent.
-    // If we can't find one (hook arrived before JSONL tracked the parent tool),
-    // skip -- JSONL will handle it on the next poll.
-    const agentType = (event.agent_type as string) ?? 'unknown';
+    const agentType = this.provider.team?.extractTeammateNameFromEvent(event) ?? 'unknown';
+
+    // Decide path: teammate spawn vs basic within-turn subagent.
+    // Two conditions must BOTH hold for the teammate path:
+    //   1. currentHookIsTeammateSpawn === true -- this specific tool call has the
+    //      teammate-spawn flag (e.g. Agent with run_in_background=true)
+    //   2. agent.teamName set -- JSONL has confirmed this agent is a team lead.
+    //      Without this guard, external sessions firing run_in_background=true
+    //      for parallel basic subagents would be mis-routed to teammate discovery.
+    // Mirrors the same gate used by the periodic scanAllTeammateFiles fallback.
+    if (this.provider.team && agent.currentHookIsTeammateSpawn === true && agent.teamName) {
+      if (debug)
+        console.log(
+          `[Pixel Agents] Hook: Agent ${agentId} - SubagentStart: teammate "${agentType}" detected, triggering discovery`,
+        );
+      this.lifecycleCallbacks.onTeammateDetected?.(agentId, event.session_id, agentType);
+      return;
+    }
+
+    // Basic within-turn subagent path: find parent tool ID from activeToolNames.
+    // Use only the real JSONL-populated id -- no synthetic fallback here, or we'd
+    // double-track parents once JSONL catches up.
+    // Falls back to HookProvider.subagentToolNames if no team provider is set.
+    const parentTools = this.provider.team
+      ? new Set<string>([
+          ...this.provider.team.teammateSpawnTools,
+          ...this.provider.team.withinTurnSubagentTools,
+        ])
+      : this.provider.subagentToolNames;
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
-      if (toolName === 'Task' || toolName === 'Agent') {
+      if (parentTools.has(toolName)) {
         parentToolId = toolId;
         break;
       }
     }
-    if (!parentToolId) return; // JSONL will handle it
+    if (!parentToolId) return; // JSONL will handle it via agent_progress tool_use
 
+    // Create child sub-agent character immediately (same as old behavior).
     const subToolId = `hook-sub-${agentType}-${Date.now()}`;
     const status = `Subtask: ${agentType}`;
 
@@ -502,7 +560,11 @@ export class HookEventHandler {
 
   /**
    * Handle SubagentStop: notify webview that a sub-agent finished.
-   * Removes the child character from the office.
+   *
+   * For Agent Teams teammates: marks all teammate agents as waiting (they're
+   * independent agents, not sub-agent characters to destroy).
+   *
+   * For old-style Task subagents: removes the child character from the office.
    */
   private handleSubagentStop(
     _event: HookEvent,
@@ -510,20 +572,44 @@ export class HookEventHandler {
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
-    // Find a parent Task/Agent tool that actually has tracked sub-agents.
-    // SubagentStop doesn't identify which specific sub-agent stopped, so we
-    // clear the first parent that still has active sub-agent tracking.
+    // Check if this agent has inline teammates (independent agents with leadAgentId).
+    // Just mark them waiting -- SubagentStop fires per-task-iteration; teammates may
+    // sit idle for minutes between lead requests before being re-invoked.
+    // Actual removal is driven by:
+    //   - Periodic team config polling (scanTeamConfigsForRemovals) -- teammate
+    //     removed when no longer in team config members list
+    //   - SessionEnd on lead (removeTeammates in ViewProvider)
+    const inlineTeammates = getInlineTeammates(agentId, this.agents);
+    if (inlineTeammates.length > 0) {
+      if (debug)
+        console.log(
+          `[Pixel Agents] Hook: Agent ${agentId} - SubagentStop: marking inline teammates as waiting`,
+        );
+      for (const [id, a] of inlineTeammates) {
+        this.markAgentWaiting(a, id, webview);
+      }
+      return;
+    }
+
+    // Old-style within-turn subagents: find a parent tool that actually has tracked
+    // sub-agents. SubagentStop doesn't identify which specific sub-agent stopped,
+    // so we clear the first parent that still has active sub-agent tracking.
+    // The `activeSubagentToolIds.has(toolId)` gate prevents us from picking a
+    // Task/Agent parent that already had its sub-agents cleared in the same turn.
+    const subagentParentTools = this.provider.team
+      ? new Set<string>([
+          ...this.provider.team.teammateSpawnTools,
+          ...this.provider.team.withinTurnSubagentTools,
+        ])
+      : this.provider.subagentToolNames;
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
-      if (
-        (toolName === 'Task' || toolName === 'Agent') &&
-        agent.activeSubagentToolIds.has(toolId)
-      ) {
+      if (subagentParentTools.has(toolName) && agent.activeSubagentToolIds.has(toolId)) {
         parentToolId = toolId;
         break;
       }
     }
-    if (!parentToolId) return;
+    if (!parentToolId) return; // JSONL will handle it via agent_progress tool_result
 
     agent.activeSubagentToolIds.delete(parentToolId);
     agent.activeSubagentToolNames.delete(parentToolId);
@@ -540,6 +626,18 @@ export class HookEventHandler {
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
+    // When lead has inline teammates, route permission to the teammates instead.
+    // The hook fires on the lead's session_id but the permission is for a teammate.
+    const inlineTeammates = getInlineTeammates(agentId, this.agents);
+    if (inlineTeammates.length > 0) {
+      for (const [id, a] of inlineTeammates) {
+        cancelPermissionTimer(id, this.permissionTimers);
+        a.permissionSent = true;
+        webview?.postMessage({ type: 'agentToolPermission', id });
+      }
+      return;
+    }
+
     cancelPermissionTimer(agentId, this.permissionTimers);
     agent.permissionSent = true;
     webview?.postMessage({
@@ -556,33 +654,6 @@ export class HookEventHandler {
     }
   }
 
-  /** Handle Notification: permission_prompt shows bubble, idle_prompt marks agent waiting. */
-  private handleNotification(
-    event: HookEvent,
-    agent: AgentState,
-    agentId: number,
-    webview: vscode.Webview | undefined,
-  ): void {
-    if (event.notification_type === 'permission_prompt') {
-      cancelPermissionTimer(agentId, this.permissionTimers);
-      agent.permissionSent = true;
-      webview?.postMessage({
-        type: 'agentToolPermission',
-        id: agentId,
-      });
-      // Also notify any sub-agents with active non-exempt tools
-      for (const parentToolId of agent.activeSubagentToolNames.keys()) {
-        webview?.postMessage({
-          type: 'subagentToolPermission',
-          id: agentId,
-          parentToolId,
-        });
-      }
-    } else if (event.notification_type === 'idle_prompt') {
-      this.markAgentWaiting(agent, agentId, webview);
-    }
-  }
-
   /** Handle Stop: Claude finished responding, mark agent as waiting. */
   private handleStop(
     agent: AgentState,
@@ -590,6 +661,83 @@ export class HookEventHandler {
     webview: vscode.Webview | undefined,
   ): void {
     this.markAgentWaiting(agent, agentId, webview);
+  }
+
+  /**
+   * Handle TeammateIdle: teammate signaled it's idle and available for work.
+   * Routes to the specific teammate if identifiable by agent_type, otherwise
+   * marks all inline teammates of this lead as waiting.
+   * Fallback: if the agent has no inline teammates, mark the agent itself.
+   */
+  private handleTeammateIdle(
+    event: HookEvent,
+    agent: AgentState,
+    agentId: number,
+    webview: vscode.Webview | undefined,
+  ): void {
+    const agentType = this.provider.team?.extractTeammateNameFromEvent(event);
+    const inlineTeammates = getInlineTeammates(agentId, this.agents);
+
+    if (inlineTeammates.length === 0) {
+      // No inline teammates — treat as a regular idle signal for this agent
+      this.markAgentWaiting(agent, agentId, webview);
+      return;
+    }
+
+    // Match by agentName if provider extracted a name from the event
+    if (agentType) {
+      const match = inlineTeammates.find(([, a]) => a.agentName === agentType);
+      if (match) {
+        const [id, a] = match;
+        if (debug)
+          console.log(`[Pixel Agents] Hook: TeammateIdle "${agentType}" -> teammate Agent ${id}`);
+        this.markAgentWaiting(a, id, webview);
+        return;
+      }
+    }
+
+    // Fallback: mark all inline teammates as waiting
+    if (debug)
+      console.log(
+        `[Pixel Agents] Hook: TeammateIdle (no agent_type match) -> marking ${inlineTeammates.length} teammate(s) waiting`,
+      );
+    for (const [id, a] of inlineTeammates) {
+      this.markAgentWaiting(a, id, webview);
+    }
+  }
+
+  /**
+   * Handle TaskCompleted: a teammate marked its task done.
+   * Routes to the specific teammate when identifiable, marking it waiting instantly.
+   */
+  private handleTaskCompleted(
+    event: HookEvent,
+    _agent: AgentState,
+    agentId: number,
+    webview: vscode.Webview | undefined,
+  ): void {
+    const subject = (event.subject as string) ?? '';
+    const agentType = this.provider.team?.extractTeammateNameFromEvent(event);
+    if (debug)
+      console.log(
+        `[Pixel Agents] Hook: Agent ${agentId} - TaskCompleted: ${subject}${agentType ? ` (agent_type=${agentType})` : ''}`,
+      );
+
+    const inlineTeammates = getInlineTeammates(agentId, this.agents);
+    if (inlineTeammates.length === 0) return;
+
+    // Match by agentName if available, otherwise mark all inline teammates waiting
+    if (agentType) {
+      const match = inlineTeammates.find(([, a]) => a.agentName === agentType);
+      if (match) {
+        const [id, a] = match;
+        this.markAgentWaiting(a, id, webview);
+        return;
+      }
+    }
+    for (const [id, a] of inlineTeammates) {
+      this.markAgentWaiting(a, id, webview);
+    }
   }
 
   /**
@@ -605,45 +753,39 @@ export class HookEventHandler {
     cancelWaitingTimer(agentId, this.waitingTimers);
     cancelPermissionTimer(agentId, this.permissionTimers);
 
-    // Clear foreground tools, preserve background agents (same logic as turn_duration handler)
-    const hasForegroundTools = agent.activeToolIds.size > agent.backgroundAgentToolIds.size;
-    if (hasForegroundTools) {
-      for (const toolId of agent.activeToolIds) {
-        if (agent.backgroundAgentToolIds.has(toolId)) continue;
-        agent.activeToolIds.delete(toolId);
-        agent.activeToolStatuses.delete(toolId);
-        const toolName = agent.activeToolNames.get(toolId);
-        agent.activeToolNames.delete(toolId);
-        if (toolName === 'Task' || toolName === 'Agent') {
-          agent.activeSubagentToolIds.delete(toolId);
-          agent.activeSubagentToolNames.delete(toolId);
-        }
+    // Clear foreground tools, preserve background agents (same logic as turn_duration handler).
+    // ALWAYS send agentToolsClear at turn end -- even when activeToolIds is empty by now
+    // (because tool_results already processed and removed them). Without this, stale
+    // sub-agent characters and permission bubbles from the turn would never clear.
+    const parentTools = this.provider.team
+      ? new Set<string>([
+          ...this.provider.team.teammateSpawnTools,
+          ...this.provider.team.withinTurnSubagentTools,
+        ])
+      : this.provider.subagentToolNames;
+    for (const toolId of [...agent.activeToolIds]) {
+      if (agent.backgroundAgentToolIds.has(toolId)) continue;
+      agent.activeToolIds.delete(toolId);
+      agent.activeToolStatuses.delete(toolId);
+      const toolName = agent.activeToolNames.get(toolId);
+      agent.activeToolNames.delete(toolId);
+      if (toolName && parentTools.has(toolName)) {
+        agent.activeSubagentToolIds.delete(toolId);
+        agent.activeSubagentToolNames.delete(toolId);
       }
-      webview?.postMessage({ type: 'agentToolsClear', id: agentId });
-      // Re-send background agent tools
-      for (const toolId of agent.backgroundAgentToolIds) {
-        const status = agent.activeToolStatuses.get(toolId);
-        if (status) {
-          webview?.postMessage({
-            type: 'agentToolStart',
-            id: agentId,
-            toolId,
-            status,
-          });
-        }
+    }
+    webview?.postMessage({ type: 'agentToolsClear', id: agentId });
+    // Re-send background agent tools to restore them after the clear
+    for (const toolId of agent.backgroundAgentToolIds) {
+      const status = agent.activeToolStatuses.get(toolId);
+      if (status) {
+        webview?.postMessage({
+          type: 'agentToolStart',
+          id: agentId,
+          toolId,
+          status,
+        });
       }
-    } else if (agent.activeToolIds.size > 0 && agent.backgroundAgentToolIds.size === 0) {
-      agent.activeToolIds.clear();
-      agent.activeToolStatuses.clear();
-      agent.activeToolNames.clear();
-      agent.activeSubagentToolIds.clear();
-      agent.activeSubagentToolNames.clear();
-      webview?.postMessage({ type: 'agentToolsClear', id: agentId });
-    } else if (agent.activeToolIds.size === 0 && agent.backgroundAgentToolIds.size === 0) {
-      // Hooks mode safety net: JSONL may have already cleared activeToolIds before
-      // the Stop hook fires, but the webview can still have stale tool entries or
-      // sub-agent characters from hook-created tools. Send agentToolsClear to clean up.
-      webview?.postMessage({ type: 'agentToolsClear', id: agentId });
     }
 
     agent.isWaiting = true;

--- a/server/src/provider.ts
+++ b/server/src/provider.ts
@@ -1,10 +1,10 @@
 /**
  * Provider abstraction for AI agent tools.
  *
- * Three provider types cover the full taxonomy:
- * - HookProvider: CLIs with hooks APIs (Claude Code, Codex, Gemini, Cursor, etc.)
- * - FileProvider: CLIs without hooks, transcript polling only (Goose, Aider, SWE-agent)
- * - StreamProvider: External services with persistent connections (Discord, LangGraph, OpenClaw)
+ * Only HookProvider ships today (Claude Code). Transcript-polling and push-based
+ * provider types will be added when a real second provider (Codex, Goose,
+ * Discord, etc.) actually lands, derived from that provider's needs rather than
+ * speculation.
  */
 
 import type { TeamProvider } from './teamProvider.js';
@@ -30,11 +30,7 @@ export type AgentEvent =
   | { kind: 'sessionStart'; source?: string }
   | { kind: 'sessionEnd'; reason?: string };
 
-export type AgentLifecycleEvent =
-  | { kind: 'agentJoined'; displayName: string; metadata?: Record<string, unknown> }
-  | { kind: 'agentLeft' };
-
-// ── Hook-based Provider (CLIs with hooks APIs, the default) ──
+// ── Hook-based Provider (CLIs with hooks APIs) ────────────────
 
 export interface HookProvider {
   readonly kind: 'hook';
@@ -47,7 +43,7 @@ export interface HookProvider {
    *  Return null for events we should ignore. */
   normalizeHookEvent(raw: Record<string, unknown>): {
     sessionId: string;
-    event: AgentEvent | AgentLifecycleEvent;
+    event: AgentEvent;
   } | null;
 
   /** Install hook scripts that POST to our server. */
@@ -89,45 +85,5 @@ export interface HookProvider {
   readonly team?: TeamProvider;
 }
 
-// ── File-based Provider (CLIs without hooks, polling only) ──
-
-export interface FileProvider {
-  readonly kind: 'file';
-  readonly id: string;
-  readonly displayName: string;
-
-  getSessionDirs(workspacePath: string): string[];
-  readonly sessionFilePattern: string;
-  buildLaunchCommand(
-    sessionId: string,
-    cwd: string,
-  ): {
-    command: string;
-    args: string[];
-    env?: Record<string, string>;
-  };
-  parseTranscriptLine(line: string): AgentEvent | null;
-  formatToolStatus(toolName: string, input?: unknown): string;
-  readonly permissionExemptTools: ReadonlySet<string>;
-  readonly subagentToolNames: ReadonlySet<string>;
-}
-
-// ── Stream-based Provider (external services that push events) ──
-
-export interface StreamProvider {
-  readonly kind: 'stream';
-  readonly id: string;
-  readonly displayName: string;
-
-  /** Connect to the external service. Calls onEvent for each agent event. */
-  connect(
-    onEvent: (agentKey: string, event: AgentEvent | AgentLifecycleEvent) => void,
-  ): Promise<void>;
-  /** Graceful disconnect */
-  disconnect(): Promise<void>;
-  formatToolStatus(toolName: string, input?: unknown): string;
-}
-
-// ── Discriminated union ──
-
-export type AgentProvider = HookProvider | FileProvider | StreamProvider;
+// TODO(provider type taxonomy): FileProvider (polling-only CLIs) and StreamProvider
+// (push-based external services) will be added alongside the first real second provider

--- a/server/src/provider.ts
+++ b/server/src/provider.ts
@@ -1,0 +1,133 @@
+/**
+ * Provider abstraction for AI agent tools.
+ *
+ * Three provider types cover the full taxonomy:
+ * - HookProvider: CLIs with hooks APIs (Claude Code, Codex, Gemini, Cursor, etc.)
+ * - FileProvider: CLIs without hooks, transcript polling only (Goose, Aider, SWE-agent)
+ * - StreamProvider: External services with persistent connections (Discord, LangGraph, OpenClaw)
+ */
+
+import type { TeamProvider } from './teamProvider.js';
+
+// ── Normalized Events (all provider types produce these) ──────
+
+export type AgentEvent =
+  | { kind: 'toolStart'; toolId: string; toolName: string; input?: unknown }
+  | { kind: 'toolEnd'; toolId: string }
+  | { kind: 'turnEnd' }
+  | { kind: 'userTurn' }
+  | {
+      kind: 'subagentStart';
+      parentToolId: string;
+      toolId: string;
+      toolName: string;
+      input?: unknown;
+    }
+  | { kind: 'subagentEnd'; parentToolId: string; toolId: string }
+  | { kind: 'subagentTurnEnd'; parentToolId: string }
+  | { kind: 'progress'; toolId: string; data: unknown }
+  | { kind: 'permissionRequest' }
+  | { kind: 'sessionStart'; source?: string }
+  | { kind: 'sessionEnd'; reason?: string };
+
+export type AgentLifecycleEvent =
+  | { kind: 'agentJoined'; displayName: string; metadata?: Record<string, unknown> }
+  | { kind: 'agentLeft' };
+
+// ── Hook-based Provider (CLIs with hooks APIs, the default) ──
+
+export interface HookProvider {
+  readonly kind: 'hook';
+  readonly id: string;
+  readonly displayName: string;
+
+  /** Normalize a raw hook event payload into an AgentEvent.
+   *  Each CLI sends different JSON (Claude: snake_case, Copilot: camelCase, etc.)
+   *  The provider translates to the common AgentEvent format.
+   *  Return null for events we should ignore. */
+  normalizeHookEvent(raw: Record<string, unknown>): {
+    sessionId: string;
+    event: AgentEvent | AgentLifecycleEvent;
+  } | null;
+
+  /** Install hook scripts that POST to our server. */
+  installHooks(serverUrl: string, authToken: string): Promise<void>;
+  /** Remove installed hook scripts. */
+  uninstallHooks(): Promise<void>;
+  /** Check if hooks are currently installed. */
+  areHooksInstalled(): Promise<boolean>;
+
+  /** Format tool status for display (e.g., "Read" -> "Reading foo.ts") */
+  formatToolStatus(toolName: string, input?: unknown): string;
+  /** Tools that don't trigger permission timers */
+  readonly permissionExemptTools: ReadonlySet<string>;
+  /** Tools that spawn sub-agent characters */
+  readonly subagentToolNames: ReadonlySet<string>;
+
+  // ── Optional file fallback (heuristic mode) ──
+
+  /** Session directories to scan. Undefined = no file fallback. */
+  getSessionDirs?(workspacePath: string): string[];
+  /** Glob pattern for session files (e.g., '*.jsonl'). */
+  readonly sessionFilePattern?: string;
+  /** Parse one line of a transcript file into an AgentEvent. */
+  parseTranscriptLine?(line: string): AgentEvent | null;
+  /** Build CLI launch command for +Agent button. */
+  buildLaunchCommand?(
+    sessionId: string,
+    cwd: string,
+  ): {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+  };
+
+  // ── Optional team/subagent extension (Agent Teams on Claude; empty for single-agent CLIs) ──
+
+  /** Optional reference to a TeamProvider. When set, the hook handler registers team-aware
+   *  branches (subagent routing, teammate discovery, permission forwarding, etc.). */
+  readonly team?: TeamProvider;
+}
+
+// ── File-based Provider (CLIs without hooks, polling only) ──
+
+export interface FileProvider {
+  readonly kind: 'file';
+  readonly id: string;
+  readonly displayName: string;
+
+  getSessionDirs(workspacePath: string): string[];
+  readonly sessionFilePattern: string;
+  buildLaunchCommand(
+    sessionId: string,
+    cwd: string,
+  ): {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+  };
+  parseTranscriptLine(line: string): AgentEvent | null;
+  formatToolStatus(toolName: string, input?: unknown): string;
+  readonly permissionExemptTools: ReadonlySet<string>;
+  readonly subagentToolNames: ReadonlySet<string>;
+}
+
+// ── Stream-based Provider (external services that push events) ──
+
+export interface StreamProvider {
+  readonly kind: 'stream';
+  readonly id: string;
+  readonly displayName: string;
+
+  /** Connect to the external service. Calls onEvent for each agent event. */
+  connect(
+    onEvent: (agentKey: string, event: AgentEvent | AgentLifecycleEvent) => void,
+  ): Promise<void>;
+  /** Graceful disconnect */
+  disconnect(): Promise<void>;
+  formatToolStatus(toolName: string, input?: unknown): string;
+}
+
+// ── Discriminated union ──
+
+export type AgentProvider = HookProvider | FileProvider | StreamProvider;

--- a/server/src/providers/hook/claude/claude.ts
+++ b/server/src/providers/hook/claude/claude.ts
@@ -1,0 +1,256 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  BASH_COMMAND_DISPLAY_MAX_LENGTH,
+  TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+} from '../../../constants.js';
+import type { AgentEvent, AgentLifecycleEvent, HookProvider } from '../../../provider.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './claudeHookInstaller.js';
+import { claudeTeamProvider } from './claudeTeamProvider.js';
+
+// ── formatToolStatus: moved from src/transcriptParser.ts ──
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+  switch (toolName) {
+    case 'Read':
+      return `Reading ${base(inp.file_path)}`;
+    case 'Edit':
+      return `Editing ${base(inp.file_path)}`;
+    case 'Write':
+      return `Writing ${base(inp.file_path)}`;
+    case 'Bash': {
+      const cmd = (inp.command as string) || '';
+      return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : cmd}`;
+    }
+    case 'Glob':
+      return 'Searching files';
+    case 'Grep':
+      return 'Searching code';
+    case 'WebFetch':
+      return 'Fetching web content';
+    case 'WebSearch':
+      return 'Searching the web';
+    case 'Task':
+    case 'Agent': {
+      const desc = typeof inp.description === 'string' ? inp.description : '';
+      return desc
+        ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '\u2026' : desc}`
+        : 'Running subtask';
+    }
+    case 'AskUserQuestion':
+      return 'Waiting for your answer';
+    case 'EnterPlanMode':
+      return 'Planning';
+    case 'NotebookEdit':
+      return 'Editing notebook';
+    case 'TeamCreate': {
+      const teamName = typeof inp.team_name === 'string' ? inp.team_name : '';
+      return teamName ? `Creating team: ${teamName}` : 'Creating team';
+    }
+    case 'SendMessage': {
+      const recipient = typeof inp.recipient === 'string' ? inp.recipient : '';
+      return recipient ? `-> ${recipient}` : 'Sending message';
+    }
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+// ── Session dir + launch command ──
+
+function getSessionDirs(workspacePath: string): string[] {
+  // Claude stores sessions at ~/.claude/projects/<workspace-path-with-dashes>/.
+  // Normalize every non-alphanumeric char (except '-') to '-' to match Claude's
+  // directory naming convention across platforms.
+  const dirName = workspacePath.replace(/[^a-zA-Z0-9-]/g, '-');
+  const projectDir = path.join(os.homedir(), '.claude', 'projects', dirName);
+
+  // Try exact match first.
+  if (fs.existsSync(projectDir)) return [projectDir];
+
+  // Case-insensitive fallback for Windows: drive letter casing can differ
+  // between what VS Code gives us (e.g. "c:\...") and Claude's encoding ("C:\...").
+  const projectsRoot = path.join(os.homedir(), '.claude', 'projects');
+  try {
+    if (fs.existsSync(projectsRoot)) {
+      const lowerDirName = dirName.toLowerCase();
+      const match = fs.readdirSync(projectsRoot).find((c) => c.toLowerCase() === lowerDirName);
+      if (match) return [path.join(projectsRoot, match)];
+    }
+  } catch {
+    /* ignore scan errors */
+  }
+
+  // Return the expected path even if it doesn't exist yet (caller tolerates missing dirs).
+  return [projectDir];
+}
+
+function buildLaunchCommand(
+  sessionId: string,
+  cwd: string,
+): { command: string; args: string[]; env?: Record<string, string> } {
+  return { command: 'claude', args: ['--session-id', sessionId], env: { PWD: cwd } };
+}
+
+// ── normalizeHookEvent: the single Claude-specific normalization boundary ──
+//
+// All raw Claude hook payload fields (tool_name, tool_input, agent_type, etc.) are
+// read HERE and HERE ONLY. Downstream (hookEventHandler.ts) sees only the normalized
+// AgentEvent union.
+//
+// Sentinel 'current' toolIds are returned for PostToolUse/SubagentStop because the
+// raw hook payload doesn't carry the id; the handler correlates using its own
+// currentHookToolId state. Synthetic hook-* ids are returned for PreToolUse because
+// the real tool id arrives later via JSONL polling.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent | AgentLifecycleEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  switch (eventName) {
+    case 'PreToolUse': {
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : '';
+      const toolInput =
+        typeof raw.tool_input === 'object' && raw.tool_input !== null
+          ? (raw.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        sessionId,
+        event: {
+          kind: 'toolStart',
+          toolId: `hook-${Date.now()}`,
+          toolName,
+          input: toolInput,
+        },
+      };
+    }
+
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      return { sessionId, event: { kind: 'toolEnd', toolId: 'current' } };
+
+    case 'Stop':
+      return { sessionId, event: { kind: 'turnEnd' } };
+
+    case 'UserPromptSubmit':
+      return { sessionId, event: { kind: 'userTurn' } };
+
+    case 'SubagentStart': {
+      const agentType = typeof raw.agent_type === 'string' ? raw.agent_type : 'unknown';
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: 'current',
+          toolId: `hook-sub-${agentType}-${Date.now()}`,
+          toolName: agentType,
+          input: raw,
+        },
+      };
+    }
+
+    case 'SubagentStop':
+      return {
+        sessionId,
+        event: { kind: 'subagentEnd', parentToolId: 'current', toolId: 'current' },
+      };
+
+    case 'PermissionRequest':
+      return { sessionId, event: { kind: 'permissionRequest' } };
+
+    case 'Notification': {
+      const notificationType =
+        typeof raw.notification_type === 'string' ? raw.notification_type : '';
+      if (notificationType === 'permission_prompt') {
+        return { sessionId, event: { kind: 'permissionRequest' } };
+      }
+      if (notificationType === 'idle_prompt') {
+        return { sessionId, event: { kind: 'turnEnd' } };
+      }
+      return null;
+    }
+
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: typeof raw.source === 'string' ? raw.source : undefined,
+        },
+      };
+
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionEnd',
+          reason: typeof raw.reason === 'string' ? raw.reason : undefined,
+        },
+      };
+
+    // Agent Teams: a teammate went idle / marked a task complete. Normalize as
+    // `subagentTurnEnd` so the team handler can route by agent_type to the teammate.
+    case 'TeammateIdle':
+    case 'TaskCompleted':
+      return {
+        sessionId,
+        event: { kind: 'subagentTurnEnd', parentToolId: 'current' },
+      };
+
+    // TaskCreated is informational; no AgentEvent shape fits it. Drop.
+    case 'TaskCreated':
+    default:
+      return null;
+  }
+}
+
+// ── Installer wrappers: adapt sync signatures to async interface ──
+
+function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  installerInstallHooks();
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  installerUninstallHooks();
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(installerAreHooksInstalled());
+}
+
+// ── The provider ──
+
+export const claudeProvider: HookProvider = {
+  kind: 'hook',
+  id: 'claude',
+  displayName: 'Claude Code',
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  permissionExemptTools: new Set(['Task', 'Agent', 'AskUserQuestion']),
+  subagentToolNames: new Set(['Task', 'Agent']),
+
+  getSessionDirs,
+  sessionFilePattern: '*.jsonl',
+  buildLaunchCommand,
+
+  team: claudeTeamProvider,
+};

--- a/server/src/providers/hook/claude/claude.ts
+++ b/server/src/providers/hook/claude/claude.ts
@@ -6,7 +6,7 @@ import {
   BASH_COMMAND_DISPLAY_MAX_LENGTH,
   TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
 } from '../../../constants.js';
-import type { AgentEvent, AgentLifecycleEvent, HookProvider } from '../../../provider.js';
+import type { AgentEvent, HookProvider } from '../../../provider.js';
 import {
   areHooksInstalled as installerAreHooksInstalled,
   installHooks as installerInstallHooks,
@@ -113,7 +113,7 @@ function buildLaunchCommand(
 
 function normalizeHookEvent(
   raw: Record<string, unknown>,
-): { sessionId: string; event: AgentEvent | AgentLifecycleEvent } | null {
+): { sessionId: string; event: AgentEvent } | null {
   const eventName = raw.hook_event_name;
   const sessionId = raw.session_id;
   if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;

--- a/server/src/providers/hook/claude/claudeHookInstaller.ts
+++ b/server/src/providers/hook/claude/claudeHookInstaller.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { CLAUDE_HOOK_EVENTS, CLAUDE_HOOK_SCRIPT_NAME, HOOK_SCRIPTS_DIR } from '../../constants.js';
+import { HOOK_SCRIPTS_DIR } from '../../../constants.js';
+import { CLAUDE_HOOK_EVENTS, CLAUDE_HOOK_SCRIPT_NAME } from './constants.js';
 
 /** Marker string used to identify Pixel Agents hook entries in Claude's settings. */
 const HOOK_SCRIPT_MARKER = CLAUDE_HOOK_SCRIPT_NAME;

--- a/server/src/providers/hook/claude/claudeTeamProvider.ts
+++ b/server/src/providers/hook/claude/claudeTeamProvider.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { TeamProvider } from '../../../teamProvider.js';
+
+/**
+ * Claude Code implementation of the TeamProvider interface.
+ *
+ * Encapsulates every Claude-specific path, field name, and tool identifier
+ * for the Agent Teams feature. Adding support for a new CLI means creating a
+ * sibling file; no changes to hookEventHandler.ts or fileWatcher.ts.
+ */
+export const claudeTeamProvider: TeamProvider = {
+  providerId: 'claude',
+
+  teammateSpawnTools: new Set(['Agent']),
+  withinTurnSubagentTools: new Set(['Task']),
+
+  isTeammateSpawnCall(toolName, toolInput) {
+    // Claude's Agent tool spawns a teammate ONLY when run_in_background is true.
+    // Agent without that flag is a basic within-turn subagent (identical UX to Task).
+    return toolName === 'Agent' && toolInput.run_in_background === true;
+  },
+
+  extractTeammateNameFromEvent(event) {
+    const value = event.agent_type;
+    return typeof value === 'string' ? value : undefined;
+  },
+
+  resolveTeammateMetadataPath(teammateJsonlFile) {
+    return teammateJsonlFile.replace(/\.jsonl$/, '.meta.json');
+  },
+
+  parseTeammateMetadata(metadataContents) {
+    try {
+      const data = JSON.parse(metadataContents) as { agentType?: unknown };
+      return typeof data.agentType === 'string' ? data.agentType : null;
+    } catch {
+      return null;
+    }
+  },
+
+  resolveTeammateJsonlDir(projectDir, leadSessionId) {
+    return path.join(projectDir, leadSessionId, 'subagents');
+  },
+
+  getTeamMembers(teamName) {
+    const configPath = path.join(os.homedir(), '.claude', 'teams', teamName, 'config.json');
+    let raw: string;
+    try {
+      raw = fs.readFileSync(configPath, 'utf-8');
+    } catch {
+      return null; // config missing / unreadable -> team dissolved
+    }
+    try {
+      const data = JSON.parse(raw) as { members?: Array<{ name?: unknown }> };
+      if (!Array.isArray(data.members)) return null;
+      const names = new Set<string>();
+      for (const m of data.members) {
+        if (m && typeof m.name === 'string') names.add(m.name);
+      }
+      return names;
+    } catch {
+      return null;
+    }
+  },
+
+  extractTeamMetadataFromRecord(record) {
+    const teamName = record.teamName;
+    if (typeof teamName !== 'string') return null;
+    const agentName = record.agentName;
+    return {
+      teamName,
+      agentName: typeof agentName === 'string' ? agentName : undefined,
+    };
+  },
+};

--- a/server/src/providers/hook/claude/constants.ts
+++ b/server/src/providers/hook/claude/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Claude-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider `server/` build doesn't accidentally depend on Claude
+ * unless Claude is the active provider.
+ *
+ * Adding another provider? Create its own `providers/<kind>/<name>/constants.ts`.
+ */
+
+/** Output filename after esbuild compiles claude-hook.ts to CJS (source is .ts, output is .js) */
+export const CLAUDE_HOOK_SCRIPT_NAME = 'claude-hook.js';
+
+/** Hook events to install in ~/.claude/settings.json.
+ *  SessionStart/SessionEnd handle session lifecycle (start, /clear, resume, exit).
+ *  Stop/PermissionRequest/Notification handle turn completion and permission UI.
+ *  SubagentStart/SubagentStop/TeammateIdle/TaskCreated/TaskCompleted power Agent Teams. */
+export const CLAUDE_HOOK_EVENTS = [
+  'SessionStart',
+  'SessionEnd',
+  'Stop',
+  'PermissionRequest',
+  'Notification',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'SubagentStart',
+  'SubagentStop',
+  'TeammateIdle',
+  'TaskCreated',
+  'TaskCompleted',
+] as const;

--- a/server/src/providers/hook/claude/hooks/claude-hook.ts
+++ b/server/src/providers/hook/claude/hooks/claude-hook.ts
@@ -3,8 +3,8 @@ import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
 
-import { HOOK_API_PREFIX, SERVER_JSON_DIR, SERVER_JSON_NAME } from '../../../constants.js';
-import type { ServerConfig } from '../../../server.js';
+import { HOOK_API_PREFIX, SERVER_JSON_DIR, SERVER_JSON_NAME } from '../../../../constants.js';
+import type { ServerConfig } from '../../../../server.js';
 
 const SERVER_JSON = path.join(os.homedir(), SERVER_JSON_DIR, SERVER_JSON_NAME);
 

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Provider registry: re-exports all bundled providers.
+ *
+ * Adding a new CLI provider:
+ *   1. Create `server/src/providers/hook/<cli>/<cli>.ts` implementing HookProvider
+ *      (or `providers/file/<cli>/<cli>.ts` for FileProvider, etc.)
+ *   2. Add an export line below.
+ *
+ * The adapter (VS Code extension, standalone CLI, etc.) imports from here rather
+ * than reaching into each provider directory directly.
+ */
+
+export { claudeProvider } from './hook/claude/claude.js';
+export { copyHookScript } from './hook/claude/claudeHookInstaller.js';

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -2,8 +2,9 @@
  * Provider registry: re-exports all bundled providers.
  *
  * Adding a new CLI provider:
- *   1. Create `server/src/providers/hook/<cli>/<cli>.ts` implementing HookProvider
- *      (or `providers/file/<cli>/<cli>.ts` for FileProvider, etc.)
+ *   1. Create `server/src/providers/hook/<cli>/<cli>.ts` implementing HookProvider.
+ *      (File-based and stream-based provider types will land when the first such
+ *       provider ships.)
  *   2. Add an export line below.
  *
  * The adapter (VS Code extension, standalone CLI, etc.) imports from here rather

--- a/server/src/teamProvider.ts
+++ b/server/src/teamProvider.ts
@@ -1,0 +1,67 @@
+/**
+ * TeamProvider: optional extension on HookProvider for CLIs that support the
+ * Lead + Teammates pattern (Claude Agent Teams today; hypothetical future CLIs).
+ *
+ * This interface only covers concepts that `HookProvider.normalizeHookEvent` +
+ * `AgentEvent` don't already cover. Generic concepts (subagent start/end, tool
+ * start/end, permission request, session lifecycle) belong on HookProvider.
+ *
+ * Providers without team support simply don't set `HookProvider.team`. No team-
+ * gated code runs for them -- no stubs, no dead branches.
+ */
+export interface TeamProvider {
+  /** CLI identifier (e.g. 'claude', 'codex'). Used for logging. */
+  providerId: string;
+
+  /** Tool names that CAN spawn persistent teammates (fast-path gate only).
+   *  Claude: 'Agent'. But note: the same tool can also spawn basic subagents, so use
+   *  `isTeammateSpawnCall(toolName, toolInput)` for the authoritative decision. */
+  teammateSpawnTools: ReadonlySet<string>;
+
+  /** Tool names that spawn within-turn, ephemeral subagents tied to a parent tool call.
+   *  Claude: 'Task'. These produce negative-ID sub-agent characters in the webview. */
+  withinTurnSubagentTools: ReadonlySet<string>;
+
+  /** Authoritative predicate: does THIS SPECIFIC tool call spawn a persistent teammate?
+   *  Depends on tool input flags, not just the tool name. Without this, we can't
+   *  distinguish basic subagents from teammates when the same tool name is reused.
+   *
+   *  Claude: `Agent` tool with `run_in_background: true`. Agent without that flag is
+   *  a basic within-turn subagent, not a teammate. */
+  isTeammateSpawnCall(toolName: string, toolInput: Record<string, unknown>): boolean;
+
+  /** Extract a teammate's identity (name) from a raw hook event payload (pre-normalization).
+   *  Used to route TeammateIdle / TaskCompleted hooks to the specific teammate agent.
+   *  Claude: reads the `agent_type` field. Returns undefined if not present. */
+  extractTeammateNameFromEvent(event: Record<string, unknown>): string | undefined;
+
+  /** Given a teammate's JSONL path, return the path to its sidecar metadata file.
+   *  Claude: `<file>.meta.json`. */
+  resolveTeammateMetadataPath(teammateJsonlFile: string): string;
+
+  /** Parse the sidecar metadata contents and return the teammate's name.
+   *  Claude: reads `agentType` string field. Returns null if invalid. */
+  parseTeammateMetadata(metadataContents: string): string | null;
+
+  /** Directory containing teammate JSONL files for the given lead session.
+   *  Claude: `<projectDir>/<leadSessionId>/subagents`. */
+  resolveTeammateJsonlDir(projectDir: string, leadSessionId: string): string;
+
+  /** Get the currently-active member names of a team. Source of truth for team membership.
+   *  Returns the Set of names, or null if the team can't be read (team dissolved / no data).
+   *
+   *  Replaces the old split `resolveTeamConfigPath` + `parseTeamConfigMembers` pair so
+   *  providers using API-driven team stores (not file-based) can implement without a path.
+   *
+   *  Claude reads `~/.claude/teams/<teamName>/config.json`'s `members[].name` array. */
+  getTeamMembers(teamName: string): Set<string> | null;
+
+  /** Extract team metadata from a transcript record (one parsed JSONL line).
+   *  Used by transcriptParser to link teammates to their lead without hardcoding
+   *  Claude-specific field names in the shared parser.
+   *
+   *  Claude: returns { teamName: record.teamName, agentName: record.agentName }. */
+  extractTeamMetadataFromRecord(
+    record: Record<string, unknown>,
+  ): { teamName?: string; agentName?: string } | null;
+}

--- a/server/src/teamUtils.ts
+++ b/server/src/teamUtils.ts
@@ -1,0 +1,41 @@
+import type { AgentState } from '../../src/types.js';
+
+/**
+ * Pure helpers for working with Lead + Teammates relationships.
+ *
+ * These replace the duplicated filter pattern
+ *   `a.leadAgentId === agentId && !a.teamUsesTmux`
+ * that previously appeared 8 times across hookEventHandler.ts and fileWatcher.ts.
+ *
+ * "Inline teammate": a teammate running in-process with the lead (no separate
+ * terminal). These share the lead's `session_id` in hook events, so routing
+ * logic needs to redirect those events from the lead to the teammate.
+ *
+ * "Tmux teammate": a teammate running in a separate tmux pane with its own
+ * `session_id`. Hooks route to it directly; no redirection needed.
+ */
+
+/** Is this agent an inline teammate (non-tmux) of the given lead? */
+export function isInlineTeammateOf(agent: AgentState, leadId: number): boolean {
+  return agent.leadAgentId === leadId && !agent.teamUsesTmux;
+}
+
+/** All inline teammates of a lead. Returns [id, agent] pairs for convenience. */
+export function getInlineTeammates(
+  leadId: number,
+  agents: Map<number, AgentState>,
+): Array<[number, AgentState]> {
+  const out: Array<[number, AgentState]> = [];
+  for (const [id, a] of agents) {
+    if (isInlineTeammateOf(a, leadId)) out.push([id, a]);
+  }
+  return out;
+}
+
+/** Does this lead have any active inline teammates? */
+export function hasInlineTeammates(leadId: number, agents: Map<number, AgentState>): boolean {
+  for (const a of agents.values()) {
+    if (isInlineTeammateOf(a, leadId)) return true;
+  }
+  return false;
+}

--- a/server/src/teamUtils.ts
+++ b/server/src/teamUtils.ts
@@ -5,7 +5,6 @@ import type { AgentState } from '../../src/types.js';
  *
  * These replace the duplicated filter pattern
  *   `a.leadAgentId === agentId && !a.teamUsesTmux`
- * that previously appeared 8 times across hookEventHandler.ts and fileWatcher.ts.
  *
  * "Inline teammate": a teammate running in-process with the lead (no separate
  * terminal). These share the lead's `session_id` in hook events, so routing

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -6,10 +6,10 @@ import * as vscode from 'vscode';
 import type { HookEvent } from '../server/src/hookEventHandler.js';
 import { HookEventHandler } from '../server/src/hookEventHandler.js';
 import {
-  copyHookScript,
   installHooks,
   uninstallHooks,
-} from '../server/src/providers/file/claudeHookInstaller.js';
+} from '../server/src/providers/hook/claude/claudeHookInstaller.js';
+import { claudeProvider, copyHookScript } from '../server/src/providers/index.js';
 import { PixelAgentsServer } from '../server/src/server.js';
 import {
   getProjectDirPath,
@@ -53,12 +53,16 @@ import {
   ensureProjectScan,
   isTrackedProjectDir,
   reassignAgentToFile,
+  scanForTeammateFiles,
   seededMtimes,
+  setTeammateRemovalCallback,
+  setTeamProvider,
   startExternalSessionScanning,
   startStaleExternalAgentCheck,
 } from './fileWatcher.js';
 import type { LayoutWatcher } from './layoutPersistence.js';
 import { readLayoutFromFile, watchLayoutFile, writeLayoutToFile } from './layoutPersistence.js';
+import { setHookProvider } from './transcriptParser.js';
 import type { AgentState } from './types.js';
 
 export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
@@ -125,8 +129,17 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
       this.waitingTimers,
       this.permissionTimers,
       () => this.webview,
+      claudeProvider,
       this.watchAllSessions,
     );
+
+    // Register Claude's team provider (if present on the hook provider) with the file
+    // watcher module + transcriptParser, plus the teammate removal callback.
+    if (claudeProvider.team) {
+      setTeamProvider(claudeProvider.team);
+    }
+    setHookProvider(claudeProvider);
+    setTeammateRemovalCallback((id) => this.removeTeammate(id, 'team-config'));
 
     this.hookEventHandler.setLifecycleCallbacks({
       onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
@@ -179,6 +192,27 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         dismissedJsonlFiles.delete(transcriptPath);
         seededMtimes.delete(transcriptPath);
         this.knownJsonlFiles.delete(transcriptPath);
+      },
+      onTeammateDetected: (parentAgentId, sessionId, _agentType) => {
+        const parentAgent = this.agents.get(parentAgentId);
+        if (!parentAgent) return;
+        scanForTeammateFiles(
+          parentAgent.projectDir,
+          sessionId,
+          parentAgentId,
+          this.nextAgentId,
+          this.agents,
+          this.fileWatchers,
+          this.pollingTimers,
+          this.waitingTimers,
+          this.permissionTimers,
+          this.webview,
+          this.persistAgents,
+          (agent) => this.registerAgentHook(agent),
+        );
+      },
+      onTeammateRemoved: (teammateAgentId) => {
+        this.removeTeammate(teammateAgentId, 'hooks');
       },
       onSessionEnd: (agentId) => {
         const agent = this.agents.get(agentId);
@@ -233,6 +267,26 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   }
 
   /** Remove all teammates of a lead agent */
+  /** Remove a single teammate agent (used by both hook callback and team config polling). */
+  private removeTeammate(teammateAgentId: number, source: string): void {
+    const agent = this.agents.get(teammateAgentId);
+    if (!agent) return;
+    console.log(`[Pixel Agents] Removing teammate ${teammateAgentId} (source: ${source})`);
+    dismissedJsonlFiles.set(agent.jsonlFile, Date.now());
+    this.unregisterAgentHook(agent);
+    removeAgent(
+      teammateAgentId,
+      this.agents,
+      this.fileWatchers,
+      this.pollingTimers,
+      this.waitingTimers,
+      this.permissionTimers,
+      this.jsonlPollTimers,
+      this.persistAgents,
+    );
+    this.webview?.postMessage({ type: 'agentClosed', id: teammateAgentId });
+  }
+
   private removeTeammates(leadId: number): void {
     const teammates: number[] = [];
     for (const [id, agent] of this.agents) {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -186,6 +186,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // Dismiss the file so heuristic scanners don't re-adopt it
         seededMtimes.delete(agent.jsonlFile);
         dismissedJsonlFiles.set(agent.jsonlFile, Date.now());
+        // If this is a team lead, remove its teammates
+        if (agent.isTeamLead) {
+          this.removeTeammates(agentId);
+        }
         // External agents: remove immediately (no terminal to keep alive)
         if (agent.isExternal) {
           this.unregisterAgentHook(agent);
@@ -226,6 +230,35 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
       .catch((e) => {
         console.error(`[Pixel Agents] Failed to start server: ${e}`);
       });
+  }
+
+  /** Remove all teammates of a lead agent */
+  private removeTeammates(leadId: number): void {
+    const teammates: number[] = [];
+    for (const [id, agent] of this.agents) {
+      if (agent.leadAgentId === leadId) {
+        teammates.push(id);
+      }
+    }
+    for (const id of teammates) {
+      const agent = this.agents.get(id);
+      if (agent) {
+        console.log(`[Pixel Agents] Removing teammate ${id} (lead ${leadId} closed)`);
+        dismissedJsonlFiles.set(agent.jsonlFile, Date.now());
+        this.unregisterAgentHook(agent);
+        removeAgent(
+          id,
+          this.agents,
+          this.fileWatchers,
+          this.pollingTimers,
+          this.waitingTimers,
+          this.permissionTimers,
+          this.jsonlPollTimers,
+          this.persistAgents,
+        );
+        this.webview?.postMessage({ type: 'agentClosed', id });
+      }
+    }
   }
 
   /** Register an agent with the hook event handler for session->agent mapping.
@@ -277,8 +310,13 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         if (agent) {
           if (agent.terminalRef) {
             agent.terminalRef.show();
+          } else if (agent.leadAgentId !== undefined) {
+            // Teammate (tmux): focus the lead's terminal instead
+            const lead = this.agents.get(agent.leadAgentId);
+            if (lead?.terminalRef) {
+              lead.terminalRef.show();
+            }
           }
-          // External agents (extension panel) have no terminal to focus
         }
       } else if (message.type === 'closeAgent') {
         const agent = this.agents.get(message.id);
@@ -716,6 +754,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         if (agent.terminalRef && agent.terminalRef === closed) {
           if (this.activeAgentId.current === id) {
             this.activeAgentId.current = null;
+          }
+          // If this is a team lead, remove its teammates
+          if (agent.isTeamLead) {
+            this.removeTeammates(id);
           }
           // Dismiss JSONL so external scanner doesn't re-adopt it
           dismissedJsonlFiles.set(agent.jsonlFile, Date.now());

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -128,6 +128,8 @@ export async function launchNewTerminal(
     seenUnknownRecordTypes: new Set(),
     folderName,
     hookDelivered: false,
+    inputTokens: 0,
+    outputTokens: 0,
   };
 
   agents.set(id, agent);
@@ -292,6 +294,10 @@ export function persistAgents(
       jsonlFile: agent.jsonlFile,
       projectDir: agent.projectDir,
       folderName: agent.folderName,
+      teamName: agent.teamName,
+      agentName: agent.agentName,
+      isTeamLead: agent.isTeamLead,
+      leadAgentId: agent.leadAgentId,
     });
   }
   context.workspaceState.update(WORKSPACE_KEY_AGENTS, persisted);
@@ -368,6 +374,12 @@ export function restoreAgents(
       seenUnknownRecordTypes: new Set(),
       folderName: p.folderName,
       hookDelivered: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      teamName: p.teamName,
+      agentName: p.agentName,
+      isTeamLead: p.isTeamLead,
+      leadAgentId: p.leadAgentId,
     };
 
     agents.set(p.id, agent);
@@ -566,6 +578,26 @@ export function sendCurrentAgentStatuses(
         type: 'agentStatus',
         id: agentId,
         status: 'waiting',
+      });
+    }
+    // Re-send team metadata
+    if (agent.teamName) {
+      webview.postMessage({
+        type: 'agentTeamInfo',
+        id: agentId,
+        teamName: agent.teamName,
+        agentName: agent.agentName,
+        isTeamLead: agent.isTeamLead,
+        leadAgentId: agent.leadAgentId,
+      });
+    }
+    // Re-send token usage
+    if (agent.inputTokens > 0 || agent.outputTokens > 0) {
+      webview.postMessage({
+        type: 'agentTokenUsage',
+        id: agentId,
+        inputTokens: agent.inputTokens,
+        outputTokens: agent.outputTokens,
       });
     }
   }

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -298,6 +298,7 @@ export function persistAgents(
       agentName: agent.agentName,
       isTeamLead: agent.isTeamLead,
       leadAgentId: agent.leadAgentId,
+      teamUsesTmux: agent.teamUsesTmux,
     });
   }
   context.workspaceState.update(WORKSPACE_KEY_AGENTS, persisted);
@@ -380,6 +381,7 @@ export function restoreAgents(
       agentName: p.agentName,
       isTeamLead: p.isTeamLead,
       leadAgentId: p.leadAgentId,
+      teamUsesTmux: p.teamUsesTmux,
     };
 
     agents.set(p.id, agent);
@@ -589,6 +591,7 @@ export function sendCurrentAgentStatuses(
         agentName: agent.agentName,
         isTeamLead: agent.isTeamLead,
         leadAgentId: agent.leadAgentId,
+        teamUsesTmux: agent.teamUsesTmux,
       });
     }
     // Re-send token usage

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -36,6 +36,7 @@ import {
   GLOBAL_SCAN_ACTIVE_MIN_SIZE,
   PROJECT_SCAN_INTERVAL_MS,
 } from '../server/src/constants.js';
+import type { TeamProvider } from '../server/src/teamProvider.js';
 import { removeAgent } from './agentManager.js';
 import { TERMINAL_NAME_PREFIX } from './constants.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
@@ -200,7 +201,7 @@ export function readNewLines(
       // (processed in transcriptParser) should clear it.
       cancelWaitingTimer(agentId, waitingTimers);
       cancelPermissionTimer(agentId, permissionTimers);
-      if (agent.permissionSent && !agent.hookDelivered) {
+      if (agent.permissionSent && !agent.hookDelivered && !agent.leadAgentId) {
         agent.permissionSent = false;
         webview?.postMessage({ type: 'agentToolPermissionClear', id: agentId });
       }
@@ -294,6 +295,27 @@ export function ensureProjectScan(
   // Start the shared timer only once
   if (projectScanTimerRef.current) return;
   projectScanTimerRef.current = setInterval(() => {
+    // Teammate scanning runs in BOTH modes (hooks + heuristic).
+    // In hooks mode, SubagentStart triggers immediate scanning, but the periodic
+    // fallback catches teammates that hooks missed (e.g. hook arrived before JSONL).
+    scanAllTeammateFiles(
+      nextAgentIdRef,
+      agents,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      webview,
+      persistAgents,
+    );
+
+    // Check team config files to detect dismissed teammates (authoritative source
+    // of truth for team membership). Removes teammates no longer in members list.
+    const toRemove = scanTeamConfigsForRemovals(agents);
+    for (const id of toRemove) {
+      teammateRemovalCallback?.(id);
+    }
+
     // When hooks are active, SessionStart handles new file detection.
     if (hooksEnabledRef?.current) return;
 
@@ -505,6 +527,287 @@ function adoptTerminalForFile(
     webview,
   );
   readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+}
+
+// ── Lead + Teammates support (provider-driven) ──
+
+/** Known teammate JSONL files (prevents re-adoption). */
+const knownTeammateFiles = new Set<string>();
+
+/** Callback to remove a teammate agent when detected as dismissed via team config. */
+let teammateRemovalCallback: ((teammateAgentId: number) => void) | null = null;
+
+/** Team provider: supplies all CLI-specific paths, parsers, and tool names.
+ *  Set once at startup via setTeamProvider(). Module functions assume it's set
+ *  by the time they're called. */
+let teamProvider: TeamProvider | null = null;
+
+/** Register the callback used to remove teammates detected as dismissed via team config polling. */
+export function setTeammateRemovalCallback(cb: (teammateAgentId: number) => void): void {
+  teammateRemovalCallback = cb;
+}
+
+/** Register the TeamProvider that describes the active CLI's Lead+Teammates pattern. */
+export function setTeamProvider(provider: TeamProvider): void {
+  teamProvider = provider;
+}
+
+/** Read teammate name from its sidecar metadata file via the active provider. */
+function readTeammateMeta(jsonlFile: string): string | null {
+  if (!teamProvider) return null;
+  try {
+    const metaFile = teamProvider.resolveTeammateMetadataPath(jsonlFile);
+    if (fs.existsSync(metaFile)) {
+      return teamProvider.parseTeammateMetadata(fs.readFileSync(metaFile, 'utf-8'));
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+/**
+ * Scan the provider's teammate JSONL directory for a given lead session.
+ * Each teammate gets its own independent agent (positive ID) with file watching.
+ *
+ * Called from two paths:
+ * 1. Hooks-triggered (immediate): onTeammateDetected callback from SubagentStart
+ * 2. Periodic fallback: ensureProjectScan timer (heuristic mode)
+ */
+export function scanForTeammateFiles(
+  projectDir: string,
+  sessionId: string,
+  parentAgentId: number,
+  nextAgentIdRef: { current: number },
+  agents: Map<number, AgentState>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+  onAgentCreated?: (agent: AgentState) => void,
+): void {
+  if (!teamProvider) return;
+  const teammateDir = teamProvider.resolveTeammateJsonlDir(projectDir, sessionId);
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(teammateDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => path.join(teammateDir, f));
+  } catch {
+    return; // teammate directory doesn't exist (yet)
+  }
+
+  const parentAgent = agents.get(parentAgentId);
+
+  for (const file of files) {
+    if (knownTeammateFiles.has(file)) continue;
+
+    // Also check if any existing agent already tracks this file
+    let alreadyTracked = false;
+    for (const a of agents.values()) {
+      if (a.jsonlFile === file) {
+        alreadyTracked = true;
+        break;
+      }
+    }
+    if (alreadyTracked) continue;
+
+    const teammateName = readTeammateMeta(file);
+    if (!teammateName) continue; // No metadata sidecar or unparseable
+
+    knownTeammateFiles.add(file);
+
+    // Deduplicate by teammate name per parent: if we already have a live agent
+    // with the same name for this parent, reassign it to the new JSONL file
+    // (Claude may restart a teammate, creating a new .jsonl for the same role).
+    let existingTeammate: AgentState | undefined;
+    for (const a of agents.values()) {
+      if (a.leadAgentId === parentAgentId && a.agentName === teammateName) {
+        existingTeammate = a;
+        break;
+      }
+    }
+    if (existingTeammate) {
+      if (debug)
+        console.log(
+          `[Pixel Agents] Teammate "${teammateName}" already exists (Agent ${existingTeammate.id}), reassigning to ${path.basename(file)}`,
+        );
+      // Reassign to new JSONL file -- stop old polling, start new
+      const oldTimer = pollingTimers.get(existingTeammate.id);
+      if (oldTimer) clearInterval(oldTimer);
+      pollingTimers.delete(existingTeammate.id);
+      existingTeammate.jsonlFile = file;
+      existingTeammate.fileOffset = 0;
+      existingTeammate.lineBuffer = '';
+      existingTeammate.lastDataAt = Date.now();
+      existingTeammate.linesProcessed = 0;
+      existingTeammate.isWaiting = false;
+      startFileWatching(
+        existingTeammate.id,
+        file,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        webview,
+      );
+      readNewLines(existingTeammate.id, agents, waitingTimers, permissionTimers, webview);
+      continue;
+    }
+
+    const id = nextAgentIdRef.current++;
+    // Read from start -- teammate JSONL is usually small and we want full tool history
+    const agent: AgentState = {
+      id,
+      sessionId,
+      terminalRef: undefined,
+      isExternal: true,
+      projectDir,
+      jsonlFile: file,
+      fileOffset: 0,
+      lineBuffer: '',
+      activeToolIds: new Set(),
+      activeToolStatuses: new Map(),
+      activeToolNames: new Map(),
+      activeSubagentToolIds: new Map(),
+      activeSubagentToolNames: new Map(),
+      backgroundAgentToolIds: new Set(),
+      isWaiting: false,
+      permissionSent: false,
+      hadToolsInTurn: false,
+      // Keep hookDelivered false: teammates need JSONL-based tool tracking
+      // (agentToolStart messages). Permission events are routed from the lead's
+      // hooks via handlePermissionRequest forwarding.
+      hookDelivered: false,
+      lastDataAt: Date.now(),
+      linesProcessed: 0,
+      seenUnknownRecordTypes: new Set(),
+      inputTokens: 0,
+      outputTokens: 0,
+      // Agent Teams fields
+      agentName: teammateName,
+      leadAgentId: parentAgentId,
+      teamName: parentAgent?.teamName,
+    };
+
+    agents.set(id, agent);
+    persistAgents();
+
+    console.log(
+      `[Pixel Agents] Teammate detected: "${teammateName}" (Agent ${id}) for parent Agent ${parentAgentId} (${path.basename(file)})`,
+    );
+
+    webview?.postMessage({
+      type: 'agentCreated',
+      id,
+      isTeammate: true,
+      teammateName,
+      parentAgentId,
+      teamName: parentAgent?.teamName,
+    });
+
+    onAgentCreated?.(agent);
+
+    startFileWatching(
+      id,
+      file,
+      agents,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      webview,
+    );
+    readNewLines(id, agents, waitingTimers, permissionTimers, webview);
+  }
+}
+
+/**
+ * Scan team config files (via the active TeamProvider) to detect teammate
+ * dismissals. A teammate is considered dismissed if:
+ *   - The team config no longer lists them in members, OR
+ *   - The team config file is missing/unreadable (team dissolved)
+ *
+ * This is the authoritative source of truth for Agent Teams membership.
+ * Returns the IDs of teammates that should be removed.
+ */
+export function scanTeamConfigsForRemovals(agents: Map<number, AgentState>): number[] {
+  const toRemove: number[] = [];
+  if (!teamProvider) return toRemove;
+  // Group teammates by their teamName for efficient config lookups
+  const teammatesByTeam = new Map<string, Array<{ id: number; agent: AgentState }>>();
+  for (const [id, agent] of agents) {
+    if (agent.leadAgentId === undefined || agent.teamUsesTmux || !agent.teamName) continue;
+    let list = teammatesByTeam.get(agent.teamName);
+    if (!list) {
+      list = [];
+      teammatesByTeam.set(agent.teamName, list);
+    }
+    list.push({ id, agent });
+  }
+
+  for (const [teamName, members] of teammatesByTeam) {
+    // Provider owns both the read and parse -- returns null on any failure (team dissolved)
+    const memberNames = teamProvider.getTeamMembers(teamName);
+
+    for (const { id, agent } of members) {
+      if (memberNames === null) {
+        toRemove.push(id);
+      } else if (agent.agentName && !memberNames.has(agent.agentName)) {
+        toRemove.push(id);
+      }
+    }
+  }
+
+  return toRemove;
+}
+
+/**
+ * Scan all tracked project dirs for teammate JSONL files.
+ * Called periodically as a fallback when hooks are disabled.
+ */
+export function scanAllTeammateFiles(
+  nextAgentIdRef: { current: number },
+  agents: Map<number, AgentState>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+  onAgentCreated?: (agent: AgentState) => void,
+): void {
+  // For each known lead agent, ask the provider to scan for teammate transcripts.
+  // CRITICAL: only scan agents that JSONL has confirmed as team leads (teamName set).
+  // Without this gate we'd pick up basic subagents' JSONL files (which some CLIs also
+  // write to the same teammate directory) and create spurious teammate characters for
+  // them when the Agent Teams feature is OFF.
+  for (const [agentId, agent] of agents) {
+    // Only scan for lead agents (not teammates themselves)
+    if (agent.leadAgentId !== undefined) continue;
+    if (!agent.sessionId || !agent.projectDir) continue;
+    // Gate: basic-mode agents never get teamName set. Real team leads do, via JSONL.
+    if (!agent.teamName) continue;
+
+    scanForTeammateFiles(
+      agent.projectDir,
+      agent.sessionId,
+      agentId,
+      nextAgentIdRef,
+      agents,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      webview,
+      persistAgents,
+      onAgentCreated,
+    );
+  }
 }
 
 // ── External session support (VS Code extension panel, etc.) ──

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -480,6 +480,8 @@ function adoptTerminalForFile(
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
     hookDelivered: false,
+    inputTokens: 0,
+    outputTokens: 0,
   };
 
   agents.set(id, agent);
@@ -595,6 +597,8 @@ export function adoptExternalSessionFromHook(
       linesProcessed: 0,
       seenUnknownRecordTypes: new Set(),
       folderName,
+      inputTokens: 0,
+      outputTokens: 0,
     };
     agents.set(id, agent);
     persistAgents();
@@ -653,6 +657,8 @@ function adoptExternalSession(
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
     folderName,
+    inputTokens: 0,
+    outputTokens: 0,
   };
 
   agents.set(id, agent);

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -159,11 +159,30 @@ export function processTranscriptLine(
             if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
               hasNonExemptTool = true;
             }
+            // Detect tmux vs inline team mode from Agent tool's run_in_background flag
+            if (
+              agent.teamName &&
+              toolName === 'Agent' &&
+              block.input?.run_in_background === true &&
+              !agent.teamUsesTmux
+            ) {
+              agent.teamUsesTmux = true;
+              webview?.postMessage({
+                type: 'agentTeamInfo',
+                id: agentId,
+                teamName: agent.teamName,
+                agentName: agent.agentName,
+                isTeamLead: agent.isTeamLead,
+                leadAgentId: agent.leadAgentId,
+                teamUsesTmux: true,
+              });
+            }
             // Skip webview message when hooks handle tool visuals (PreToolUse sent it instantly).
             // Exception: Task/Agent tools always go through JSONL so the sub-agent character
             // is created with the stable JSONL tool ID, matching cleanup messages.
             const isAgentTool = toolName === 'Task' || toolName === 'Agent';
             if (!agent.hookDelivered || isAgentTool) {
+              const runInBackground = isAgentTool && block.input?.run_in_background === true;
               webview?.postMessage({
                 type: 'agentToolStart',
                 id: agentId,
@@ -171,6 +190,7 @@ export function processTranscriptLine(
                 status,
                 toolName,
                 permissionActive: agent.permissionSent,
+                runInBackground,
               });
             }
           }

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -54,6 +54,14 @@ export function formatToolStatus(toolName: string, input: Record<string, unknown
       return 'Planning';
     case 'NotebookEdit':
       return `Editing notebook`;
+    case 'TeamCreate': {
+      const teamName = typeof input.team_name === 'string' ? input.team_name : '';
+      return teamName ? `Creating team: ${teamName}` : 'Creating team';
+    }
+    case 'SendMessage': {
+      const recipient = typeof input.recipient === 'string' ? input.recipient : '';
+      return recipient ? `-> ${recipient}` : 'Sending message';
+    }
     default:
       return `Using ${toolName}`;
   }
@@ -73,6 +81,47 @@ export function processTranscriptLine(
   agent.linesProcessed++;
   try {
     const record = JSON.parse(line);
+
+    // -- Agent Teams: extract teamName/agentName from top-level JSONL fields --
+    if (record.teamName && !agent.teamName) {
+      agent.teamName = record.teamName as string;
+      agent.agentName = (record.agentName as string) || undefined;
+      if (debug) {
+        console.log(
+          `[Pixel Agents] Agent ${agentId} team metadata: team=${agent.teamName}, role=${agent.agentName ?? 'lead'}`,
+        );
+      }
+      // Link teammates to leads within the same team
+      linkTeammates(agentId, agent, agents);
+
+      webview?.postMessage({
+        type: 'agentTeamInfo',
+        id: agentId,
+        teamName: agent.teamName,
+        agentName: agent.agentName,
+        isTeamLead: agent.isTeamLead,
+        leadAgentId: agent.leadAgentId,
+      });
+    }
+
+    // -- Token usage extraction from assistant records --
+    const usage = record.message?.usage as
+      | { input_tokens?: number; output_tokens?: number }
+      | undefined;
+    if (usage) {
+      if (typeof usage.input_tokens === 'number') {
+        agent.inputTokens += usage.input_tokens;
+      }
+      if (typeof usage.output_tokens === 'number') {
+        agent.outputTokens += usage.output_tokens;
+      }
+      webview?.postMessage({
+        type: 'agentTokenUsage',
+        id: agentId,
+        inputTokens: agent.inputTokens,
+        outputTokens: agent.outputTokens,
+      });
+    }
 
     // Resilient content extraction: support both record.message.content and record.content
     // Claude Code may change the JSONL structure across versions
@@ -457,6 +506,67 @@ function processProgressRecord(
     if (stillHasNonExempt && !agent.hookDelivered) {
       startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
     }
+  }
+}
+
+/**
+ * Link teammates within the same team.
+ * The lead is the agent with no agentName (or the first one detected in the team).
+ * Teammates get leadAgentId pointing to the lead.
+ */
+function linkTeammates(_agentId: number, agent: AgentState, agents: Map<number, AgentState>): void {
+  const teamName = agent.teamName;
+  if (!teamName) return;
+
+  // Find all agents in this team
+  const teamAgents: AgentState[] = [];
+  for (const a of agents.values()) {
+    if (a.teamName === teamName) {
+      teamAgents.push(a);
+    }
+  }
+
+  // Determine lead: agent without agentName, or the first agent in the team that has isTeamLead
+  let lead: AgentState | undefined;
+  for (const a of teamAgents) {
+    if (a.isTeamLead) {
+      lead = a;
+      break;
+    }
+  }
+  if (!lead) {
+    // No lead found yet -- the agent without agentName is the lead
+    for (const a of teamAgents) {
+      if (!a.agentName) {
+        lead = a;
+        break;
+      }
+    }
+  }
+  if (!lead) {
+    // Still no lead -- first agent in the team is the lead
+    lead = teamAgents[0];
+  }
+
+  // Mark lead
+  if (lead && !lead.isTeamLead) {
+    lead.isTeamLead = true;
+    lead.leadAgentId = undefined;
+  }
+
+  // Link teammates to lead
+  for (const a of teamAgents) {
+    if (a.id !== lead.id && !a.isTeamLead) {
+      a.leadAgentId = lead.id;
+    }
+  }
+
+  // Update current agent's fields after linking
+  if (agent.id === lead.id) {
+    agent.isTeamLead = true;
+    agent.leadAgentId = undefined;
+  } else {
+    agent.leadAgentId = lead.id;
   }
 }
 

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -9,6 +9,7 @@ import {
   TEXT_IDLE_DELAY_MS,
   TOOL_DONE_DELAY_MS,
 } from '../server/src/constants.js';
+import type { HookProvider } from '../server/src/provider.js';
 import {
   cancelPermissionTimer,
   cancelWaitingTimer,
@@ -20,7 +21,25 @@ import type { AgentState } from './types.js';
 
 const PERMISSION_EXEMPT_TOOLS = new Set(['Task', 'Agent', 'AskUserQuestion']);
 
+/** Hook provider: supplies formatToolStatus + team.extractTeamMetadataFromRecord.
+ *  Registered once at startup via setHookProvider(). Functions below assume it's set. */
+let hookProvider: HookProvider | null = null;
+
+/** Register the HookProvider that owns CLI-specific formatting and team metadata extraction. */
+export function setHookProvider(provider: HookProvider): void {
+  hookProvider = provider;
+}
+
+/** Format a tool status line. Delegates to the active HookProvider's formatToolStatus. */
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
+  if (hookProvider) return hookProvider.formatToolStatus(toolName, input);
+  // Fallback for bootstrapping / tests without a provider set.
+  return defaultFormatToolStatus(toolName, input);
+}
+
+/** Fallback formatter for edge cases (tests, provider not yet registered).
+ *  Mirrors Claude's formatting; most code paths use the provider's implementation. */
+function defaultFormatToolStatus(toolName: string, input: Record<string, unknown>): string {
   const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
   switch (toolName) {
     case 'Read':
@@ -82,12 +101,13 @@ export function processTranscriptLine(
   try {
     const record = JSON.parse(line);
 
-    // -- Agent Teams: extract teamName/agentName from top-level JSONL fields --
-    // Update when teamName appears or changes (lead may create multiple teams in one session)
-    const recordTeamName = record.teamName as string | undefined;
-    if (recordTeamName && recordTeamName !== agent.teamName) {
-      agent.teamName = recordTeamName;
-      agent.agentName = (record.agentName as string) || undefined;
+    // -- Agent Teams: extract team metadata via the active provider --
+    // The provider reads its CLI's own field names (Claude: record.teamName + record.agentName).
+    // Other CLIs would implement this differently or not at all.
+    const teamMeta = hookProvider?.team?.extractTeamMetadataFromRecord(record);
+    if (teamMeta?.teamName && teamMeta.teamName !== agent.teamName) {
+      agent.teamName = teamMeta.teamName;
+      agent.agentName = teamMeta.agentName;
       agent.isTeamLead = undefined;
       agent.leadAgentId = undefined;
       if (debug) {
@@ -178,11 +198,12 @@ export function processTranscriptLine(
               });
             }
             // Skip webview message when hooks handle tool visuals (PreToolUse sent it instantly).
-            // Exception: Task/Agent tools always go through JSONL so the sub-agent character
-            // is created with the stable JSONL tool ID, matching cleanup messages.
-            const isAgentTool = toolName === 'Task' || toolName === 'Agent';
-            if (!agent.hookDelivered || isAgentTool) {
-              const runInBackground = isAgentTool && block.input?.run_in_background === true;
+            // EXCEPTION: subagent-spawn tools (Task/Agent) ALWAYS use JSONL so the sub-agent
+            // character is created with the REAL tool id. SubagentStop and subagentClear use
+            // the real id -- a synthetic-id sub-agent from PreToolUse could never be matched.
+            const isSubagentSpawn = toolName === 'Agent' || toolName === 'Task';
+            if (!agent.hookDelivered || isSubagentSpawn) {
+              const runInBackground = isSubagentSpawn && block.input?.run_in_background === true;
               webview?.postMessage({
                 type: 'agentToolStart',
                 id: agentId,
@@ -195,7 +216,11 @@ export function processTranscriptLine(
             }
           }
         }
-        if (hasNonExemptTool && !agent.hookDelivered) {
+        // Skip heuristic timer when hooks are active OR for teammates.
+        // Teammate tools (WebFetch, WebSearch) are naturally slow; the heuristic
+        // produces false positives. Permission on teammates comes from the lead's
+        // routed Notification(permission_prompt) hook — slower but accurate.
+        if (hasNonExemptTool && !agent.hookDelivered && !agent.leadAgentId) {
           startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
         }
       } else if (blocks.some((b) => b.type === 'text') && !agent.hadToolsInTurn) {
@@ -427,7 +452,7 @@ function processProgressRecord(
   // Skip when hooks are active — Notification hook handles permission detection exactly.
   const dataType = data.type as string | undefined;
   if (dataType === 'bash_progress' || dataType === 'mcp_progress') {
-    if (agent.activeToolIds.has(parentToolId) && !agent.hookDelivered) {
+    if (agent.activeToolIds.has(parentToolId) && !agent.hookDelivered && !agent.leadAgentId) {
       startPermissionTimer(agentId, agents, permissionTimers, PERMISSION_EXEMPT_TOOLS, webview);
     }
     return;

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -83,9 +83,13 @@ export function processTranscriptLine(
     const record = JSON.parse(line);
 
     // -- Agent Teams: extract teamName/agentName from top-level JSONL fields --
-    if (record.teamName && !agent.teamName) {
-      agent.teamName = record.teamName as string;
+    // Update when teamName appears or changes (lead may create multiple teams in one session)
+    const recordTeamName = record.teamName as string | undefined;
+    if (recordTeamName && recordTeamName !== agent.teamName) {
+      agent.teamName = recordTeamName;
       agent.agentName = (record.agentName as string) || undefined;
+      agent.isTeamLead = undefined;
+      agent.leadAgentId = undefined;
       if (debug) {
         console.log(
           `[Pixel Agents] Agent ${agentId} team metadata: team=${agent.teamName}, role=${agent.agentName ?? 'lead'}`,
@@ -526,47 +530,38 @@ function linkTeammates(_agentId: number, agent: AgentState, agents: Map<number, 
     }
   }
 
-  // Determine lead: agent without agentName, or the first agent in the team that has isTeamLead
+  // Determine lead: always prefer the agent WITHOUT agentName (the real lead has agentName=null).
+  // This handles the case where a teammate is detected first and temporarily marked as lead,
+  // then the real lead joins later.
   let lead: AgentState | undefined;
   for (const a of teamAgents) {
-    if (a.isTeamLead) {
+    if (!a.agentName) {
       lead = a;
       break;
     }
   }
   if (!lead) {
-    // No lead found yet -- the agent without agentName is the lead
+    // No agent without agentName -- use existing isTeamLead or first agent
     for (const a of teamAgents) {
-      if (!a.agentName) {
+      if (a.isTeamLead) {
         lead = a;
         break;
       }
     }
   }
   if (!lead) {
-    // Still no lead -- first agent in the team is the lead
     lead = teamAgents[0];
   }
 
-  // Mark lead
-  if (lead && !lead.isTeamLead) {
-    lead.isTeamLead = true;
-    lead.leadAgentId = undefined;
-  }
-
-  // Link teammates to lead
+  // Update all team members: mark lead, clear stale lead flags, link teammates
   for (const a of teamAgents) {
-    if (a.id !== lead.id && !a.isTeamLead) {
+    if (a.id === lead.id) {
+      a.isTeamLead = true;
+      a.leadAgentId = undefined;
+    } else {
+      a.isTeamLead = false;
       a.leadAgentId = lead.id;
     }
-  }
-
-  // Update current agent's fields after linking
-  if (agent.id === lead.id) {
-    agent.isTeamLead = true;
-    agent.leadAgentId = undefined;
-  } else {
-    agent.leadAgentId = lead.id;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,16 @@ export interface AgentState {
   pendingClear?: boolean;
   /** Hook-generated tool ID for PreToolUse/PostToolUse correlation */
   currentHookToolId?: string;
+
+  // -- Token tracking --
+  inputTokens: number;
+  outputTokens: number;
+
+  // -- Agent Teams --
+  teamName?: string;
+  agentName?: string;
+  isTeamLead?: boolean;
+  leadAgentId?: number;
 }
 
 export interface PersistedAgent {
@@ -51,4 +61,10 @@ export interface PersistedAgent {
   projectDir: string;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+
+  // -- Agent Teams --
+  teamName?: string;
+  agentName?: string;
+  isTeamLead?: boolean;
+  leadAgentId?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export interface AgentState {
   pendingClear?: boolean;
   /** Hook-generated tool ID for PreToolUse/PostToolUse correlation */
   currentHookToolId?: string;
+  /** Tool name from PreToolUse (e.g. 'Agent', 'Task') for SubagentStart correlation */
+  currentHookToolName?: string;
+  /** True if the CURRENT PreToolUse tool call is a teammate spawn (e.g. Agent with
+   *  run_in_background=true). Authoritative source for teammate vs basic-subagent
+   *  routing in SubagentStart. Set in PreToolUse, NOT cleared in PostToolUse (survives
+   *  the PostToolUse-before-SubagentStart race); overwritten on the next PreToolUse. */
+  currentHookIsTeammateSpawn?: boolean;
 
   // -- Token tracking --
   inputTokens: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface AgentState {
   agentName?: string;
   isTeamLead?: boolean;
   leadAgentId?: number;
+  /** True when lead spawns teammates via tmux (run_in_background Agent calls) */
+  teamUsesTmux?: boolean;
 }
 
 export interface PersistedAgent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,4 +69,5 @@ export interface PersistedAgent {
   agentName?: string;
   isTeamLead?: boolean;
   leadAgentId?: number;
+  teamUsesTmux?: boolean;
 }

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -133,3 +133,18 @@ export const AUTO_ON_SIDE_DEPTH = 2;
 export const CHARACTER_HIT_HALF_WIDTH = 8;
 export const CHARACTER_HIT_HEIGHT = 24;
 export const TOOL_OVERLAY_VERTICAL_OFFSET = 32;
+
+// ── Agent Teams ─────────────────────────────────────────────
+export const MAX_CONTEXT_TOKENS = 200_000;
+export const TOKEN_WARN_THRESHOLD = 0.6;
+export const TOKEN_DANGER_THRESHOLD = 0.8;
+export const TOKEN_CRITICAL_THRESHOLD = 0.95;
+export const FUEL_GAUGE_WIDTH_PX = 40;
+export const FUEL_GAUGE_HEIGHT_PX = 4;
+export const FUEL_COLOR_OK = '#44cc44';
+export const FUEL_COLOR_WARN = '#ffcc00';
+export const FUEL_COLOR_DANGER = '#ff8800';
+export const FUEL_COLOR_CRITICAL = '#ff2222';
+export const FUEL_GAUGE_BG = '#222';
+export const TEAM_LEAD_COLOR = '#ffd700';
+export const TEAM_ROLE_COLOR = '#66aaff';

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -234,7 +234,11 @@ export function useExtensionMessages(
           os.clearPermissionBubble(id);
         }
         // Create sub-agent character for Task/Agent tool subtasks
-        if (toolName === 'Task' || toolName === 'Agent') {
+        // Skip for team leads -- their Agent/Task calls spawn tmux teammates,
+        // not inline sub-agents. The real teammates appear via external session detection.
+        const parentCh = os.characters.get(id);
+        const isTeamLead = parentCh?.teamName && parentCh?.isTeamLead;
+        if ((toolName === 'Task' || toolName === 'Agent') && !isTeamLead) {
           const label = status.startsWith('Subtask:') ? status.slice('Subtask:'.length).trim() : '';
           const subId = os.addSubagent(id, toolId);
           setSubagentCharacters((prev) => {

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -233,12 +233,12 @@ export function useExtensionMessages(
         if (!permissionActive) {
           os.clearPermissionBubble(id);
         }
-        // Create sub-agent character for Task/Agent tool subtasks
-        // Skip for team leads -- their Agent/Task calls spawn tmux teammates,
-        // not inline sub-agents. The real teammates appear via external session detection.
-        const parentCh = os.characters.get(id);
-        const isTeamLead = parentCh?.teamName && parentCh?.isTeamLead;
-        if ((toolName === 'Task' || toolName === 'Agent') && !isTeamLead) {
+        // Create sub-agent character for Task/Agent tool subtasks.
+        // In tmux mode, Agent tool has run_in_background=true -- these are ghost
+        // placeholders replaced by real external teammates, suppress them.
+        // In inline mode (no run_in_background), sub-agents ARE the teammates.
+        const runInBackground = msg.runInBackground as boolean | undefined;
+        if ((toolName === 'Task' || toolName === 'Agent') && !runInBackground) {
           const label = status.startsWith('Subtask:') ? status.slice('Subtask:'.length).trim() : '';
           const subId = os.addSubagent(id, toolId);
           setSubagentCharacters((prev) => {
@@ -271,9 +271,16 @@ export function useExtensionMessages(
           delete next[id];
           return next;
         });
-        // Remove all sub-agent characters belonging to this agent
-        os.removeAllSubagents(id);
-        setSubagentCharacters((prev) => prev.filter((s) => s.parentAgentId !== id));
+        // Remove all sub-agent characters belonging to this agent.
+        // Exception: team leads with inline teammates -- their sub-agents represent
+        // real teammates and should only be removed by SubagentStop/subagentClear.
+        const clearCh = os.characters.get(id);
+        const hasInlineTeammates =
+          clearCh?.teamName && clearCh?.isTeamLead && !clearCh?.teamUsesTmux;
+        if (!hasInlineTeammates) {
+          os.removeAllSubagents(id);
+          setSubagentCharacters((prev) => prev.filter((s) => s.parentAgentId !== id));
+        }
         os.setAgentTool(id, null);
         os.clearPermissionBubble(id);
       } else if (msg.type === 'agentSelected') {
@@ -459,6 +466,7 @@ export function useExtensionMessages(
           msg.agentName as string | undefined,
           msg.isTeamLead as boolean | undefined,
           msg.leadAgentId as number | undefined,
+          msg.teamUsesTmux as boolean | undefined,
         );
       } else if (msg.type === 'agentTokenUsage') {
         const id = msg.id as number;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -152,9 +152,32 @@ export function useExtensionMessages(
       } else if (msg.type === 'agentCreated') {
         const id = msg.id as number;
         const folderName = msg.folderName as string | undefined;
+        const isTeammate = msg.isTeammate as boolean | undefined;
+        const teammateName = msg.teammateName as string | undefined;
+        const teammateParentId = msg.parentAgentId as number | undefined;
+        const teamName = msg.teamName as string | undefined;
         setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]));
-        setSelectedAgent(id);
-        os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+        // Don't auto-select teammates (keep focus on lead)
+        if (!isTeammate) {
+          setSelectedAgent(id);
+        }
+        if (isTeammate && teammateParentId !== undefined) {
+          // Teammate: inherit parent's palette and workspace folderName (teammate runs
+          // in the same workspace as the lead). Name shown via agentName (teamRoleLabel).
+          const parentCh = os.characters.get(teammateParentId);
+          const palette = parentCh ? parentCh.palette : undefined;
+          const hueShift = parentCh ? parentCh.hueShift : undefined;
+          os.addAgent(id, palette, hueShift, undefined, undefined, parentCh?.folderName);
+          // Set team metadata on the character
+          const ch = os.characters.get(id);
+          if (ch) {
+            ch.leadAgentId = teammateParentId;
+            ch.teamName = teamName ?? parentCh?.teamName;
+            ch.agentName = teammateName;
+          }
+        } else {
+          os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+        }
         saveAgentSeats(os);
       } else if (msg.type === 'agentClosed') {
         const id = msg.id as number;
@@ -234,11 +257,20 @@ export function useExtensionMessages(
           os.clearPermissionBubble(id);
         }
         // Create sub-agent character for Task/Agent tool subtasks.
-        // In tmux mode, Agent tool has run_in_background=true -- these are ghost
-        // placeholders replaced by real external teammates, suppress them.
-        // In inline mode (no run_in_background), sub-agents ARE the teammates.
+        // In tmux / inline teams mode, Agent tool has run_in_background=true -- those
+        // are handled via the independent teammate path (onTeammateDetected), not here.
+        // runInBackground gates them out so we don't create ghost sub-agents for them.
+        //
+        // Skip creation for synthetic hook-ids. Later SubagentStop/subagentClear use
+        // the REAL tool id from JSONL; creating with a synthetic id would orphan the
+        // sub-agent (mismatched keys). JSONL's agentToolStart (with real id) handles
+        // creation in both hooks and heuristic modes -- ~500ms delay vs instant hook.
         const runInBackground = msg.runInBackground as boolean | undefined;
-        if ((toolName === 'Task' || toolName === 'Agent') && !runInBackground) {
+        if (
+          (toolName === 'Task' || toolName === 'Agent') &&
+          !runInBackground &&
+          !toolId.startsWith('hook-')
+        ) {
           const label = status.startsWith('Subtask:') ? status.slice('Subtask:'.length).trim() : '';
           const subId = os.addSubagent(id, toolId);
           setSubagentCharacters((prev) => {
@@ -356,7 +388,10 @@ export function useExtensionMessages(
             [id]: { ...agentSubs, [parentToolId]: [...list, { toolId, status, done: false }] },
           };
         });
-        // Update sub-agent character's tool and active state
+        // Update sub-agent character's tool and active state (if already created by
+        // agentToolStart via PreToolUse). The lookup uses the REAL parent tool id from
+        // JSONL, which won't match the synthetic hook-id the sub-agent was created
+        // with -- so this is a best-effort update for the heuristic (JSONL-driven) path.
         const subId = os.getSubagentId(id, parentToolId);
         if (subId !== null) {
           const subToolName = extractToolName(status);

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -447,6 +447,18 @@ export function useExtensionMessages(
         } catch (err) {
           console.error(`❌ Webview: Error processing furnitureAssetsLoaded:`, err);
         }
+      } else if (msg.type === 'agentTeamInfo') {
+        const id = msg.id as number;
+        os.setTeamInfo(
+          id,
+          msg.teamName as string | undefined,
+          msg.agentName as string | undefined,
+          msg.isTeamLead as boolean | undefined,
+          msg.leadAgentId as number | undefined,
+        );
+      } else if (msg.type === 'agentTokenUsage') {
+        const id = msg.id as number;
+        os.setAgentTokens(id, msg.inputTokens as number, msg.outputTokens as number);
       }
     };
     window.addEventListener('message', handler);

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -1,7 +1,23 @@
 import { useEffect, useState } from 'react';
 
 import { Button } from '../../components/ui/Button.js';
-import { CHARACTER_SITTING_OFFSET_PX, TOOL_OVERLAY_VERTICAL_OFFSET } from '../../constants.js';
+import {
+  CHARACTER_SITTING_OFFSET_PX,
+  FUEL_COLOR_CRITICAL,
+  FUEL_COLOR_DANGER,
+  FUEL_COLOR_OK,
+  FUEL_COLOR_WARN,
+  FUEL_GAUGE_BG,
+  FUEL_GAUGE_HEIGHT_PX,
+  FUEL_GAUGE_WIDTH_PX,
+  MAX_CONTEXT_TOKENS,
+  TEAM_LEAD_COLOR,
+  TEAM_ROLE_COLOR,
+  TOKEN_CRITICAL_THRESHOLD,
+  TOKEN_DANGER_THRESHOLD,
+  TOKEN_WARN_THRESHOLD,
+  TOOL_OVERLAY_VERTICAL_OFFSET,
+} from '../../constants.js';
 import type { SubagentCharacter } from '../../hooks/useExtensionMessages.js';
 import type { OfficeState } from '../engine/officeState.js';
 import type { ToolActivity } from '../types.js';
@@ -41,6 +57,13 @@ function getActivityText(
   }
 
   return 'Idle';
+}
+
+function getFuelColor(ratio: number): string {
+  if (ratio >= TOKEN_CRITICAL_THRESHOLD) return FUEL_COLOR_CRITICAL;
+  if (ratio >= TOKEN_DANGER_THRESHOLD) return FUEL_COLOR_DANGER;
+  if (ratio >= TOKEN_WARN_THRESHOLD) return FUEL_COLOR_WARN;
+  return FUEL_COLOR_OK;
 }
 
 export function ToolOverlay({
@@ -129,13 +152,20 @@ export function ToolOverlay({
           dotColor = 'var(--color-status-active)';
         }
 
+        // Team info
+        const isTeamAgent = !!ch.teamName;
+        const teamRoleLabel = ch.isTeamLead ? 'LEAD' : ch.agentName || null;
+        const totalTokens = ch.inputTokens + ch.outputTokens;
+        const tokenRatio = totalTokens / MAX_CONTEXT_TOKENS;
+        const hasExtraLines = !!(ch.folderName || teamRoleLabel);
+
         return (
           <div
             key={id}
             className="absolute flex flex-col items-center -translate-x-1/2"
             style={{
               left: screenX,
-              top: screenY - (ch.folderName ? 34 : 28),
+              top: screenY - (hasExtraLines ? 34 : 28),
               pointerEvents: isSelected ? 'auto' : 'none',
               opacity: alwaysShowOverlay && !isSelected && !isHovered ? (isSub ? 0.5 : 0.75) : 1,
               zIndex: isSelected ? 42 : 41,
@@ -149,6 +179,18 @@ export function ToolOverlay({
                 />
               )}
               <div className="flex flex-col gap-0 overflow-hidden">
+                {teamRoleLabel && (
+                  <span
+                    className="overflow-hidden text-ellipsis block leading-none"
+                    style={{
+                      fontSize: '18px',
+                      color: ch.isTeamLead ? TEAM_LEAD_COLOR : TEAM_ROLE_COLOR,
+                      fontWeight: ch.isTeamLead ? 'bold' : undefined,
+                    }}
+                  >
+                    {teamRoleLabel}
+                  </span>
+                )}
                 <span
                   className="overflow-hidden text-ellipsis block leading-none"
                   style={{
@@ -179,6 +221,25 @@ export function ToolOverlay({
                 </Button>
               )}
             </div>
+            {isTeamAgent && totalTokens > 0 && (
+              <div
+                style={{
+                  width: FUEL_GAUGE_WIDTH_PX,
+                  height: FUEL_GAUGE_HEIGHT_PX,
+                  background: FUEL_GAUGE_BG,
+                  marginTop: 2,
+                }}
+                title={`${Math.round(tokenRatio * 100)}% context used (${(totalTokens / 1000).toFixed(0)}k tokens)`}
+              >
+                <div
+                  style={{
+                    width: `${Math.min(tokenRatio * 100, 100)}%`,
+                    height: '100%',
+                    background: getFuelColor(tokenRatio),
+                  }}
+                />
+              </div>
+            )}
           </div>
         );
       })}

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -84,6 +84,8 @@ export function createCharacter(
     matrixEffect: null,
     matrixEffectTimer: 0,
     matrixEffectSeeds: [],
+    inputTokens: 0,
+    outputTokens: 0,
   };
 }
 

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -685,6 +685,28 @@ export class OfficeState {
     }
   }
 
+  setTeamInfo(
+    id: number,
+    teamName?: string,
+    agentName?: string,
+    isTeamLead?: boolean,
+    leadAgentId?: number,
+  ): void {
+    const ch = this.characters.get(id);
+    if (!ch) return;
+    ch.teamName = teamName;
+    ch.agentName = agentName;
+    ch.isTeamLead = isTeamLead;
+    ch.leadAgentId = leadAgentId;
+  }
+
+  setAgentTokens(id: number, inputTokens: number, outputTokens: number): void {
+    const ch = this.characters.get(id);
+    if (!ch) return;
+    ch.inputTokens = inputTokens;
+    ch.outputTokens = outputTokens;
+  }
+
   update(dt: number): void {
     // Furniture animation cycling
     const prevFrame = Math.floor(this.furnitureAnimTimer / FURNITURE_ANIM_INTERVAL_SEC);

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -691,6 +691,7 @@ export class OfficeState {
     agentName?: string,
     isTeamLead?: boolean,
     leadAgentId?: number,
+    teamUsesTmux?: boolean,
   ): void {
     const ch = this.characters.get(id);
     if (!ch) return;
@@ -698,6 +699,9 @@ export class OfficeState {
     ch.agentName = agentName;
     ch.isTeamLead = isTeamLead;
     ch.leadAgentId = leadAgentId;
+    if (teamUsesTmux !== undefined) {
+      ch.teamUsesTmux = teamUsesTmux;
+    }
   }
 
   setAgentTokens(id: number, inputTokens: number, outputTokens: number): void {

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -190,6 +190,8 @@ export interface Character {
   isTeamLead?: boolean;
   /** ID of the lead agent (set on teammates) */
   leadAgentId?: number;
+  /** True when lead spawns teammates via tmux (run_in_background Agent calls) */
+  teamUsesTmux?: boolean;
   /** Cumulative input tokens consumed */
   inputTokens: number;
   /** Cumulative output tokens consumed */

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -180,4 +180,18 @@ export interface Character {
   matrixEffectSeeds: number[];
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+
+  // -- Agent Teams --
+  /** Team name this agent belongs to */
+  teamName?: string;
+  /** Role name within the team (null for lead) */
+  agentName?: string;
+  /** Whether this agent is the team lead */
+  isTeamLead?: boolean;
+  /** ID of the lead agent (set on teammates) */
+  leadAgentId?: number;
+  /** Cumulative input tokens consumed */
+  inputTokens: number;
+  /** Cumulative output tokens consumed */
+  outputTokens: number;
 }


### PR DESCRIPTION
 ## Description                                                                                                                                                                 
                                                                                                                                                                                 
  Add visualization support for Claude Code's experimental Agent Teams feature. When a lead agent spawns teammates (via TeamCreate), Pixel Agents detects, links, and renders team members with role labels, token fuel gauges, and coordinated lifecycle management.                                                                                        
                                                                                                                                                                                 
  Supports both team modes:                                                                                                                                                      
  - **Tmux mode** (teammates as independent sessions in tmux panes): each teammate gets its own character with blue role label, independent tool activity, and proper cleanup on lead close                                                                                                                                                                     
  - **Inline mode** (teammates as sub-agents within lead's session): sub-agent characters persist through turn boundaries, though all tool activity displays on the lead (Claude Code hooks limitation)                                                                                                                                                         
                                                                                                                                                                                 
  Deterministic mode detection via the Agent tool's `run_in_background` input field (tmux) vs `subagent_type` (inline). Ghost sub-agent characters suppressed in tmux mode, preserved in inline mode.                                                                                                                                                      
                                                                                                                                                                                 
  ### Key changes                                                                                                                                                             
  - Extract `teamName`/`agentName` from JSONL records, link teammates to leads                                                                                                   
  - Gold "LEAD" badge on leads, blue role label on teammates (e.g., "web-researcher")                                                                                            
  - Token fuel gauge (green/yellow/orange/red) below team agent overlays                                                                                                         
  - Handle `TeammateIdle`, `TaskCreated`, `TaskCompleted` hook events                                                                                                            
  - `TeamCreate` and `SendMessage` tool status formatting                                                                                                                        
  - Persist/restore all team metadata across F5 reload                                                                                                                           
  - Coordinated cleanup: lead close removes all teammates                                                                                                                        
  - Click teammate focuses lead's terminal                                                                                                                                       
                                                                                                                                                                                 
  Cherry-picks ideas from PR #79 (token extraction, badges, fuel gauge) and PR #177 (teammate detection concept).                                                                
                                                                                                                                                                                 
  ## Type of change                                                                                                                                                              
                                                                                                                                                                                 
  - [x] New feature
  
   ## Related issues              
  Issues: Closes #59
PRs: Supersedes #79, #177
 
  ## Screenshots / GIFs          
   
<img width="923" height="778" alt="screenshot_2026-04-07_00-52-27" src="https://github.com/user-attachments/assets/aecd09c9-8c4d-47d7-9b73-4459291f1367" />                                                              
                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                   
                                                                                                                                                                              
  - [x] Rebased on latest `main`
  - [x] Tested in Extension Development Host (F5)                                                                                                                                
  - [x] `npm run compile` passes (types + lint + build)                                                                                                                          
  - [x] `npm test` passes (63 tests)                                                                                                                                             
  - [x] Tmux mode: TeamCreate spawns teammates as external agents, no ghost sub-agents, role labels visible                                                                      
  - [x] Inline mode: Agent tool spawns sub-agent teammates, persist through turn boundaries                                                                                      
  - [x] Lead close removes all teammates                                                                                                                                         
  - [x] F5 reload restores team metadata and labels                                                                                                                                  
  - [x] Regular agents (non-teams) unaffected                                                                                                                                    
  - [x] Watch All Sessions toggle works with team agents  