### PR TITLE
fix: improve character animation timing and add idle breathing

### DIFF
--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -10,22 +10,24 @@ export const MAX_ROWS = 64;
 // ── Character Animation ─────────────────────────────────────
 export const WALK_SPEED_PX_PER_SEC = 48;
 export const WALK_FRAME_DURATION_SEC = 0.15;
-export const TYPE_FRAME_DURATION_SEC = 0.3;
-export const WANDER_PAUSE_MIN_SEC = 2.0;
-export const WANDER_PAUSE_MAX_SEC = 20.0;
-export const WANDER_MOVES_BEFORE_REST_MIN = 3;
-export const WANDER_MOVES_BEFORE_REST_MAX = 6;
-export const SEAT_REST_MIN_SEC = 120.0;
-export const SEAT_REST_MAX_SEC = 240.0;
+export const TYPE_FRAME_DURATION_SEC = 0.18;
+export const WANDER_PAUSE_MIN_SEC = 1.0;
+export const WANDER_PAUSE_MAX_SEC = 6.0;
+export const WANDER_MOVES_BEFORE_REST_MIN = 5;
+export const WANDER_MOVES_BEFORE_REST_MAX = 12;
+export const SEAT_REST_MIN_SEC = 30.0;
+export const SEAT_REST_MAX_SEC = 70.0;
+/** Duration of idle breathing animation frame (cycles walk frames 0↔1). */
+export const IDLE_FRAME_DURATION_SEC = 2.5;
 
 // ── Matrix Effect ────────────────────────────────────────────
-export const MATRIX_EFFECT_DURATION_SEC = 0.3;
+export const MATRIX_EFFECT_DURATION_SEC = 1.8;
 export const MATRIX_TRAIL_LENGTH = 6;
 export const MATRIX_SPRITE_COLS = 16;
 export const MATRIX_SPRITE_ROWS = 24;
 export const MATRIX_FLICKER_FPS = 30;
 export const MATRIX_FLICKER_VISIBILITY_THRESHOLD = 180;
-export const MATRIX_COLUMN_STAGGER_RANGE = 0.3;
+export const MATRIX_COLUMN_STAGGER_RANGE = 0.4;
 export const MATRIX_HEAD_COLOR = '#ccffcc';
 export const matrixGreenBright = (a: number): string => `rgba(0, 255, 65, ${a})`;
 export const matrixGreenMid = (a: number): string => `rgba(0, 170, 40, ${a})`;
@@ -49,7 +51,7 @@ export const BUTTON_RADIUS_ZOOM_FACTOR = 3;
 export const BUTTON_ICON_SIZE_FACTOR = 0.45;
 export const BUTTON_LINE_WIDTH_MIN = 1.5;
 export const BUTTON_LINE_WIDTH_ZOOM_FACTOR = 0.5;
-export const BUBBLE_FADE_DURATION_SEC = 0.5;
+export const BUBBLE_FADE_DURATION_SEC = 1.5;
 export const BUBBLE_SITTING_OFFSET_PX = 10;
 export const BUBBLE_VERTICAL_OFFSET_PX = 24;
 export const FALLBACK_FLOOR_COLOR = '#808080';
@@ -120,10 +122,10 @@ export const WHATS_NEW_FADE_MS = 1000;
 
 // ── Game Logic ───────────────────────────────────────────────
 export const MAX_DELTA_TIME_SEC = 0.1;
-export const WAITING_BUBBLE_DURATION_SEC = 2.0;
-export const DISMISS_BUBBLE_FAST_FADE_SEC = 0.3;
-export const INACTIVE_SEAT_TIMER_MIN_SEC = 3.0;
-export const INACTIVE_SEAT_TIMER_RANGE_SEC = 2.0;
+export const WAITING_BUBBLE_DURATION_SEC = 15.0;
+export const DISMISS_BUBBLE_FAST_FADE_SEC = 2.0;
+export const INACTIVE_SEAT_TIMER_MIN_SEC = 1.5;
+export const INACTIVE_SEAT_TIMER_RANGE_SEC = 1.0;
 /** Default/fallback palette count (bundled characters). Actual count comes from getLoadedCharacterCount(). */
 export const PALETTE_COUNT = 6;
 export const HUE_SHIFT_MIN_DEG = 45;

--- a/webview-ui/src/office/engine/characters.ts
+++ b/webview-ui/src/office/engine/characters.ts
@@ -1,4 +1,5 @@
 import {
+  IDLE_FRAME_DURATION_SEC,
   SEAT_REST_MAX_SEC,
   SEAT_REST_MIN_SEC,
   TYPE_FRAME_DURATION_SEC,
@@ -123,8 +124,11 @@ export function updateCharacter(
     }
 
     case CharacterState.IDLE: {
-      // No idle animation — static pose
-      ch.frame = 0;
+      // Idle breathing animation — cycle between walk frames 0 and 1
+      if (ch.frameTimer >= IDLE_FRAME_DURATION_SEC) {
+        ch.frameTimer -= IDLE_FRAME_DURATION_SEC;
+        ch.frame = (ch.frame + 1) % 2;
+      }
       if (ch.seatTimer < 0) ch.seatTimer = 0; // clear turn-end sentinel
       // If became active, pathfind to seat
       if (ch.isActive) {
@@ -327,7 +331,7 @@ export function getCharacterSprite(ch: Character, sprites: CharacterSprites): Sp
     case CharacterState.WALK:
       return sprites.walk[ch.dir][ch.frame % 4];
     case CharacterState.IDLE:
-      return sprites.walk[ch.dir][1];
+      return sprites.walk[ch.dir][ch.frame % 2];
     default:
       return sprites.walk[ch.dir][1];
   }


### PR DESCRIPTION
## Summary

Characters currently feel static between movements — typing is slow, status bubbles vanish too fast to read, the matrix spawn effect is nearly invisible, and idle characters are completely still. This PR makes the office feel more alive through targeted timing adjustments and a subtle idle breathing animation.

## Changes

All changes are isolated to constant values and one small animation loop — no architectural changes, no new dependencies, no new assets needed.

### Timing constants (`webview-ui/src/constants.ts`)

| Constant | Before | After | Why |
|----------|--------|-------|-----|
| `TYPE_FRAME_DURATION_SEC` | 0.3 | 0.18 | Faster, more energetic typing animation |
| `SEAT_REST_MIN/MAX_SEC` | 120–240 | 30–70 | Characters get up and wander more often |
| `WANDER_PAUSE_MIN/MAX_SEC` | 2–20 | 1–6 | Smoother, more natural roaming |
| `WANDER_MOVES_BEFORE_REST_MIN/MAX` | 3–6 | 5–12 | Characters explore further before sitting |
| `INACTIVE_SEAT_TIMER_MIN_SEC` | 3.0 | 1.5 | Quicker idle transition |
| `INACTIVE_SEAT_TIMER_RANGE_SEC` | 2.0 | 1.0 | Less variance in idle timing |
| `WAITING_BUBBLE_DURATION_SEC` | 2.0 | 15.0 | Users can actually read tool status text |
| `DISMISS_BUBBLE_FAST_FADE_SEC` | 0.3 | 2.0 | Smoother bubble fade-out |
| `BUBBLE_FADE_DURATION_SEC` | 0.5 | 1.5 | Gentler transition when bubbles disappear |
| `MATRIX_EFFECT_DURATION_SEC` | 0.3 | 1.8 | Sub-agent spawn effect becomes clearly visible |
| `MATRIX_COLUMN_STAGGER_RANGE` | 0.3 | 0.4 | More dramatic cascading rain effect |

### Idle breathing animation (`webview-ui/src/office/engine/characters.ts`)

- New `IDLE_FRAME_DURATION_SEC = 2.5` constant
- IDLE state now cycles between walk frames 0 and 1 every 2.5s
- Characters subtly "breathe" instead of standing completely frozen
- Uses existing walk sprite frames — no new assets needed

## Why this matters

The core appeal of Pixel Agents is watching characters react to your development workflow. These changes make the office feel alive during both active work and idle periods, without changing any architecture or adding dependencies.

Closes #100