### PR TITLE
feat: pixel art tool badges above agent characters

### DIFF
--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -74,6 +74,25 @@ export const CANVAS_FALLBACK_TILE_COLOR = '#444';
 export const CANVAS_ERROR_TILE_COLOR = '#FF00FF';
 export const WALL_COLOR = '#3A3A5C';
 
+// ── Tool badges ─────────────────────────────────────────────
+export const TOOL_BADGE_OUTLINE_COLOR = '#1a1a1a';
+export const TOOL_BADGE_FALLBACK_COLOR = '#CBD5E1';
+export const TOOL_BADGE_READ_COLOR = '#60A5FA';
+export const TOOL_BADGE_GREP_COLOR = '#22D3EE';
+export const TOOL_BADGE_GLOB_COLOR = '#2DD4BF';
+export const TOOL_BADGE_BASH_COLOR = '#34D399';
+export const TOOL_BADGE_EDIT_COLOR = '#FBBF24';
+export const TOOL_BADGE_WRITE_COLOR = '#F87171';
+export const TOOL_BADGE_NOTEBOOK_COLOR = '#F472B6';
+export const TOOL_BADGE_WEB_FETCH_COLOR = '#A78BFA';
+export const TOOL_BADGE_WEB_SEARCH_COLOR = '#C084FC';
+export const TOOL_BADGE_TASK_COLOR = '#FACC15';
+export const TOOL_BADGE_TODO_COLOR = '#94A3B8';
+export const TOOL_BADGE_SKILL_COLOR = '#FB923C';
+export const TOOL_BADGE_ASK_COLOR = '#F0ABFC';
+export const TOOL_BADGE_SIZE_PX = 9;
+export const TOOL_BADGE_VERTICAL_OFFSET_PX = 4;
+
 // ── Camera ───────────────────────────────────────────────────
 export const CAMERA_FOLLOW_LERP = 0.1;
 export const CAMERA_FOLLOW_SNAP_THRESHOLD = 0.5;

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -568,6 +568,7 @@ export class OfficeState {
         ch.seatTimer = -1;
         ch.path = [];
         ch.moveProgress = 0;
+        ch.currentTool = null;
       }
       this.rebuildFurnitureInstances();
     }

--- a/webview-ui/src/office/engine/renderer.ts
+++ b/webview-ui/src/office/engine/renderer.ts
@@ -51,6 +51,7 @@ import { CharacterState, TILE_SIZE, TileType } from '../types.js';
 import { getWallInstances, hasWallSprites, wallColorToHex } from '../wallTiles.js';
 import { getCharacterSprite } from './characters.js';
 import { renderMatrixEffect } from './matrixEffect.js';
+import { renderToolBadges } from './toolBadges.js';
 
 // ── Render functions ────────────────────────────────────────────
 
@@ -621,6 +622,9 @@ export function renderFrame(
   const selectedId = selection?.selectedAgentId ?? null;
   const hoveredId = selection?.hoveredAgentId ?? null;
   renderScene(ctx, allFurniture, characters, offsetX, offsetY, zoom, selectedId, hoveredId);
+
+  // Tool badges (below bubbles, above characters)
+  renderToolBadges(ctx, characters, offsetX, offsetY, zoom);
 
   // Speech bubbles (always on top of characters)
   renderBubbles(ctx, characters, offsetX, offsetY, zoom);

--- a/webview-ui/src/office/engine/toolBadges.ts
+++ b/webview-ui/src/office/engine/toolBadges.ts
@@ -1,0 +1,240 @@
+import {
+  BUBBLE_SITTING_OFFSET_PX,
+  BUBBLE_VERTICAL_OFFSET_PX,
+  TOOL_BADGE_ASK_COLOR,
+  TOOL_BADGE_BASH_COLOR,
+  TOOL_BADGE_EDIT_COLOR,
+  TOOL_BADGE_FALLBACK_COLOR,
+  TOOL_BADGE_GLOB_COLOR,
+  TOOL_BADGE_GREP_COLOR,
+  TOOL_BADGE_NOTEBOOK_COLOR,
+  TOOL_BADGE_OUTLINE_COLOR,
+  TOOL_BADGE_READ_COLOR,
+  TOOL_BADGE_SIZE_PX,
+  TOOL_BADGE_SKILL_COLOR,
+  TOOL_BADGE_TASK_COLOR,
+  TOOL_BADGE_TODO_COLOR,
+  TOOL_BADGE_VERTICAL_OFFSET_PX,
+  TOOL_BADGE_WEB_FETCH_COLOR,
+  TOOL_BADGE_WEB_SEARCH_COLOR,
+  TOOL_BADGE_WRITE_COLOR,
+} from '../../constants.js';
+import type { Character } from '../types.js';
+import { CharacterState } from '../types.js';
+
+type IconPixels = readonly string[];
+
+interface ToolIcon {
+  color: string;
+  pixels: IconPixels;
+}
+
+const ICON_READ: IconPixels = [
+  '.........',
+  '.XXX.XXX.',
+  'X...X...X',
+  'X...X...X',
+  'X...X...X',
+  'X...X...X',
+  'X...X...X',
+  '.XXX.XXX.',
+  '.........',
+];
+
+const ICON_GREP: IconPixels = [
+  '.XXXXX...',
+  'X.....X..',
+  'X.....X..',
+  'X.....X..',
+  'X.....X..',
+  '.XXXXX.X.',
+  '......XX.',
+  '.......XX',
+  '........X',
+];
+
+const ICON_GLOB: IconPixels = [
+  '....X....',
+  'X...X...X',
+  '.X..X..X.',
+  '..X.X.X..',
+  'XXXXXXXXX',
+  '..X.X.X..',
+  '.X..X..X.',
+  'X...X...X',
+  '....X....',
+];
+
+const ICON_BASH: IconPixels = [
+  '.........',
+  'XX.......',
+  '.XX......',
+  '..XX.....',
+  '...XX....',
+  '..XX.....',
+  '.XX......',
+  'XX..XXXXX',
+  '.........',
+];
+
+const ICON_EDIT: IconPixels = [
+  '.......XX',
+  '......XXX',
+  '.....XXX.',
+  '....XXX..',
+  '...XXX...',
+  '..XXX....',
+  '.XXX.....',
+  'XXX......',
+  'XX.......',
+];
+
+const ICON_WRITE: IconPixels = [
+  'XXXXXX...',
+  'X....X...',
+  'X....X...',
+  'X.XX.X...',
+  'X....X...',
+  'X.XX.X...',
+  'X....X...',
+  'X....X...',
+  'XXXXXX...',
+];
+
+const ICON_WEB: IconPixels = [
+  '...XXX...',
+  '.XX...XX.',
+  'X..X.X..X',
+  'X.XXXXX.X',
+  'XXX...XXX',
+  'X.XXXXX.X',
+  'X..X.X..X',
+  '.XX...XX.',
+  '...XXX...',
+];
+
+const ICON_TASK: IconPixels = [
+  '...XXX...',
+  '.XXXXXXX.',
+  '.X.....X.',
+  'XX.....XX',
+  'XX.....XX',
+  'XX.....XX',
+  '.X.....X.',
+  '.XXXXXXX.',
+  '...XXX...',
+];
+
+const ICON_CHECK: IconPixels = [
+  '.........',
+  '........X',
+  '.......XX',
+  '......XX.',
+  '.....XX..',
+  'X...XX...',
+  'XX.XX....',
+  '.XXX.....',
+  '..X......',
+];
+
+const ICON_STAR: IconPixels = [
+  '....X....',
+  '....X....',
+  '...XXX...',
+  'XXXXXXXXX',
+  '.XXXXXXX.',
+  '..XXXXX..',
+  '.XX.X.XX.',
+  '.X...X.X.',
+  'X.....X..',
+];
+
+const ICON_HELP: IconPixels = [
+  '.XXXXX...',
+  'X.....X..',
+  'X.....X..',
+  '.....X...',
+  '....X....',
+  '....X....',
+  '.........',
+  '....X....',
+  '.........',
+];
+
+const ICONS: Record<string, ToolIcon> = {
+  Read: { color: TOOL_BADGE_READ_COLOR, pixels: ICON_READ },
+  Grep: { color: TOOL_BADGE_GREP_COLOR, pixels: ICON_GREP },
+  Glob: { color: TOOL_BADGE_GLOB_COLOR, pixels: ICON_GLOB },
+  Bash: { color: TOOL_BADGE_BASH_COLOR, pixels: ICON_BASH },
+  Edit: { color: TOOL_BADGE_EDIT_COLOR, pixels: ICON_EDIT },
+  Write: { color: TOOL_BADGE_WRITE_COLOR, pixels: ICON_WRITE },
+  NotebookEdit: { color: TOOL_BADGE_NOTEBOOK_COLOR, pixels: ICON_WRITE },
+  WebFetch: { color: TOOL_BADGE_WEB_FETCH_COLOR, pixels: ICON_WEB },
+  WebSearch: { color: TOOL_BADGE_WEB_SEARCH_COLOR, pixels: ICON_WEB },
+  Task: { color: TOOL_BADGE_TASK_COLOR, pixels: ICON_TASK },
+  Agent: { color: TOOL_BADGE_TASK_COLOR, pixels: ICON_TASK },
+  TodoWrite: { color: TOOL_BADGE_TODO_COLOR, pixels: ICON_CHECK },
+  Skill: { color: TOOL_BADGE_SKILL_COLOR, pixels: ICON_STAR },
+  AskUserQuestion: { color: TOOL_BADGE_ASK_COLOR, pixels: ICON_HELP },
+};
+
+const FALLBACK: ToolIcon = { color: TOOL_BADGE_FALLBACK_COLOR, pixels: ICON_HELP };
+
+function iconFor(tool: string): ToolIcon {
+  return ICONS[tool] ?? FALLBACK;
+}
+
+export function renderToolBadges(
+  ctx: CanvasRenderingContext2D,
+  characters: Character[],
+  offsetX: number,
+  offsetY: number,
+  zoom: number,
+): void {
+  ctx.save();
+  ctx.imageSmoothingEnabled = false;
+
+  for (const ch of characters) {
+    if (!ch.currentTool) continue;
+    if (ch.bubbleType === 'permission') continue;
+
+    const icon = iconFor(ch.currentTool);
+    const { color, pixels } = icon;
+
+    const sittingOff = ch.state === CharacterState.TYPE ? BUBBLE_SITTING_OFFSET_PX : 0;
+    const centerX = offsetX + ch.x * zoom;
+    const topY =
+      offsetY +
+      (ch.y + sittingOff - BUBBLE_VERTICAL_OFFSET_PX - TOOL_BADGE_VERTICAL_OFFSET_PX) * zoom -
+      TOOL_BADGE_SIZE_PX * zoom;
+
+    const bx = Math.round(centerX - (TOOL_BADGE_SIZE_PX * zoom) / 2);
+    const by = Math.round(topY);
+
+    for (let py = 0; py < pixels.length; py++) {
+      const row = pixels[py];
+      for (let px = 0; px < row.length; px++) {
+        const c = row.charCodeAt(px);
+        if (c === 46) continue;
+
+        ctx.fillStyle = TOOL_BADGE_OUTLINE_COLOR;
+        ctx.fillRect(bx + (px - 1) * zoom, by + py * zoom, zoom, zoom);
+        ctx.fillRect(bx + (px + 1) * zoom, by + py * zoom, zoom, zoom);
+        ctx.fillRect(bx + px * zoom, by + (py - 1) * zoom, zoom, zoom);
+        ctx.fillRect(bx + px * zoom, by + (py + 1) * zoom, zoom, zoom);
+      }
+    }
+
+    for (let py = 0; py < pixels.length; py++) {
+      const row = pixels[py];
+      for (let px = 0; px < row.length; px++) {
+        const c = row.charCodeAt(px);
+        if (c === 46) continue;
+        ctx.fillStyle = color;
+        ctx.fillRect(bx + px * zoom, by + py * zoom, zoom, zoom);
+      }
+    }
+  }
+
+  ctx.restore();
+}

--- a/webview-ui/src/office/toolUtils.ts
+++ b/webview-ui/src/office/toolUtils.ts
@@ -1,13 +1,16 @@
 /** Map status prefixes back to tool names for animation selection */
 const STATUS_TO_TOOL: Record<string, string> = {
   Reading: 'Read',
+  'Searching files': 'Glob',
+  'Searching code': 'Grep',
+  'Searching the web': 'WebSearch',
   Searching: 'Grep',
   Globbing: 'Glob',
   Fetching: 'WebFetch',
-  'Searching web': 'WebSearch',
   Writing: 'Write',
   Editing: 'Edit',
   Running: 'Bash',
+  Subtask: 'Task',
   Task: 'Task',
 };
 


### PR DESCRIPTION
## Summary

Adds small 9×9 pixel art badges that float above each character showing which tool is currently running. Gives you a glanceable view of what every agent is doing without having to hover or select.

Each tool has a distinct shape and accent color with a dark outline so it reads clearly over any background:

- **Read** — book (blue)
- **Grep** — magnifying glass (cyan)
- **Glob** — asterisk/wildcard (teal)
- **Bash** — `>_` prompt (green)
- **Edit** — diagonal pencil (amber)
- **Write / NotebookEdit** — document (red / pink)
- **WebFetch / WebSearch** — globe (violet / purple)
- **Task / Agent** — ring (gold)
- **TodoWrite** — checkmark (slate)
- **Skill** — star (orange)
- **AskUserQuestion** — question (fuchsia)

Badges are hidden while a permission bubble is showing so they don't stack visually.

Also fixes a small status→tool mapping bug: `"Searching files"` (Glob) was matching the `"Searching"` prefix first and being classified as Grep. Added longer-prefix-first entries so Glob, Grep, and WebSearch are each identified correctly.

## Test plan

- [ ] Open the webview with active agents
- [ ] Trigger Read / Grep / Glob / Bash / Edit / Write / WebFetch / WebSearch / Task — verify each shows the correct icon and color above the character
- [ ] Verify the badge disappears when the tool completes
- [ ] Verify the badge hides while a permission bubble (`...`) is showing
- [ ] Verify sub-agents also show their current tool badge