### PR TITLE
feat: add token counter overlay

### DIFF
--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -42,6 +42,7 @@ import {
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
   GLOBAL_KEY_LAST_SEEN_VERSION,
+  GLOBAL_KEY_SHOW_TOKEN_COUNTER,
   GLOBAL_KEY_SOUND_ENABLED,
   GLOBAL_KEY_WATCH_ALL_SESSIONS,
   LAYOUT_REVISION_KEY,
@@ -401,6 +402,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
       } else if (message.type === 'saveLayout') {
         this.layoutWatcher?.markOwnWrite();
         writeLayoutToFile(message.layout as Record<string, unknown>);
+      } else if (message.type === 'setShowTokenCounter') {
+        this.context.globalState.update(GLOBAL_KEY_SHOW_TOKEN_COUNTER, message.enabled);
       } else if (message.type === 'setSoundEnabled') {
         this.context.globalState.update(GLOBAL_KEY_SOUND_ENABLED, message.enabled);
       } else if (message.type === 'setLastSeenVersion') {
@@ -507,6 +510,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           GLOBAL_KEY_HOOKS_INFO_SHOWN,
           false,
         );
+        const showTokenCounter = this.context.globalState.get<boolean>(
+          GLOBAL_KEY_SHOW_TOKEN_COUNTER,
+          true,
+        );
         const config = readConfig();
         this.webview?.postMessage({
           type: 'settingsLoaded',
@@ -517,6 +524,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           alwaysShowLabels,
           hooksEnabled,
           hooksInfoShown,
+          showTokenCounter,
           externalAssetDirectories: config.externalAssetDirectories,
         });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const GLOBAL_KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
 export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 export const GLOBAL_KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
+export const GLOBAL_KEY_SHOW_TOKEN_COUNTER = 'pixel-agents.showTokenCounter';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { DebugView } from './components/DebugView.js';
 import { EditActionBar } from './components/EditActionBar.js';
 import { MigrationNotice } from './components/MigrationNotice.js';
 import { SettingsModal } from './components/SettingsModal.js';
+import { TokenCounter } from './components/TokenCounter.js';
 import { Tooltip } from './components/Tooltip.js';
 import { Modal } from './components/ui/Modal.js';
 import { VersionIndicator } from './components/VersionIndicator.js';
@@ -71,6 +72,9 @@ function App() {
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    agentTokens,
+    showTokenCounter,
+    setShowTokenCounter,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -190,6 +194,8 @@ function App() {
       {!isDebugMode ? (
         <>
           <ZoomControls zoom={editor.zoom} onZoomChange={editor.handleZoomChange} />
+
+          {showTokenCounter && <TokenCounter agentTokens={agentTokens} />}
 
           {/* Vignette overlay */}
           <div
@@ -360,6 +366,12 @@ function App() {
           const newVal = !hooksEnabled;
           setHooksEnabled(newVal);
           vscode.postMessage({ type: 'setHooksEnabled', enabled: newVal });
+        }}
+        showTokenCounter={showTokenCounter}
+        onToggleShowTokenCounter={() => {
+          const newVal = !showTokenCounter;
+          setShowTokenCounter(newVal);
+          vscode.postMessage({ type: 'setShowTokenCounter', enabled: newVal });
         }}
       />
 

--- a/webview-ui/src/browserMock.ts
+++ b/webview-ui/src/browserMock.ts
@@ -261,7 +261,14 @@ export function dispatchMockMessages(): void {
     soundEnabled: false,
     extensionVersion: '1.3.0',
     lastSeenVersion: '1.2',
+    showTokenCounter: true,
   });
+
+  // Mock agents with token usage so the full UI is visible in dev
+  dispatch({ type: 'agentCreated', id: 1, folderName: 'pixel-agents' });
+  dispatch({ type: 'agentCreated', id: 2, folderName: 'pixel-agents' });
+  dispatch({ type: 'agentTokenUsage', id: 1, inputTokens: 124800, outputTokens: 31200 });
+  dispatch({ type: 'agentTokenUsage', id: 2, inputTokens: 87500, outputTokens: 18300 });
 
   console.log('[BrowserMock] Messages dispatched');
 }

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -19,6 +19,8 @@ interface SettingsModalProps {
   onToggleWatchAllSessions: () => void;
   hooksEnabled: boolean;
   onToggleHooksEnabled: () => void;
+  showTokenCounter: boolean;
+  onToggleShowTokenCounter: () => void;
 }
 
 export function SettingsModal({
@@ -33,6 +35,8 @@ export function SettingsModal({
   onToggleWatchAllSessions,
   hooksEnabled,
   onToggleHooksEnabled,
+  showTokenCounter,
+  onToggleShowTokenCounter,
 }: SettingsModalProps) {
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
 
@@ -107,6 +111,11 @@ export function SettingsModal({
         label="Instant Detection (Hooks)"
         checked={hooksEnabled}
         onChange={onToggleHooksEnabled}
+      />
+      <Checkbox
+        label="Token Counter"
+        checked={showTokenCounter}
+        onChange={onToggleShowTokenCounter}
       />
       <Checkbox
         label="Always Show Labels"

--- a/webview-ui/src/components/TokenCounter.tsx
+++ b/webview-ui/src/components/TokenCounter.tsx
@@ -1,0 +1,65 @@
+import {
+  FUEL_COLOR_CRITICAL,
+  FUEL_COLOR_DANGER,
+  FUEL_COLOR_OK,
+  FUEL_COLOR_WARN,
+  MAX_CONTEXT_TOKENS,
+  TOKEN_CRITICAL_THRESHOLD,
+  TOKEN_DANGER_THRESHOLD,
+  TOKEN_WARN_THRESHOLD,
+} from '../constants.js';
+
+interface AgentTokens {
+  input: number;
+  output: number;
+}
+
+interface TokenCounterProps {
+  agentTokens: Record<number, AgentTokens>;
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export function TokenCounter({ agentTokens }: TokenCounterProps) {
+  const entries = Object.values(agentTokens);
+  if (entries.length === 0) return null;
+
+  let totalInput = 0;
+  let totalOutput = 0;
+  let maxInput = 0;
+
+  for (const { input, output } of entries) {
+    totalInput += input;
+    totalOutput += output;
+    if (input > maxInput) maxInput = input;
+  }
+
+  const ratio = maxInput / MAX_CONTEXT_TOKENS;
+  const color =
+    ratio >= TOKEN_CRITICAL_THRESHOLD
+      ? FUEL_COLOR_CRITICAL
+      : ratio >= TOKEN_DANGER_THRESHOLD
+        ? FUEL_COLOR_DANGER
+        : ratio >= TOKEN_WARN_THRESHOLD
+          ? FUEL_COLOR_WARN
+          : FUEL_COLOR_OK;
+
+  return (
+    <div className="absolute top-8 right-8 z-10 pixel-panel px-10 py-6 select-none pointer-events-none">
+      <div className="flex flex-col gap-2 text-2xs tabular-nums" style={{ color }}>
+        <div className="flex gap-6 justify-between">
+          <span className="text-text-muted">in</span>
+          <span>{fmt(totalInput)}</span>
+        </div>
+        <div className="flex gap-6 justify-between">
+          <span className="text-text-muted">out</span>
+          <span>{fmt(totalOutput)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -46,6 +46,11 @@ export interface WorkspaceFolder {
   path: string;
 }
 
+interface AgentTokens {
+  input: number;
+  output: number;
+}
+
 interface ExtensionMessageState {
   agents: number[];
   selectedAgent: number | null;
@@ -66,6 +71,9 @@ interface ExtensionMessageState {
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
+  agentTokens: Record<number, AgentTokens>;
+  showTokenCounter: boolean;
+  setShowTokenCounter: (v: boolean) => void;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -103,6 +111,8 @@ export function useExtensionMessages(
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
+  const [agentTokens, setAgentTokens] = useState<Record<number, AgentTokens>>({});
+  const [showTokenCounter, setShowTokenCounter] = useState(true);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -196,6 +206,12 @@ export function useExtensionMessages(
           return next;
         });
         setSubagentTools((prev) => {
+          if (!(id in prev)) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+        setAgentTokens((prev) => {
           if (!(id in prev)) return prev;
           const next = { ...prev };
           delete next[id];
@@ -469,6 +485,9 @@ export function useExtensionMessages(
         if (typeof msg.hooksInfoShown === 'boolean') {
           setHooksInfoShown(msg.hooksInfoShown as boolean);
         }
+        if (typeof msg.showTokenCounter === 'boolean') {
+          setShowTokenCounter(msg.showTokenCounter as boolean);
+        }
         if (Array.isArray(msg.externalAssetDirectories)) {
           setExternalAssetDirectories(msg.externalAssetDirectories as string[]);
         }
@@ -505,7 +524,10 @@ export function useExtensionMessages(
         );
       } else if (msg.type === 'agentTokenUsage') {
         const id = msg.id as number;
-        os.setAgentTokens(id, msg.inputTokens as number, msg.outputTokens as number);
+        const inputTokens = msg.inputTokens as number;
+        const outputTokens = msg.outputTokens as number;
+        os.setAgentTokens(id, inputTokens, outputTokens);
+        setAgentTokens((prev) => ({ ...prev, [id]: { input: inputTokens, output: outputTokens } }));
       }
     };
     window.addEventListener('message', handler);
@@ -534,5 +556,8 @@ export function useExtensionMessages(
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    agentTokens,
+    showTokenCounter,
+    setShowTokenCounter,
   };
 }


### PR DESCRIPTION
## Description
- Adds a compact token counter in the top-right corner of the office view showing cumulative `in` / `out` tokens across all active agents
- Color-coded using existing thresholds: green → yellow → orange → red as the most active agent's context fills up
- Toggleable via Settings → "Token Counter" checkbox (default: on, persisted in VS Code globalState)

## Type of change
<!-- Check the one that applies -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ...

## Related issues
Token counter #111
[Feature]: Add tokens used and tokens left #247 

## Screenshots / GIFs
<img width="120" height="93" alt="ui0" src="https://github.com/user-attachments/assets/4e7daa15-3564-444c-b4f1-f89b5729feb7" />
<img width="1568" height="928" alt="ui1" src="https://github.com/user-attachments/assets/cf573668-09ee-4f79-9d81-e683e4677a0f" />
<img width="504" height="587" alt="ui2" src="https://github.com/user-attachments/assets/7fe19df1-ac56-49d7-819f-fcfe275274a2" />

## Test plan

- [x] Open the Pixel Agents panel and start a Claude agent
- [x] Send a message to Claude and wait for a response --> the counter appears in the top-right with real token values
- [x] Open Settings and uncheck "Token Counter" --> counter disappears
- [x] Re-check "Token Counter" --> counter reappears
- [x] Close the agent --> counter disappears (tokens cleared on agent close)
- [x] Run `npm run build` and `npm test` --> all checks pass