### PR TITLE
fix: run npm install in server/ to resolve vitest build error

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pixel-agents-server-tests",
+  "name": "pixel-agents",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pixel-agents-server-tests",
+      "name": "pixel-agents",
       "devDependencies": {
         "vitest": "^3.2.1"
       }
@@ -550,9 +550,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +564,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -584,9 +578,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -601,9 +592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,9 +606,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,9 +620,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -652,9 +634,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,9 +648,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,9 +662,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,9 +676,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +690,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,9 +704,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,9 +718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## What

Commits the updated `server/package-lock.json` generated after running `npm install` inside the `server/` directory.

## Why

The `server/` subdirectory has its own `package.json` with `vitest` as a dev dependency, but it was never installed as part of the documented setup steps. This caused the build to fail with:

```
server/__tests__/*.test.ts: error TS2307: Cannot find module 'vitest'
```

The `npm run build` (and `npm run compile`) pipeline runs `tsc --noEmit -p server/tsconfig.test.json`, which type-checks the test files — so `vitest` must be installed for the build to succeed.

## Fix

Running `cd server && npm install` resolves the issue. The updated lockfile is the only file changed.

## Reviewer notes

- The `name` field in `server/package-lock.json` changed from `pixel-agents-server-tests` to `pixel-agents` (matches the `name` in `server/package.json`)
- A few platform-specific `libc` entries were removed — this is a platform difference between the original lockfile (Linux) and macOS arm64