### PR TITLE
fix: subagent characters not despawning on completion

### DIFF
--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -373,14 +373,19 @@ export class HookEventHandler {
     agent.permissionSent = false;
     agent.hadToolsInTurn = true;
 
-    // Send tool start + active state to webview (instant, no 500ms JSONL delay)
-    webview?.postMessage({
-      type: 'agentToolStart',
-      id: agentId,
-      toolId: hookToolId,
-      status,
-      toolName,
-    });
+    // Send tool start + active state to webview (instant, no 500ms JSONL delay).
+    // Skip for Task/Agent tools — their sub-agent characters need the stable JSONL
+    // tool ID (not the transient hook ID) so that SubagentStop/tool_result cleanup
+    // can find and remove them. JSONL handles agentToolStart for these tools.
+    if (toolName !== 'Task' && toolName !== 'Agent') {
+      webview?.postMessage({
+        type: 'agentToolStart',
+        id: agentId,
+        toolId: hookToolId,
+        status,
+        toolName,
+      });
+    }
     webview?.postMessage({
       type: 'agentStatus',
       id: agentId,
@@ -490,12 +495,15 @@ export class HookEventHandler {
     agentId: number,
     webview: vscode.Webview | undefined,
   ): void {
-    // Find parent tool and clear all sub-agent tracking for it.
-    // SubagentStop doesn't give us the specific sub-tool ID, so clear all
-    // sub-agents under the first matching Task/Agent parent.
+    // Find a parent Task/Agent tool that actually has tracked sub-agents.
+    // SubagentStop doesn't identify which specific sub-agent stopped, so we
+    // clear the first parent that still has active sub-agent tracking.
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
-      if (toolName === 'Task' || toolName === 'Agent') {
+      if (
+        (toolName === 'Task' || toolName === 'Agent') &&
+        agent.activeSubagentToolIds.has(toolId)
+      ) {
         parentToolId = toolId;
         break;
       }
@@ -615,6 +623,11 @@ export class HookEventHandler {
       agent.activeToolNames.clear();
       agent.activeSubagentToolIds.clear();
       agent.activeSubagentToolNames.clear();
+      webview?.postMessage({ type: 'agentToolsClear', id: agentId });
+    } else if (agent.activeToolIds.size === 0 && agent.backgroundAgentToolIds.size === 0) {
+      // Hooks mode safety net: JSONL may have already cleared activeToolIds before
+      // the Stop hook fires, but the webview can still have stale tool entries or
+      // sub-agent characters from hook-created tools. Send agentToolsClear to clean up.
       webview?.postMessage({ type: 'agentToolsClear', id: agentId });
     }
 

--- a/src/transcriptParser.ts
+++ b/src/transcriptParser.ts
@@ -106,8 +106,11 @@ export function processTranscriptLine(
             if (!PERMISSION_EXEMPT_TOOLS.has(toolName)) {
               hasNonExemptTool = true;
             }
-            // Skip webview message when hooks handle tool visuals (PreToolUse sent it instantly)
-            if (!agent.hookDelivered) {
+            // Skip webview message when hooks handle tool visuals (PreToolUse sent it instantly).
+            // Exception: Task/Agent tools always go through JSONL so the sub-agent character
+            // is created with the stable JSONL tool ID, matching cleanup messages.
+            const isAgentTool = toolName === 'Task' || toolName === 'Agent';
+            if (!agent.hookDelivered || isAgentTool) {
               webview?.postMessage({
                 type: 'agentToolStart',
                 id: agentId,
@@ -183,7 +186,11 @@ export function processTranscriptLine(
               agent.activeToolIds.delete(completedToolId);
               agent.activeToolStatuses.delete(completedToolId);
               agent.activeToolNames.delete(completedToolId);
-              if (!agent.hookDelivered) {
+              // Send agentToolDone when hooks are off, or for Task/Agent tools
+              // (which always use JSONL path for consistent sub-agent lifecycle).
+              const isCompletedAgentTool =
+                completedToolName === 'Task' || completedToolName === 'Agent';
+              if (!agent.hookDelivered || isCompletedAgentTool) {
                 const toolId = completedToolId;
                 setTimeout(() => {
                   webview?.postMessage({


### PR DESCRIPTION
## Summary
- Sub-agent characters were created with transient hook tool IDs (`hook-XXXX`) but all cleanup paths (SubagentStop, JSONL tool_result, markAgentWaiting) used JSONL tool IDs (`toolu_XXXX`), causing a key mismatch that prevented character removal
- Skip `agentToolStart` from PreToolUse for Task/Agent tools so JSONL creates sub-agent characters with stable tool IDs that match cleanup messages
- Always send `agentToolStart`/`agentToolDone` for Task/Agent via JSONL even when hooks are active
- Add safety net `agentToolsClear` in `markAgentWaiting` when `activeToolIds` is empty (JSONL cleared them before Stop hook fired)
- SubagentStop now only matches parent tools that have active sub-agent tracking

## Test plan
- [x] All 63 existing tests pass
- [ ] Launch multiple subagents (e.g. parallel Agent tool calls) and verify characters despawn when they complete
- [ ] Verify single subagent still spawns and despawns correctly
- [ ] Verify subagent permission bubbles still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)