### PR TITLE
feat: add terminal runner for Ghostty and browser-based viewing

### DIFF
--- a/terminal/package-lock.json
+++ b/terminal/package-lock.json
@@ -1,0 +1,628 @@
+{
+  "name": "pixel-agents-terminal",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pixel-agents-terminal",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "pixel-agents-terminal": "dist/terminal/src/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "25.x",
+        "@types/ws": "^8.5.14",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/terminal/package.json
+++ b/terminal/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pixel-agents-terminal",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pixel Agents terminal runner — run pixel-agents outside VS Code (Ghostty, iTerm2, etc.)",
+  "bin": {
+    "pixel-agents-terminal": "./dist/terminal/src/index.js"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/terminal/src/index.js",
+    "check-types": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "25.x",
+    "@types/ws": "^8.5.14",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/terminal/src/bridge.ts
+++ b/terminal/src/bridge.ts
@@ -1,0 +1,158 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+
+import { WebSocketServer } from 'ws';
+import type { WebSocket } from 'ws';
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+};
+
+/**
+ * HTTP + WebSocket server that:
+ * - Serves webview-ui/dist as a static web app
+ * - Injects a WebSocket client script into index.html so the browser can receive live events
+ * - Broadcasts messages to all connected WebSocket clients
+ */
+export class TerminalBridge {
+  private server: http.Server;
+  private wss: WebSocketServer;
+  private clients = new Set<WebSocket>();
+  private port = 0;
+  private readonly webviewDir: string;
+
+  constructor(webviewDir?: string) {
+    // In development (tsx), __dirname is terminal/src/ so ../../ reaches the repo root.
+    // In production (compiled), callers should pass webviewDir explicitly.
+    this.webviewDir = webviewDir ?? path.resolve(__dirname, '../../dist/webview');
+    this.server = http.createServer((req, res) => {
+      this.handleRequest(req, res);
+    });
+    this.wss = new WebSocketServer({ noServer: true });
+
+    this.server.on('upgrade', (req, socket, head) => {
+      if (req.url === '/events') {
+        this.wss.handleUpgrade(
+          req,
+          socket as Parameters<typeof this.wss.handleUpgrade>[1],
+          head,
+          (ws) => {
+            this.wss.emit('connection', ws);
+            this.clients.add(ws);
+            ws.on('close', () => {
+              this.clients.delete(ws);
+            });
+          },
+        );
+      }
+    });
+  }
+
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server.address();
+        if (addr && typeof addr === 'object') {
+          this.port = addr.port;
+          resolve(this.port);
+        } else {
+          reject(new Error('Failed to get bridge server address'));
+        }
+      });
+      this.server.on('error', reject);
+    });
+  }
+
+  stop(): void {
+    this.wss.close();
+    this.server.close();
+  }
+
+  /** Send a webview protocol message to all connected browser clients. */
+  broadcast(message: unknown): void {
+    const data = JSON.stringify(message);
+    for (const client of this.clients) {
+      if (client.readyState === 1 /* WebSocket.OPEN */) {
+        client.send(data);
+      }
+    }
+  }
+
+  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const urlPath = req.url?.split('?')[0] ?? '/';
+    const safePath = urlPath === '/' ? 'index.html' : urlPath.replace(/^\//, '');
+    let filePath = path.join(this.webviewDir, safePath);
+
+    // Path traversal guard
+    if (!filePath.startsWith(this.webviewDir)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    // SPA fallback: unknown routes serve index.html
+    if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+      filePath = path.join(this.webviewDir, 'index.html');
+    }
+
+    const ext = path.extname(filePath);
+    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+
+    try {
+      let content: Buffer = fs.readFileSync(filePath);
+
+      // Inject WebSocket client before </body> so the browser connects to the terminal runner
+      if (ext === '.html') {
+        const injected = this.buildInjectedScript();
+        content = Buffer.from(content.toString('utf-8').replace('</body>', `${injected}</body>`));
+      }
+
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    } catch {
+      res.writeHead(500);
+      res.end('Internal server error');
+    }
+  }
+
+  /**
+   * Builds the inline script injected into index.html.
+   *
+   * Sets window.__PIXEL_AGENTS_TERMINAL__ = true so future code can detect terminal mode,
+   * then opens a WebSocket to /events and forwards each received message to window as a
+   * MessageEvent — exactly what useExtensionMessages already listens for.
+   */
+  private buildInjectedScript(): string {
+    return `<script>
+(function () {
+  window.__PIXEL_AGENTS_TERMINAL__ = true;
+  var ws = new WebSocket('ws://127.0.0.1:${this.port}/events');
+  ws.onopen = function () {
+    console.log('[pixel-agents-terminal] Connected to runner');
+  };
+  ws.onmessage = function (e) {
+    try {
+      var data = JSON.parse(e.data);
+      window.dispatchEvent(new MessageEvent('message', { data: data }));
+    } catch (err) {
+      console.error('[pixel-agents-terminal] Failed to parse message', err);
+    }
+  };
+  ws.onerror = function (e) {
+    console.error('[pixel-agents-terminal] WebSocket error', e);
+  };
+  ws.onclose = function () {
+    console.warn('[pixel-agents-terminal] Disconnected from runner');
+  };
+})();
+</script>`;
+  }
+}

--- a/terminal/src/eventTranslator.ts
+++ b/terminal/src/eventTranslator.ts
@@ -1,0 +1,123 @@
+import type { TerminalBridge } from './bridge.js';
+
+const TOOL_DISPLAY_MAX = 30;
+
+/**
+ * Minimal port of src/transcriptParser.ts formatToolStatus.
+ * Produces the status string shown in character speech bubbles.
+ */
+function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
+  if (toolName === 'Bash') {
+    const cmd = typeof input.command === 'string' ? input.command.trim() : '';
+    const short = cmd.length > TOOL_DISPLAY_MAX ? `${cmd.slice(0, TOOL_DISPLAY_MAX)}\u2026` : cmd;
+    return `Running: ${short}`;
+  }
+  if (toolName === 'Task' || toolName === 'Agent') {
+    const desc = typeof input.description === 'string' ? input.description : '';
+    const short =
+      desc.length > TOOL_DISPLAY_MAX ? `${desc.slice(0, TOOL_DISPLAY_MAX)}\u2026` : desc;
+    return desc ? `Subtask: ${short}` : 'Subtask';
+  }
+  if (toolName === 'Read') {
+    const p = typeof input.file_path === 'string' ? (input.file_path.split('/').pop() ?? '') : '';
+    return `Reading: ${p}`;
+  }
+  if (toolName === 'Edit' || toolName === 'Write') {
+    const p = typeof input.file_path === 'string' ? (input.file_path.split('/').pop() ?? '') : '';
+    return `${toolName === 'Write' ? 'Writing' : 'Editing'}: ${p}`;
+  }
+  if (toolName === 'Glob') {
+    const pattern = typeof input.pattern === 'string' ? input.pattern : '';
+    return `Searching: ${pattern}`;
+  }
+  if (toolName === 'Grep') {
+    const pattern = typeof input.pattern === 'string' ? input.pattern : '';
+    return `Grep: ${pattern}`;
+  }
+  return toolName;
+}
+
+interface AgentEntry {
+  id: number;
+  currentHookToolId?: string;
+}
+
+/**
+ * Translates raw Claude Code hook events (received via PixelAgentsServer) into
+ * webview protocol messages (agentCreated, agentToolStart, agentStatus, etc.)
+ * and broadcasts them to browser clients via TerminalBridge.
+ *
+ * This is a simplified, standalone replacement for HookEventHandler that has no
+ * VS Code dependencies. It covers the hook-driven subset of events (no JSONL polling).
+ */
+export class EventTranslator {
+  private readonly sessionToAgent = new Map<string, AgentEntry>();
+  private nextId = 1;
+
+  constructor(private readonly bridge: TerminalBridge) {}
+
+  handleHookEvent(_providerId: string, event: Record<string, unknown>): void {
+    const eventName = event.hook_event_name as string;
+    const sessionId = event.session_id as string;
+
+    if (eventName === 'SessionStart') {
+      this.ensureAgent(sessionId, /* logReason */ 'SessionStart');
+      return;
+    }
+
+    const entry = this.ensureAgent(sessionId, eventName);
+    const { id } = entry;
+
+    if (eventName === 'PreToolUse') {
+      const toolName = (event.tool_name as string | undefined) ?? '';
+      const toolInput = (event.tool_input as Record<string, unknown> | undefined) ?? {};
+      const status = formatToolStatus(toolName, toolInput);
+      const toolId = `hook-${Date.now().toString()}`;
+      entry.currentHookToolId = toolId;
+      this.bridge.broadcast({ type: 'agentToolStart', id, toolId, status, toolName });
+      this.bridge.broadcast({ type: 'agentStatus', id, status: 'active' });
+    } else if (eventName === 'PostToolUse' || eventName === 'PostToolUseFailure') {
+      if (entry.currentHookToolId) {
+        this.bridge.broadcast({ type: 'agentToolDone', id, toolId: entry.currentHookToolId });
+        entry.currentHookToolId = undefined;
+      }
+    } else if (eventName === 'Stop') {
+      entry.currentHookToolId = undefined;
+      this.bridge.broadcast({ type: 'agentToolsClear', id });
+      this.bridge.broadcast({ type: 'agentStatus', id, status: 'waiting' });
+    } else if (
+      eventName === 'PermissionRequest' ||
+      (eventName === 'Notification' && event.notification_type === 'permission_prompt')
+    ) {
+      this.bridge.broadcast({ type: 'agentToolPermission', id });
+    } else if (eventName === 'Notification' && event.notification_type === 'idle_prompt') {
+      this.bridge.broadcast({ type: 'agentStatus', id, status: 'waiting' });
+    } else if (eventName === 'SessionEnd') {
+      const reason = (event.reason as string | undefined) ?? 'unknown';
+      // /clear and /resume are followed immediately by a new SessionStart — keep the agent alive
+      if (reason !== 'clear' && reason !== 'resume') {
+        this.bridge.broadcast({ type: 'agentClosed', id });
+        this.sessionToAgent.delete(sessionId);
+        console.log(`[pixel-agents-terminal] Agent ${id.toString()} closed (reason: ${reason})`);
+      }
+    }
+  }
+
+  /**
+   * Returns the agent entry for a session, creating one (and broadcasting agentCreated)
+   * if it does not yet exist. Handles the race where hook events arrive before SessionStart.
+   */
+  private ensureAgent(sessionId: string, reason: string): AgentEntry {
+    const existing = this.sessionToAgent.get(sessionId);
+    if (existing) return existing;
+
+    const id = this.nextId++;
+    const entry: AgentEntry = { id };
+    this.sessionToAgent.set(sessionId, entry);
+    this.bridge.broadcast({ type: 'agentCreated', id });
+    console.log(
+      `[pixel-agents-terminal] Agent ${id.toString()} created via ${reason} (session ${sessionId.slice(0, 8)}...)`,
+    );
+    return entry;
+  }
+}

--- a/terminal/src/index.ts
+++ b/terminal/src/index.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { TerminalRunner } from './runner.js';
+
+const runner = new TerminalRunner();
+
+process.on('SIGINT', () => {
+  runner.stop();
+  process.exit(0);
+});
+
+runner.start().catch((err: unknown) => {
+  console.error('[pixel-agents-terminal] Fatal error:', err);
+  process.exit(1);
+});

--- a/terminal/src/runner.ts
+++ b/terminal/src/runner.ts
@@ -1,0 +1,50 @@
+import { PixelAgentsServer } from '../../server/src/server.js';
+
+import { TerminalBridge } from './bridge.js';
+import { EventTranslator } from './eventTranslator.js';
+
+/**
+ * Orchestrates the three components of the terminal runner:
+ *
+ * 1. PixelAgentsServer  — existing HTTP server that receives Claude Code hook events
+ *                         and writes ~/.pixel-agents/server.json for hook script discovery.
+ * 2. TerminalBridge     — HTTP static server (webview-ui/dist) + WebSocket server.
+ *                         Injects a client script into index.html that forwards
+ *                         WebSocket messages to window so useExtensionMessages receives them.
+ * 3. EventTranslator    — translates raw hook events into webview protocol messages
+ *                         (agentCreated, agentToolStart, agentStatus, …) and broadcasts
+ *                         them to all connected browser clients.
+ */
+export class TerminalRunner {
+  private readonly hookServer = new PixelAgentsServer();
+  private readonly bridge: TerminalBridge;
+  private readonly translator: EventTranslator;
+
+  constructor(webviewDir?: string) {
+    this.bridge = new TerminalBridge(webviewDir);
+    this.translator = new EventTranslator(this.bridge);
+  }
+
+  async start(): Promise<void> {
+    const [hookConfig, uiPort] = await Promise.all([this.hookServer.start(), this.bridge.start()]);
+
+    this.hookServer.onHookEvent((providerId, event) => {
+      this.translator.handleHookEvent(providerId, event);
+    });
+
+    console.log('');
+    console.log('[pixel-agents-terminal] Runner started');
+    console.log(
+      `[pixel-agents-terminal] Hook server : http://127.0.0.1:${hookConfig.port.toString()}`,
+    );
+    console.log(`[pixel-agents-terminal] Open in browser: http://127.0.0.1:${uiPort.toString()}`);
+    console.log('[pixel-agents-terminal] Press Ctrl+C to stop');
+    console.log('');
+  }
+
+  stop(): void {
+    this.hookServer.stop();
+    this.bridge.stop();
+    console.log('[pixel-agents-terminal] Stopped');
+  }
+}

--- a/terminal/tsconfig.json
+++ b/terminal/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "rootDir": "..",
+    "outDir": "./dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "../server/src/constants.ts",
+    "../server/src/server.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new `terminal/` package that allows running Pixel Agents outside of VS Code — directly from Ghostty, iTerm2, or any terminal.

### How it works

The runner starts two servers on the same port:

- **HTTP static server** — serves the built `webview-ui/dist` as a regular web app, with a small WebSocket client script injected into `index.html`
- **WebSocket endpoint** (`/events`) — broadcasts webview protocol messages to all connected browser clients

The existing `PixelAgentsServer` (from `server/`) is reused unchanged to receive Claude Code hook events. A new `EventTranslator` converts those raw hook events into webview protocol messages (`agentCreated`, `agentToolStart`, `agentStatus`, etc.) without any VS Code dependencies.

The webview already runs in browser mode today (via `browserMock.ts`), so no changes to `webview-ui` are needed. The injected script bridges the gap: it listens on WebSocket and dispatches received messages as `window.dispatchEvent(new MessageEvent(...))` — exactly what `useExtensionMessages` already listens for.

### Usage

```bash
# build the webview first
npm run build:webview

# start the terminal runner
cd terminal && npx tsx src/index.ts
```

Then open the printed URL in a browser tab.

### Architecture

```
terminal/
├── src/
│   ├── index.ts           # CLI entry point (SIGINT handler)
│   ├── runner.ts          # Orchestrates all three components
│   ├── bridge.ts          # HTTP static server + WebSocket server
│   └── eventTranslator.ts # Hook events → webview protocol messages
├── package.json
└── tsconfig.json
```

### What works in this PR

- Session start/end → agent appears/disappears in office
- Tool use (Bash, Read, Edit, Write, Grep, Glob, Task/Agent) → character animates with status bubble
- Permission requests → permission bubble
- Stop event → character returns to idle/waiting animation
- Zero changes to existing code (webview-ui, server, extension src)

### Known limitations / future work

- JSONL file watching not yet implemented (hooks-only mode, same as when hooks are enabled in VS Code)
- Kitty Graphics Protocol / native terminal render not yet implemented (Phase 2)
- Production build path needs to be resolved (currently development-only via `tsx`)
- Layout persistence not yet wired (uses default layout on every start)