### PR TITLE
fix: track knownJsonlFiles on adopt, reassign, and remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -275,7 +275,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						this.activeAgentId.current = null;
 					}
 					removeAgent(
-						id, this.agents,
+						id, this.agents, this.knownJsonlFiles,
 						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 						this.jsonlPollTimers, this.persistAgents,
 					);
@@ -316,7 +316,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 		this.layoutWatcher = null;
 		for (const id of [...this.agents.keys()]) {
 			removeAgent(
-				id, this.agents,
+				id, this.agents, this.knownJsonlFiles,
 				this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 				this.jsonlPollTimers, this.persistAgents,
 			);

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -100,6 +100,7 @@ export function launchNewTerminal(
 export function removeAgent(
 	agentId: number,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -126,7 +127,8 @@ export function removeAgent(
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 
-	// Remove from maps
+	// Remove from tracking
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agents.delete(agentId);
 	persistAgents();
 }

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -139,7 +139,8 @@ function scanForNewJsonlFiles(
 				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
 				reassignAgentToFile(
 					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+					agents, knownJsonlFiles,
+					fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 					webview, persistAgents,
 				);
 			} else {
@@ -156,7 +157,7 @@ function scanForNewJsonlFiles(
 					if (!owned) {
 						adoptTerminalForFile(
 							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
+							nextAgentIdRef, agents, activeAgentIdRef, knownJsonlFiles,
 							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 							webview, persistAgents,
 						);
@@ -174,6 +175,7 @@ function adoptTerminalForFile(
 	nextAgentIdRef: { current: number },
 	agents: Map<number, AgentState>,
 	activeAgentIdRef: { current: number | null },
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -200,6 +202,7 @@ function adoptTerminalForFile(
 	};
 
 	agents.set(id, agent);
+	knownJsonlFiles.add(jsonlFile);
 	activeAgentIdRef.current = id;
 	persistAgents();
 
@@ -214,6 +217,7 @@ export function reassignAgentToFile(
 	agentId: number,
 	newFilePath: string,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -236,8 +240,10 @@ export function reassignAgentToFile(
 	cancelPermissionTimer(agentId, permissionTimers);
 	clearAgentActivity(agent, agentId, permissionTimers, webview);
 
-	// Swap to new file
+	// Remove old file from known set, swap to new file
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agent.jsonlFile = newFilePath;
+	knownJsonlFiles.add(newFilePath);
 	agent.fileOffset = 0;
 	agent.lineBuffer = '';
 	persistAgents();


### PR DESCRIPTION
## Summary

Fixes three related bugs in JSONL file tracking that cause issues with `/clear` detection and terminal adoption:

- **`adoptTerminalForFile`**: Now adds the JSONL file to `knownJsonlFiles` after adoption, preventing repeated adoption attempts on every project scan cycle
- **`reassignAgentToFile`**: Now removes the old file and adds the new file to `knownJsonlFiles`, preventing infinite reassignment loops when `/clear` creates a new session file
- **`removeAgent`**: Now removes the agent's JSONL file from `knownJsonlFiles` on terminal close, preventing stale entries from blocking future `/clear` detection and keeping the set from growing unbounded

## Changes

- `src/fileWatcher.ts`: Added `knownJsonlFiles` parameter to `adoptTerminalForFile` and `reassignAgentToFile`, with proper add/delete calls
- `src/agentManager.ts`: Added `knownJsonlFiles` parameter to `removeAgent` with cleanup on agent removal
- `src/PixelAgentsViewProvider.ts`: Updated all `removeAgent` call sites to pass `knownJsonlFiles`

## Testing

- Type-checks pass (`tsc --noEmit`)
- No breaking changes to public API — only internal function signatures updated