### PR TITLE
fix: replace boolean skip flag with exact mtime matching in layout watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- **JSONL file tracking** — Fixed three related bugs in `knownJsonlFiles` management that caused issues with `/clear` detection and terminal adoption:
+  - `adoptTerminalForFile` now adds the JSONL file to `knownJsonlFiles`, preventing repeated adoption attempts on every project scan cycle
+  - `reassignAgentToFile` now removes the old file and adds the new file to `knownJsonlFiles`, preventing infinite reassignment loops when `/clear` creates a new session file
+  - `removeAgent` now removes the agent's JSONL file from `knownJsonlFiles` on terminal close, preventing stale entries from blocking future `/clear` detection
+- **Agent restoration timing** — `sendExistingAgents` now fires immediately after `restoreAgents()` completes, ensuring restored agents are always communicated to the webview regardless of project directory state
+- **Layout watcher race condition** — Replaced boolean `skipNextChange` flag with exact mtime matching in the cross-window layout file watcher, preventing legitimate external changes from being incorrectly skipped when multiple VS Code windows write in quick succession

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixel-agents",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-agents",
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@types/node": "22.x",
@@ -827,7 +828,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1628,7 +1627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,7 +3823,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3967,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -98,6 +98,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 					this.jsonlPollTimers, this.projectScanTimer, this.activeAgentId,
 					this.webview, this.persistAgents,
 				);
+				// Send restored agents to webview now that the message handler is ready
+				sendExistingAgents(this.agents, this.context, this.webview);
 				// Send persisted settings to webview
 				const soundEnabled = this.context.globalState.get<boolean>(GLOBAL_KEY_SOUND_ENABLED, true);
 				this.webview?.postMessage({ type: 'settingsLoaded', soundEnabled });
@@ -213,7 +215,6 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						}
 					})();
 				}
-				sendExistingAgents(this.agents, this.context, this.webview);
 			} else if (message.type === 'openSessionsFolder') {
 				const projectDir = getProjectDirPath();
 				if (projectDir && fs.existsSync(projectDir)) {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -85,8 +85,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 				console.log(`[Pixel Agents] saveAgentSeats:`, JSON.stringify(message.seats));
 				this.context.workspaceState.update(WORKSPACE_KEY_AGENT_SEATS, message.seats);
 			} else if (message.type === 'saveLayout') {
-				this.layoutWatcher?.markOwnWrite();
 				writeLayoutToFile(message.layout as Record<string, unknown>);
+				this.layoutWatcher?.markOwnWrite();
 			} else if (message.type === 'setSoundEnabled') {
 				this.context.globalState.update(GLOBAL_KEY_SOUND_ENABLED, message.enabled);
 			} else if (message.type === 'webviewReady') {
@@ -247,8 +247,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						vscode.window.showErrorMessage('Pixel Agents: Invalid layout file.');
 						return;
 					}
-					this.layoutWatcher?.markOwnWrite();
 					writeLayoutToFile(imported);
+					this.layoutWatcher?.markOwnWrite();
 					this.webview?.postMessage({ type: 'layoutLoaded', layout: imported });
 					vscode.window.showInformationMessage('Pixel Agents: Layout imported successfully.');
 				} catch {

--- a/src/PixelAgentsViewProvider.ts
+++ b/src/PixelAgentsViewProvider.ts
@@ -275,7 +275,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 						this.activeAgentId.current = null;
 					}
 					removeAgent(
-						id, this.agents,
+						id, this.agents, this.knownJsonlFiles,
 						this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 						this.jsonlPollTimers, this.persistAgents,
 					);
@@ -316,7 +316,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 		this.layoutWatcher = null;
 		for (const id of [...this.agents.keys()]) {
 			removeAgent(
-				id, this.agents,
+				id, this.agents, this.knownJsonlFiles,
 				this.fileWatchers, this.pollingTimers, this.waitingTimers, this.permissionTimers,
 				this.jsonlPollTimers, this.persistAgents,
 			);

--- a/src/agentManager.ts
+++ b/src/agentManager.ts
@@ -100,6 +100,7 @@ export function launchNewTerminal(
 export function removeAgent(
 	agentId: number,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -126,7 +127,8 @@ export function removeAgent(
 	cancelWaitingTimer(agentId, waitingTimers);
 	cancelPermissionTimer(agentId, permissionTimers);
 
-	// Remove from maps
+	// Remove from tracking
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agents.delete(agentId);
 	persistAgents();
 }

--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -139,7 +139,8 @@ function scanForNewJsonlFiles(
 				console.log(`[Pixel Agents] New JSONL detected: ${path.basename(file)}, reassigning to agent ${activeAgentIdRef.current}`);
 				reassignAgentToFile(
 					activeAgentIdRef.current, file,
-					agents, fileWatchers, pollingTimers, waitingTimers, permissionTimers,
+					agents, knownJsonlFiles,
+					fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 					webview, persistAgents,
 				);
 			} else {
@@ -156,7 +157,7 @@ function scanForNewJsonlFiles(
 					if (!owned) {
 						adoptTerminalForFile(
 							activeTerminal, file, projectDir,
-							nextAgentIdRef, agents, activeAgentIdRef,
+							nextAgentIdRef, agents, activeAgentIdRef, knownJsonlFiles,
 							fileWatchers, pollingTimers, waitingTimers, permissionTimers,
 							webview, persistAgents,
 						);
@@ -174,6 +175,7 @@ function adoptTerminalForFile(
 	nextAgentIdRef: { current: number },
 	agents: Map<number, AgentState>,
 	activeAgentIdRef: { current: number | null },
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -200,6 +202,7 @@ function adoptTerminalForFile(
 	};
 
 	agents.set(id, agent);
+	knownJsonlFiles.add(jsonlFile);
 	activeAgentIdRef.current = id;
 	persistAgents();
 
@@ -214,6 +217,7 @@ export function reassignAgentToFile(
 	agentId: number,
 	newFilePath: string,
 	agents: Map<number, AgentState>,
+	knownJsonlFiles: Set<string>,
 	fileWatchers: Map<number, fs.FSWatcher>,
 	pollingTimers: Map<number, ReturnType<typeof setInterval>>,
 	waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
@@ -236,8 +240,10 @@ export function reassignAgentToFile(
 	cancelPermissionTimer(agentId, permissionTimers);
 	clearAgentActivity(agent, agentId, permissionTimers, webview);
 
-	// Swap to new file
+	// Remove old file from known set, swap to new file
+	knownJsonlFiles.delete(agent.jsonlFile);
 	agent.jsonlFile = newFilePath;
+	knownJsonlFiles.add(newFilePath);
 	agent.fileOffset = 0;
 	agent.lineBuffer = '';
 	persistAgents();

--- a/src/layoutPersistence.ts
+++ b/src/layoutPersistence.ts
@@ -87,7 +87,7 @@ export function watchLayoutFile(
 	onExternalChange: (layout: Record<string, unknown>) => void,
 ): LayoutWatcher {
 	const filePath = getLayoutFilePath();
-	let skipNextChange = false;
+	let expectedOwnMtime: number | null = null;
 	let lastMtime = 0;
 	let fsWatcher: fs.FSWatcher | null = null;
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -108,8 +108,9 @@ export function watchLayoutFile(
 			if (stat.mtimeMs <= lastMtime) return;
 			lastMtime = stat.mtimeMs;
 
-			if (skipNextChange) {
-				skipNextChange = false;
+			// Skip only if this exact mtime matches our own write
+			if (expectedOwnMtime !== null && stat.mtimeMs === expectedOwnMtime) {
+				expectedOwnMtime = null;
 				return;
 			}
 
@@ -153,11 +154,10 @@ export function watchLayoutFile(
 
 	return {
 		markOwnWrite(): void {
-			skipNextChange = true;
-			// Update lastMtime preemptively so a near-instant poll doesn't miss the flag
+			// Called AFTER writeLayoutToFile — record the actual mtime of our write
 			try {
 				if (fs.existsSync(filePath)) {
-					lastMtime = fs.statSync(filePath).mtimeMs;
+					expectedOwnMtime = fs.statSync(filePath).mtimeMs;
 				}
 			} catch { /* ignore */ }
 		},


### PR DESCRIPTION
## Summary

Fixes a race condition in the layout file watcher where legitimate external changes from other VS Code windows could be incorrectly skipped.

## Problem

The layout watcher used a boolean `skipNextChange` flag to ignore our own writes. This had a race condition: if an external write from another VS Code window happened between our `markOwnWrite()` call and the next poll cycle, the combined mtime change would consume the skip flag, causing the external change to be silently dropped.

## Fix

Replace the boolean flag with exact mtime matching:
- `markOwnWrite()` now reads the actual file mtime **after** `writeLayoutToFile()` completes and stores it as `expectedOwnMtime`
- `checkForChange()` skips only when the detected mtime matches `expectedOwnMtime` exactly
- If an external write produces a different mtime, it is correctly processed as an external change

This ensures that even when multiple VS Code windows write to the layout file in quick succession, each window correctly processes the others' changes.