### PR TITLE
feat: add autoShowPanel and autoSpawnAgent startup settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -46,6 +48,21 @@
           "name": "Pixel Agents"
         }
       ]
+    },
+    "configuration": {
+      "title": "Pixel Agents",
+      "properties": {
+        "pixel-agents.autoShowPanel": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically open and focus the Pixel Agents panel when VS Code starts."
+        },
+        "pixel-agents.autoSpawnAgent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically spawn a Claude Code agent when VS Code starts, if no agents are currently running."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -34,6 +34,7 @@ import {
 } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
 import {
+  CONFIG_KEY_AUTO_SPAWN_AGENT,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
@@ -103,6 +104,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   private pixelAgentsServer: PixelAgentsServer | null = null;
   // ServerConfig is not stored as a field; use this.pixelAgentsServer?.getConfig() if needed.
   private hookEventHandler: HookEventHandler | null = null;
+
+  // Auto-spawn guard: ensures the startup spawn fires at most once per VS Code
+  // session, even though webviewReady fires on every panel focus.
+  private autoSpawnAttempted = false;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.initHooks();
@@ -495,6 +500,43 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         for (const agent of this.agents.values()) {
           this.registerAgentHook(agent);
         }
+
+        // Auto-spawn: launch one agent on first webviewReady if the setting is
+        // enabled and no agents are currently running.
+        if (
+          !this.autoSpawnAttempted &&
+          vscode.workspace.getConfiguration().get<boolean>(CONFIG_KEY_AUTO_SPAWN_AGENT, false) &&
+          this.agents.size === 0
+        ) {
+          this.autoSpawnAttempted = true;
+          console.log('[Pixel Agents] Auto-spawning agent on startup');
+          const prevAgentIds = new Set(this.agents.keys());
+          await launchNewTerminal(
+            this.nextAgentId,
+            this.nextTerminalIndex,
+            this.agents,
+            this.activeAgentId,
+            this.knownJsonlFiles,
+            this.fileWatchers,
+            this.pollingTimers,
+            this.waitingTimers,
+            this.permissionTimers,
+            this.jsonlPollTimers,
+            this.projectScanTimer,
+            this.webview,
+            this.persistAgents,
+          );
+          for (const [id, agent] of this.agents) {
+            if (!prevAgentIds.has(id)) {
+              this.registerAgentHook(agent);
+            }
+          }
+        } else {
+          // Mark as attempted even when skipping, so subsequent panel focuses
+          // (which retrigger webviewReady) never auto-spawn unexpectedly.
+          this.autoSpawnAttempted = true;
+        }
+
         // Send persisted settings to webview
         const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
         const lastSeenVersion = this.context.globalState.get<string>(

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -34,6 +34,7 @@ import {
 } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
 import {
+  CONFIG_KEY_AUTO_SHOW_PANEL,
   CONFIG_KEY_AUTO_SPAWN_AGENT,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
   GLOBAL_KEY_HOOKS_ENABLED,
@@ -510,6 +511,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         ) {
           this.autoSpawnAttempted = true;
           console.log('[Pixel Agents] Auto-spawning agent on startup');
+          // When the user also opted into autoShowPanel, skip terminal.show()
+          // so the panel view stays on Pixel Agents. The terminal still runs;
+          // clicking the character focuses it via the focusAgent handler.
+          const autoShowPanel = vscode.workspace
+            .getConfiguration()
+            .get<boolean>(CONFIG_KEY_AUTO_SHOW_PANEL, false);
           const prevAgentIds = new Set(this.agents.keys());
           await launchNewTerminal(
             this.nextAgentId,
@@ -525,6 +532,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.projectScanTimer,
             this.webview,
             this.persistAgents,
+            undefined,
+            undefined,
+            autoShowPanel,
           );
           for (const [id, agent] of this.agents) {
             if (!prevAgentIds.has(id)) {

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -50,6 +50,7 @@ export async function launchNewTerminal(
   persistAgents: () => void,
   folderPath?: string,
   bypassPermissions?: boolean,
+  suppressShow?: boolean,
 ): Promise<void> {
   const folders = vscode.workspace.workspaceFolders;
   // Use home directory as fallback cwd when no workspace is open (common on Linux/macOS).
@@ -62,7 +63,13 @@ export async function launchNewTerminal(
     name: `${TERMINAL_NAME_PREFIX} #${idx}`,
     cwd,
   });
-  terminal.show();
+  // When suppressShow is set (auto-spawn + autoShowPanel), keep the panel view
+  // on Pixel Agents instead of switching to Terminal. Claude Code still runs
+  // via sendText below; user can click the character to focus the terminal via
+  // the existing focusAgent message handler.
+  if (!suppressShow) {
+    terminal.show();
+  }
 
   const sessionId = crypto.randomUUID();
   const launch = claudeProvider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,10 @@ export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 export const GLOBAL_KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
 
+// ── VS Code Settings (contributes.configuration keys) ───────
+export const CONFIG_KEY_AUTO_SHOW_PANEL = 'pixel-agents.autoShowPanel';
+export const CONFIG_KEY_AUTO_SPAWN_AGENT = 'pixel-agents.autoSpawnAgent';
+
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';
 export const COMMAND_SHOW_PANEL = 'pixel-agents.showPanel';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 
-import { COMMAND_EXPORT_DEFAULT_LAYOUT, COMMAND_SHOW_PANEL, VIEW_ID } from './constants.js';
+import {
+  COMMAND_EXPORT_DEFAULT_LAYOUT,
+  COMMAND_SHOW_PANEL,
+  CONFIG_KEY_AUTO_SHOW_PANEL,
+  VIEW_ID,
+} from './constants.js';
 import { PixelAgentsViewProvider } from './PixelAgentsViewProvider.js';
 
 let providerInstance: PixelAgentsViewProvider | undefined;
@@ -23,6 +28,13 @@ export function activate(context: vscode.ExtensionContext) {
       provider.exportDefaultLayout();
     }),
   );
+
+  // Auto-show panel: focus the Pixel Agents panel on startup if the user has
+  // opted in via the pixel-agents.autoShowPanel setting.
+  const config = vscode.workspace.getConfiguration();
+  if (config.get<boolean>(CONFIG_KEY_AUTO_SHOW_PANEL, false)) {
+    vscode.commands.executeCommand(`${VIEW_ID}.focus`);
+  }
 }
 
 export function deactivate() {


### PR DESCRIPTION
Closes #138.

## What this adds

Two opt-in VS Code settings, both `false` by default so existing users see no change:

| Setting | Default | What it does |
|---|---|---|
| `pixel-agents.autoShowPanel` | `false` | Focuses the Pixel Agents panel automatically when VS Code starts |
| `pixel-agents.autoSpawnAgent` | `false` | Launches one Claude Code terminal + agent on startup, but only if no agents are currently running |

Both settings appear in the VS Code Settings UI under **Pixel Agents**.

## How it works

**autoShowPanel** -- `src/extension.ts`

After the webview view provider and commands are registered, `activate()` reads the setting and calls `vscode.commands.executeCommand('pixel-agents.panelView.focus')` if it is enabled. To make this work even when the panel has never been pinned open before, `"onStartupFinished"` is added to `activationEvents` in `package.json`. Without it, the extension would only activate when the user manually opened the panel, which defeats the purpose.

**autoSpawnAgent** -- `src/PixelAgentsViewProvider.ts`

The spawn happens inside the `webviewReady` message handler, right after `restoreAgents()`. At that point we know whether any agents are currently tracked. The guard condition is:

```
!this.autoSpawnAttempted
  && config.get('pixel-agents.autoSpawnAgent') === true
  && this.agents.size === 0
```

A `autoSpawnAttempted` boolean field on the provider ensures the spawn fires at most once per VS Code session. `webviewReady` is sent every time the panel is focused, so without this guard a user who toggled the panel open and closed would keep spawning new agents.

If existing agents are present (restored from a previous session), the spawn is skipped entirely -- the user's existing workspace is left untouched.

## How to test

1. Install the extension in development mode (F5).
2. Open VS Code Settings, search for "Pixel Agents".
3. Enable `autoShowPanel` -- reload VS Code -- the Pixel Agents panel should open automatically.
4. Enable `autoSpawnAgent` -- reload VS Code -- a Claude Code terminal should appear and a character should spawn in the panel.
5. Reload again with agents already running -- confirm no additional agent is spawned.
6. Disable both settings -- reload -- confirm VS Code behaves exactly as before (no panel focus, no terminal).