### PR TITLE
feat: worktree agents — isolated branch per agent

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -14,6 +14,7 @@ import { PixelAgentsServer } from '../server/src/server.js';
 import {
   getProjectDirPath,
   launchNewTerminal,
+  launchWorktreeAgent,
   persistAgents,
   removeAgent,
   restoreAgents,
@@ -315,6 +316,29 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  private async promptRemoveWorktree(worktreePath: string): Promise<void> {
+    const branchName = path.basename(worktreePath);
+    const choice = await vscode.window.showInformationMessage(
+      `Remove worktree '${branchName}'?`,
+      'Yes',
+      'No',
+    );
+    if (choice !== 'Yes') return;
+    try {
+      const { execSync } = await import('child_process');
+      const repoRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      execSync(`git worktree remove "${worktreePath}" --force`, { cwd: repoRoot });
+      try {
+        execSync(`git branch -D "${branchName}"`, { cwd: repoRoot });
+      } catch {
+        // Branch may not exist or already deleted — ignore
+      }
+      void vscode.window.showInformationMessage(`Pixel Agents: Removed worktree '${branchName}'.`);
+    } catch (e) {
+      void vscode.window.showErrorMessage(`Pixel Agents: Failed to remove worktree: ${e}`);
+    }
+  }
+
   /** Register an agent with the hook event handler for session->agent mapping.
    *  hookDelivered is NOT set here. It is set only in hookEventHandler.handleEvent()
    *  when an actual hook event arrives, preserving heuristic fallback for agents
@@ -359,6 +383,38 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.registerAgentHook(agent);
           }
         }
+      } else if (message.type === 'requestWorktreeAgent') {
+        const now = new Date();
+        const defaultBranch = `worktree-${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;
+        const input = await vscode.window.showInputBox({
+          prompt: 'Branch name for new worktree agent (leave empty for timestamp)',
+          placeHolder: defaultBranch,
+        });
+        if (input === undefined) return;
+        const branchName = input.trim() || defaultBranch;
+        const prevAgentIds = new Set(this.agents.keys());
+        await launchWorktreeAgent(
+          this.nextAgentId,
+          this.nextTerminalIndex,
+          this.agents,
+          this.activeAgentId,
+          this.knownJsonlFiles,
+          this.fileWatchers,
+          this.pollingTimers,
+          this.waitingTimers,
+          this.permissionTimers,
+          this.jsonlPollTimers,
+          this.projectScanTimer,
+          this.webview,
+          this.persistAgents,
+          branchName.trim(),
+          message.bypassPermissions as boolean | undefined,
+        );
+        for (const [id, agent] of this.agents) {
+          if (!prevAgentIds.has(id)) {
+            this.registerAgentHook(agent);
+          }
+        }
       } else if (message.type === 'focusAgent') {
         const agent = this.agents.get(message.id);
         if (agent) {
@@ -375,6 +431,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
       } else if (message.type === 'closeAgent') {
         const agent = this.agents.get(message.id);
         if (agent) {
+          const worktreePath = agent.worktreePath;
           if (agent.terminalRef) {
             agent.terminalRef.dispose();
           } else {
@@ -392,6 +449,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
               this.persistAgents,
             );
             webviewView.webview.postMessage({ type: 'agentClosed', id: message.id });
+          }
+          if (worktreePath) {
+            void this.promptRemoveWorktree(worktreePath);
           }
         }
       } else if (message.type === 'saveAgentSeats') {
@@ -508,6 +568,18 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           false,
         );
         const config = readConfig();
+        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        let isGitRepo = false;
+        if (workspaceRoot) {
+          try {
+            const { execSync } = await import('child_process');
+            execSync('git rev-parse --git-dir', { cwd: workspaceRoot, stdio: 'ignore' });
+            isGitRepo = true;
+          } catch {
+            isGitRepo = false;
+          }
+        }
+        console.log(`[Pixel Agents] isGitRepo: ${isGitRepo}, workspaceRoot: ${workspaceRoot}`);
         this.webview?.postMessage({
           type: 'settingsLoaded',
           soundEnabled,
@@ -518,6 +590,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           hooksEnabled,
           hooksInfoShown,
           externalAssetDirectories: config.externalAssetDirectories,
+          isGitRepo,
         });
 
         // Send workspace folders to webview (only when multi-root)
@@ -531,7 +604,6 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 
         // Ensure project scan runs even with no restored agents (to adopt external terminals)
         const projectDir = getProjectDirPath();
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         console.log(`[Pixel Agents] Debug: Platform: ${process.platform}, arch: ${process.arch}`);
         console.log('[Extension] workspaceRoot:', workspaceRoot);
         console.log('[Extension] projectDir:', projectDir);
@@ -813,6 +885,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           if (agent.isTeamLead) {
             this.removeTeammates(id);
           }
+          const worktreePath = agent.worktreePath;
           // Dismiss JSONL so external scanner doesn't re-adopt it
           dismissedJsonlFiles.set(agent.jsonlFile, Date.now());
           this.unregisterAgentHook(agent);
@@ -827,6 +900,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.persistAgents,
           );
           webviewView.webview.postMessage({ type: 'agentClosed', id });
+          if (worktreePath) {
+            void this.promptRemoveWorktree(worktreePath);
+          }
         }
       }
     });

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -76,6 +77,7 @@ export async function launchNewTerminal(
   persistAgents: () => void,
   folderPath?: string,
   bypassPermissions?: boolean,
+  worktreePath?: string,
 ): Promise<void> {
   const folders = vscode.workspace.workspaceFolders;
   // Use home directory as fallback cwd when no workspace is open (common on Linux/macOS).
@@ -104,7 +106,11 @@ export async function launchNewTerminal(
 
   // Create agent immediately (before JSONL file exists)
   const id = nextAgentIdRef.current++;
-  const folderName = isMultiRoot && cwd ? path.basename(cwd) : undefined;
+  const folderName = worktreePath
+    ? `⊕ ${path.basename(worktreePath)}`
+    : isMultiRoot && cwd
+      ? path.basename(cwd)
+      : undefined;
   const agent: AgentState = {
     id,
     sessionId,
@@ -127,6 +133,7 @@ export async function launchNewTerminal(
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
     folderName,
+    worktreePath,
     hookDelivered: false,
     inputTokens: 0,
     outputTokens: 0,
@@ -294,6 +301,7 @@ export function persistAgents(
       jsonlFile: agent.jsonlFile,
       projectDir: agent.projectDir,
       folderName: agent.folderName,
+      worktreePath: agent.worktreePath,
       teamName: agent.teamName,
       agentName: agent.agentName,
       isTeamLead: agent.isTeamLead,
@@ -327,6 +335,7 @@ export function restoreAgents(
   let maxId = 0;
   let maxIdx = 0;
   let restoredProjectDir: string | null = null;
+  const newlyRestoredTerminalIds: number[] = [];
 
   for (const p of persisted) {
     // Skip agents already in the map — prevents duplicate file watchers on re-entry
@@ -374,6 +383,7 @@ export function restoreAgents(
       linesProcessed: 0,
       seenUnknownRecordTypes: new Set(),
       folderName: p.folderName,
+      worktreePath: p.worktreePath,
       hookDelivered: false,
       inputTokens: 0,
       outputTokens: 0,
@@ -386,6 +396,7 @@ export function restoreAgents(
 
     agents.set(p.id, agent);
     knownJsonlFiles.add(p.jsonlFile);
+    if (!isExternal) newlyRestoredTerminalIds.push(p.id);
     if (isExternal) {
       console.log(
         `[Pixel Agents] Terminal: Agent ${p.id} - restored external → ${path.basename(p.jsonlFile)}`,
@@ -453,15 +464,13 @@ export function restoreAgents(
     }
   }
 
-  // After a short delay, remove restored terminal agents that never received data.
+  // After a short delay, remove NEWLY restored terminal agents that never received data.
   // These are dead terminals restored by VS Code (e.g., after /clear or restart)
-  // where Claude is no longer running.
-  const restoredTerminalIds = [...agents.entries()]
-    .filter(([, a]) => !a.isExternal && a.terminalRef)
-    .map(([id]) => id);
-  if (restoredTerminalIds.length > 0) {
+  // where Claude is no longer running. Only targets agents restored in THIS call —
+  // not already-live agents — to avoid killing active agents on panel re-focus.
+  if (newlyRestoredTerminalIds.length > 0) {
     setTimeout(() => {
-      for (const id of restoredTerminalIds) {
+      for (const id of newlyRestoredTerminalIds) {
         const agent = agents.get(id);
         if (agent && !agent.isExternal && agent.linesProcessed === 0) {
           console.log(
@@ -604,6 +613,68 @@ export function sendCurrentAgentStatuses(
       });
     }
   }
+}
+
+export async function launchWorktreeAgent(
+  nextAgentIdRef: { current: number },
+  nextTerminalIndexRef: { current: number },
+  agents: Map<number, AgentState>,
+  activeAgentIdRef: { current: number | null },
+  knownJsonlFiles: Set<string>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
+  projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
+  webview: vscode.Webview | undefined,
+  persistAgents: () => void,
+  branchName: string,
+  bypassPermissions?: boolean,
+): Promise<void> {
+  const repoRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!repoRoot) {
+    void vscode.window.showErrorMessage('Pixel Agents: No workspace folder open.');
+    return;
+  }
+
+  const worktreePath = path.join(repoRoot, '.worktrees', branchName);
+
+  try {
+    execSync(`git worktree add "${worktreePath}" -b "${branchName}"`, {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('already exists')) {
+      void vscode.window.showErrorMessage(`Pixel Agents: Branch '${branchName}' already exists.`);
+    } else {
+      void vscode.window.showErrorMessage(`Pixel Agents: Failed to create worktree: ${msg}`);
+    }
+    return;
+  }
+
+  console.log(`[Pixel Agents] Created worktree at ${worktreePath} for branch '${branchName}'`);
+
+  await launchNewTerminal(
+    nextAgentIdRef,
+    nextTerminalIndexRef,
+    agents,
+    activeAgentIdRef,
+    knownJsonlFiles,
+    fileWatchers,
+    pollingTimers,
+    waitingTimers,
+    permissionTimers,
+    jsonlPollTimers,
+    projectScanTimerRef,
+    webview,
+    persistAgents,
+    worktreePath,
+    bypassPermissions,
+    worktreePath,
+  );
 }
 
 export function sendLayout(

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface AgentState {
   hadToolsInTurn: boolean;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Path of git worktree directory, if agent was launched in a worktree */
+  worktreePath?: string;
   /** Timestamp of last JSONL data received (ms since epoch) */
   lastDataAt: number;
   /** Total JSONL lines processed for this agent */
@@ -70,6 +72,8 @@ export interface PersistedAgent {
   projectDir: string;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Path of git worktree directory, if agent was launched in a worktree */
+  worktreePath?: string;
 
   // -- Agent Teams --
   teamName?: string;

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -71,6 +71,7 @@ function App() {
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    isGitRepo,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -326,6 +327,7 @@ function App() {
         isSettingsOpen={isSettingsOpen}
         onToggleSettings={() => setIsSettingsOpen((v) => !v)}
         workspaceFolders={workspaceFolders}
+        isGitRepo={isGitRepo}
       />
 
       <VersionIndicator

--- a/webview-ui/src/components/BottomToolbar.tsx
+++ b/webview-ui/src/components/BottomToolbar.tsx
@@ -12,6 +12,7 @@ interface BottomToolbarProps {
   isSettingsOpen: boolean;
   onToggleSettings: () => void;
   workspaceFolders: WorkspaceFolder[];
+  isGitRepo?: boolean;
 }
 
 export function BottomToolbar({
@@ -21,9 +22,11 @@ export function BottomToolbar({
   isSettingsOpen,
   onToggleSettings,
   workspaceFolders,
+  isGitRepo,
 }: BottomToolbarProps) {
   const [isFolderPickerOpen, setIsFolderPickerOpen] = useState(false);
   const [isBypassMenuOpen, setIsBypassMenuOpen] = useState(false);
+  const [isWorktreeMode, setIsWorktreeMode] = useState(false);
   const folderPickerRef = useRef<HTMLDivElement>(null);
   const pendingBypassRef = useRef(false);
   // Close folder picker / bypass menu on outside click
@@ -44,6 +47,10 @@ export function BottomToolbar({
   const handleAgentClick = () => {
     setIsBypassMenuOpen(false);
     pendingBypassRef.current = false;
+    if (isWorktreeMode) {
+      vscode.postMessage({ type: 'requestWorktreeAgent', bypassPermissions: false });
+      return;
+    }
     if (hasMultipleFolders) {
       setIsFolderPickerOpen((v) => !v);
     } else {
@@ -72,6 +79,10 @@ export function BottomToolbar({
 
   const handleBypassSelect = (bypassPermissions: boolean) => {
     setIsBypassMenuOpen(false);
+    if (isWorktreeMode) {
+      vscode.postMessage({ type: 'requestWorktreeAgent', bypassPermissions });
+      return;
+    }
     if (hasMultipleFolders) {
       pendingBypassRef.current = bypassPermissions;
       setIsFolderPickerOpen(true);
@@ -97,9 +108,14 @@ export function BottomToolbar({
               : 'bg-accent hover:bg-accent-bright'
           }
         >
-          + Agent
+          + Agent{isWorktreeMode ? ' ⊕' : ''}
         </Button>
         <Dropdown isOpen={isBypassMenuOpen}>
+          {isGitRepo && (
+            <DropdownItem onClick={() => setIsWorktreeMode((v) => !v)}>
+              {isWorktreeMode ? '☑' : '☐'} New worktree branch
+            </DropdownItem>
+          )}
           <DropdownItem onClick={() => handleBypassSelect(true)}>
             Skip permissions mode <span className="text-2xs text-warning">⚠</span>
           </DropdownItem>

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -66,6 +66,7 @@ interface ExtensionMessageState {
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
+  isGitRepo: boolean;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -103,6 +104,7 @@ export function useExtensionMessages(
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
+  const [isGitRepo, setIsGitRepo] = useState(false);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -469,6 +471,9 @@ export function useExtensionMessages(
         if (typeof msg.hooksInfoShown === 'boolean') {
           setHooksInfoShown(msg.hooksInfoShown as boolean);
         }
+        if (typeof msg.isGitRepo === 'boolean') {
+          setIsGitRepo(msg.isGitRepo as boolean);
+        }
         if (Array.isArray(msg.externalAssetDirectories)) {
           setExternalAssetDirectories(msg.externalAssetDirectories as string[]);
         }
@@ -534,5 +539,6 @@ export function useExtensionMessages(
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    isGitRepo,
   };
 }


### PR DESCRIPTION
## Summary

Adds support for spawning an agent in a fresh git worktree, so parallel agents can work on the same repo without stepping on each other's working tree. Optional toggle in the `+ Agent` dropdown; combines with the existing "Skip permissions mode" flag.

## How it works

1. Hover `+ Agent` → new **`☐ New worktree branch`** toggle appears above `Skip permissions mode`. Works with normal and bypass modes.

   
<img width="273" height="198" alt="image" src="https://github.com/user-attachments/assets/b0166b91-dbd3-4cdd-b20d-964028033b14" />


2. Toggle on → button label becomes `+ Agent ⊕`. Click → VS Code prompts for a branch name (empty = timestamp default `worktree-YYYYMMDD-HHMMSS`).

   
<img width="317" height="208" alt="image" src="https://github.com/user-attachments/assets/f202b116-e59e-46d8-9dbc-de35e07ed2b5" />

   

---


<img width="611" height="111" alt="image" src="https://github.com/user-attachments/assets/150858b9-bf39-4853-87f0-7343da534c3b" />


3. Extension runs `git worktree add .worktrees/<branch> -b <branch>` off `HEAD` (same semantics as `git checkout -b`), spawns a new terminal with `cwd` set to the worktree, launches Claude there.

4. Character label shows the worktree name with a `⊕` marker so you can tell worktree agents apart at a glance.

   
<img width="837" height="611" alt="image" src="https://github.com/user-attachments/assets/4559ae30-456c-4569-bc35-edc78427ade4" />


5. On close (via × in UI or closing the terminal directly), VS Code prompts to clean up. **Yes** runs `git worktree remove --force` + `git branch -D`.

   
<img width="491" height="161" alt="image" src="https://github.com/user-attachments/assets/c47fce73-9884-47cd-ba0e-2cc70df271d2" />


## Also included — restore bug fix

Found while testing: `restoreAgents` ran a 10s cleanup that queried **all** non-external agents in the map and killed any with `linesProcessed === 0`. Since `webviewReady` fires on every panel focus, a freshly-launched agent would get killed ~10s after the panel was re-focused.

Fix: track only terminals newly restored in the current call (`newlyRestoredTerminalIds`) instead of every agent in the map. Same filter logic (`!isExternal` + had a matching live terminal), just scoped correctly.

## Files

- `src/types.ts` — `worktreePath?: string` on `AgentState` + `PersistedAgent`
- `src/agentManager.ts` — new `launchWorktreeAgent()`, `worktreePath` threaded through `launchNewTerminal`/persist/restore, `⊕ <branch>` folder label, `restoreAgents` cleanup scoping fix
- `src/PixelAgentsViewProvider.ts` — `requestWorktreeAgent` handler, `promptRemoveWorktree` helper called from both close paths, `isGitRepo` in `settingsLoaded`
- `webview-ui/src/hooks/useExtensionMessages.ts` — `isGitRepo` state
- `webview-ui/src/App.tsx` — pass `isGitRepo` to `BottomToolbar`
- `webview-ui/src/components/BottomToolbar.tsx` — `New worktree branch` toggle, `+ Agent ⊕` label

## Test plan

- [ ] Toggle hidden when workspace is not a git repo
- [ ] Empty branch name → timestamp default
- [ ] Worktree created under `.worktrees/<branch>`, terminal cwd is the worktree
- [ ] Branch forks from current `HEAD`
- [ ] Close via × in UI → both worktree and branch removed
- [ ] Close via terminal tab × → same cleanup dialog
- [ ] Combine with `Skip permissions mode` → `--dangerously-skip-permissions` passed through
- [ ] Panel re-focus does not kill live agents (restoreAgents fix)