### PR TITLE
fix: send existingAgents immediately after restore, regardless of project dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -98,6 +98,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 					this.jsonlPollTimers, this.projectScanTimer, this.activeAgentId,
 					this.webview, this.persistAgents,
 				);
+				// Send restored agents to webview now that the message handler is ready
+				sendExistingAgents(this.agents, this.context, this.webview);
 				// Send persisted settings to webview
 				const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
 				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
@@ -213,7 +215,6 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						}
 					})();
 				}
-				sendExistingAgents(this.agents, this.context, this.webview);
 			} else if (message.type === 'openSessionsFolder') {
 				const projectDir = getProjectDirPath();
 				if (projectDir && fs.existsSync(projectDir)) {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -275,7 +275,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						this.activeAgentId.current = null;
 					}
 					removeAgent(
-						id, this.agents,
+						id, this.agents, this.knownJsonlFiles,
 						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 						this.jsonlPollTimers, this.persistAgents,
 					);
@@ -316,7 +316,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 		this.layoutWatcher = null;
 		for (const id of [...this.agents.keys()]) {
 			removeAgent(
-				id, this.agents,
+				id, this.agents, this.knownJsonlFiles,
 				this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 				this.jsonlPollTimers, this.persistAgents,
 			);

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -100,6 +100,7 @@ export function launchNewTerminal(
 export function removeAgent(
 	agentId: number,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -126,7 +127,8 @@ export function removeAgent(
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 
-	// Remove from maps
+	// Remove from tracking
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agents.delete(agentId);
 	persistAgents();
 }

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -139,7 +139,8 @@ function scanForNewJsonlFiles(
 				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
 				reassignAgentToFile(
 					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+					agents, knownJsonlFiles,
+					fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 					webview, persistAgents,
 				);
 			} else {
@@ -156,7 +157,7 @@ function scanForNewJsonlFiles(
 					if (!owned) {
 						adoptTerminalForFile(
 							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
+							nextAgentIdRef, agents, activeAgentIdRef, knownJsonlFiles,
 							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 							webview, persistAgents,
 						);
@@ -174,6 +175,7 @@ function adoptTerminalForFile(
 	nextAgentIdRef: { current: number },
 	agents: Map<number, AgentState>,
 	activeAgentIdRef: { current: number | null },
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -200,6 +202,7 @@ function adoptTerminalForFile(
 	};
 
 	agents.set(id, agent);
+	knownJsonlFiles.add(jsonlFile);
 	activeAgentIdRef.current = id;
 	persistAgents();
 
@@ -214,6 +217,7 @@ export function reassignAgentToFile(
 	agentId: number,
 	newFilePath: string,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -236,8 +240,10 @@ export function reassignAgentToFile(
 	cancelPermissionTimer(agentId, permissionTimers);
 	clearAgentActivity(agent, agentId, permissionTimers, webview);
 
-	// Swap to new file
+	// Remove old file from known set, swap to new file
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agent.jsonlFile = newFilePath;
+	knownJsonlFiles.add(newFilePath);
 	agent.fileOffset = 0;
 	agent.lineBuffer = '';
 	persistAgents();


### PR DESCRIPTION
## Summary

Fixes a bug where restored agents were not sent to the webview when no project directory existed, and ensures `existingAgents` is sent at the correct time in the initialization sequence.

## Problem

`sendExistingAgents` was only called inside the `if (projectDir)` block of the `webviewReady` handler. This meant:
- When no project directory was available, restored agents were never communicated to the webview
- The call happened after async asset loading was initiated, creating unnecessary coupling between agent restoration and asset loading

## Fix

Move `sendExistingAgents` to fire immediately after `restoreAgents()` completes, before any async asset loading begins. This ensures:
- Restored agents are always sent to the webview regardless of project directory state
- The webview receives agent IDs and statuses as soon as its message handler is registered
- Cleaner separation between synchronous restoration and async asset loading