### PR TITLE
feat: Cursor IDE support + agent progress tooltip (port of PR #136)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,16 @@
 # Pixel Agents — Compressed Reference
 
-VS Code extension with embedded React webview: pixel art office where AI agents (Claude Code terminals) are animated characters.
+VS Code / Cursor IDE extension with embedded React webview: pixel art office where AI agents (Claude Code terminals) are animated characters.
+
+## Cursor IDE Compatibility
+
+Extension works in both VS Code and Cursor IDE (a VS Code fork). Key adaptations:
+
+- `engines.vscode` lowered to `^1.85.0` for Cursor compatibility (Cursor is based on VS Code ~1.93.x)
+- `adapters/vscode/ideDetector.ts` detects IDE at runtime via `vscode.env.appName`
+- IDE type passed to webview via `ideInfo` message, displayed in Settings modal
+- To install in Cursor: package as VSIX (`vsce package`) and install via Cursor's "Install from VSIX" option
+- `adoptExistingTerminals()` in `adapters/vscode/agentManager.ts` matches pre-open Claude terminals to recent JSONL files on startup
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,25 @@ This is the source code for the free Pixel Agents extension for VS Code — inst
 
 ## Requirements
 
-- VS Code 1.105.0 or later
+- **VS Code 1.85.0+** or **Cursor IDE** (any recent version)
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
 - **Platform**: Windows, Linux, and macOS are supported
 
 ## Getting Started
 
-If you just want to use Pixel Agents, the easiest way is to download the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents). If you want to play with the code, develop, or contribute, then:
+If you just want to use Pixel Agents, install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) or [Open VSX](https://open-vsx.org/extension/pablodelucca/pixel-agents).
+
+### Install on Cursor IDE
+
+Cursor does not include the VS Code Marketplace. Install manually via a `.vsix` file:
+
+1. Build or download a VSIX (`npx @vscode/vsce package --allow-missing-repository`)
+2. In Cursor: **Command Palette** → **Extensions: Install from VSIX...**
+3. Or run: `cursor --install-extension pixel-agents-x.x.x.vsix`
+
+> Manually installed extensions do not auto-update.
+
+If you want to play with the code, develop, or contribute:
 
 ### Install from source
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,635 @@
+# Pixel Agents — Premium Features Roadmap
+
+> This file tracks the implementation progress of all premium features.
+> It serves as both a **report** and a **continuity guide** for agents resuming work in new sessions.
+>
+> **How to use this file:**
+>
+> - Before starting work, read this file to understand current state
+> - After completing a feature/task, update the status and add notes
+> - Each feature has acceptance criteria — mark them as done when complete
+> - Sprint sections at the bottom track what's in progress
+
+---
+
+## Feature List (ordered by implementation complexity)
+
+| #   | Feature                     | Epic          | Complexity | Status    | Sprint   |
+| --- | --------------------------- | ------------- | ---------- | --------- | -------- |
+| F01 | Agent Hover Tooltip         | Agent UX      | XS         | `done`    | Sprint 1 |
+| F02 | Smart Notifications         | Agent UX      | S          | `backlog` | —        |
+| F03 | Agent Templates / Presets   | Agent Config  | S          | `backlog` | —        |
+| F04 | Activity Timeline           | Analytics     | M          | `backlog` | —        |
+| F05 | Agent Dashboard (metrics)   | Analytics     | M          | `backlog` | —        |
+| F06 | Cost Budget & Guardrails    | Analytics     | M          | `backlog` | —        |
+| F07 | File Heatmap                | Visualization | M          | `backlog` | —        |
+| F08 | Git Awareness               | Integration   | L          | `backlog` | —        |
+| F09 | Agent Orchestration / Teams | Orchestration | L          | `backlog` | —        |
+| F10 | Agent Performance Scoring   | Analytics     | L          | `backlog` | —        |
+| F11 | Project Map View            | Visualization | XL         | `backlog` | —        |
+
+**Status values:** `backlog` → `in_progress` → `review` → `done`
+**Complexity:** XS (<1h), S (1-4h), M (4-12h), L (1-3 days), XL (3+ days)
+
+---
+
+## F01 — Agent Hover Tooltip
+
+**Epic:** Agent UX
+**Complexity:** XS
+**Status:** `done`
+**Branch:** `feat/cursor-ide-support` (included in initial PR)
+
+### Description
+
+When hovering over an agent character in the office, show a tooltip with:
+
+- Agent name / terminal name
+- Current task description (extracted from the most recent JSONL tool_use)
+- Completion percentage estimate (based on tool activity patterns)
+- Current status (active, waiting, permission)
+
+### Acceptance Criteria
+
+- [ ] Tooltip appears on mouse hover over character sprite
+- [ ] Shows agent ID/name and folder name (if multi-root)
+- [ ] Shows current tool activity (e.g., "Editing: src/app.tsx")
+- [ ] Shows estimated progress percentage with visual bar
+- [ ] Tooltip disappears on mouse leave
+- [ ] Does not interfere with click-to-select behavior
+- [ ] Works for both regular agents and sub-agents
+
+### Technical Notes
+
+- Hover detection already exists in `OfficeCanvas.tsx` (mouse hit-testing)
+- Tool activity data is in `agentTools` state from `useExtensionMessages`
+- Progress estimation: count tool_use events in current turn vs average turn length
+- Render as HTML overlay (not canvas) for text clarity
+
+### Files to modify
+
+- `webview-ui/src/office/components/OfficeCanvas.tsx` — hover detection
+- `webview-ui/src/office/components/ToolOverlay.tsx` — tooltip rendering
+- `webview-ui/src/hooks/useExtensionMessages.ts` — track tool counts for progress
+- `src/transcriptParser.ts` — extract task description from JSONL
+
+### Implementation Notes
+
+- Tooltip already existed for hover/selected agents in `ToolOverlay.tsx` — enhanced it
+- Added agent label (folder name or "Agent #N") above activity text
+- Progress bar uses logarithmic curve: `(1 - e^(-toolCount/8)) * 100`, capped at 95%
+- Progress never reaches 100% — turn completion is signaled by `turn_duration` which clears the bar
+- Extension tracks `turnToolCount` per agent in `AgentState`, resets on new user prompt or turn end
+- Sends `agentTurnProgress` message to webview on each tool completion
+- Progress bar color matches status dot (green for active, amber for permission wait)
+
+---
+
+## F02 — Smart Notifications
+
+**Epic:** Agent UX
+**Complexity:** S
+**Status:** `backlog`
+**Branch:** `feat/smart-notifications`
+
+### Description
+
+Enhanced notification system beyond the current chime:
+
+- Native OS notification when agent needs attention (permission wait)
+- Notification when agent finishes a long task (> N minutes)
+- Alert when agent is in a loop (same tool called 5+ times in a row)
+- Configurable notification preferences in Settings modal
+
+### Acceptance Criteria
+
+- [ ] OS-level notifications via `vscode.window.showInformationMessage` for permission waits
+- [ ] Long-task completion notification (configurable threshold, default 2 min)
+- [ ] Loop detection: alert when same tool_use name appears 5+ times consecutively
+- [ ] Settings UI: toggle each notification type independently
+- [ ] Notifications respect system DND / focus mode
+- [ ] Sound notification setting still works independently
+
+### Technical Notes
+
+- Use `vscode.window.showInformationMessage` for native notifications (works cross-platform)
+- Loop detection in `transcriptParser.ts` — track last N tool names per agent
+- Store notification preferences in `globalState`
+- Long-task timer: start on first `agentToolStart`, fire if no `agentStatus: waiting` within threshold
+
+### Files to modify
+
+- `src/transcriptParser.ts` — loop detection logic
+- `src/PixelAgentsViewProvider.ts` — fire native notifications
+- `src/agentManager.ts` — long-task timer
+- `src/constants.ts` — new timing constants
+- `src/types.ts` — add notification preferences to state
+- `webview-ui/src/components/SettingsModal.tsx` — notification toggles UI
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F03 — Agent Templates / Presets
+
+**Epic:** Agent Config
+**Complexity:** S
+**Status:** `backlog`
+**Branch:** `feat/agent-templates`
+
+### Description
+
+Define reusable agent configurations before launching:
+
+- Custom name and skin/palette
+- Working directory
+- Claude CLI flags (e.g., `--allowedTools`, `--model`)
+- System prompt / CLAUDE.md override
+- Save/load templates per workspace
+
+### Acceptance Criteria
+
+- [ ] "New Agent" button opens template picker (or quick-launch with default)
+- [ ] Template editor modal: name, directory, CLI flags, palette selection
+- [ ] Templates saved per workspace in `workspaceState`
+- [ ] Template list in Settings modal with create/edit/delete
+- [ ] Character spawns with pre-assigned name, palette, and seat preference
+- [ ] Terminal starts with configured CLI flags
+- [ ] Import/export templates as JSON
+
+### Technical Notes
+
+- Store templates in `workspaceState` key `pixel-agents.templates`
+- Template type: `{ name, cwd?, cliFlags?, palette?, seatId? }`
+- Modify `launchNewTerminal` to accept template config
+- Bottom toolbar: long-press or dropdown on "+ Agent" to pick template
+
+### Files to modify
+
+- `src/types.ts` — `AgentTemplate` interface
+- `src/agentManager.ts` — template-aware `launchNewTerminal`
+- `src/PixelAgentsViewProvider.ts` — template CRUD messages
+- `src/constants.ts` — workspace key for templates
+- `webview-ui/src/components/BottomToolbar.tsx` — template picker UI
+- `webview-ui/src/components/SettingsModal.tsx` — template management
+- New: `webview-ui/src/components/TemplateEditor.tsx`
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F04 — Activity Timeline
+
+**Epic:** Analytics
+**Complexity:** M
+**Status:** `backlog`
+**Branch:** `feat/activity-timeline`
+
+### Description
+
+Visual timeline per agent showing chronological activity:
+
+- File operations (read, edit, write, create) with file paths
+- Bash commands executed
+- Permission waits and their duration
+- Turn boundaries (start/end markers)
+- Clickable entries: opens file/diff in editor
+
+### Acceptance Criteria
+
+- [ ] Timeline panel accessible by clicking agent or via context menu
+- [ ] Chronological list of events with timestamps
+- [ ] Event types: file_edit, file_read, bash_command, permission_wait, turn_start, turn_end
+- [ ] Click file event → opens file in editor at relevant line
+- [ ] Click bash event → shows command + output summary
+- [ ] Auto-scroll to latest event
+- [ ] Filter by event type
+- [ ] Timeline persists across webview reloads (stored in agent state)
+
+### Technical Notes
+
+- Parse JSONL `tool_use` blocks: extract tool name, input params (file path, command)
+- Store timeline events in new `AgentState.timeline: TimelineEvent[]`
+- Render as scrollable React component overlaying the office
+- Use `vscode.commands.executeCommand('vscode.open', uri)` for file navigation
+- Limit stored events to last 500 per agent to avoid memory issues
+
+### Files to modify
+
+- `src/types.ts` — `TimelineEvent` interface
+- `src/transcriptParser.ts` — emit timeline events
+- `src/PixelAgentsViewProvider.ts` — forward timeline events to webview
+- New: `webview-ui/src/components/ActivityTimeline.tsx`
+- `webview-ui/src/hooks/useExtensionMessages.ts` — timeline state
+- `webview-ui/src/office/components/ToolOverlay.tsx` — timeline trigger
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F05 — Agent Dashboard (Metrics)
+
+**Epic:** Analytics
+**Complexity:** M
+**Status:** `backlog`
+**Branch:** `feat/agent-dashboard`
+
+### Description
+
+Dashboard panel showing per-agent metrics:
+
+- Session duration
+- Tool usage breakdown (pie chart: how many edits, reads, bash, etc.)
+- Token consumption estimate (based on JSONL content size)
+- Permission wait count and total wait time
+- Files touched (unique count)
+- Cost estimate in USD (configurable rate per token)
+
+### Acceptance Criteria
+
+- [ ] Dashboard accessible via Settings or dedicated button
+- [ ] Per-agent cards with key metrics
+- [ ] Aggregate view across all agents
+- [ ] Tool usage breakdown visualization (canvas-based, pixel art style)
+- [ ] Session cost estimate with configurable token price
+- [ ] Export metrics as JSON/CSV
+- [ ] Metrics reset on session clear
+
+### Technical Notes
+
+- Accumulate metrics in `AgentState` extensions (tool counts, byte counts)
+- Token estimation: rough heuristic based on JSONL record sizes
+- Cost: `estimated_tokens * price_per_token` (user-configurable, default Claude pricing)
+- Render dashboard in webview as overlay panel
+- Pixel art styled charts (bar chart using sprite-like blocks)
+
+### Files to modify
+
+- `src/types.ts` — `AgentMetrics` interface
+- `src/transcriptParser.ts` — accumulate metrics on each record
+- `src/agentManager.ts` — metrics in agent state
+- New: `webview-ui/src/components/AgentDashboard.tsx`
+- `webview-ui/src/hooks/useExtensionMessages.ts` — metrics state
+- `webview-ui/src/components/SettingsModal.tsx` — dashboard toggle
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F06 — Cost Budget & Guardrails
+
+**Epic:** Analytics
+**Complexity:** M
+**Status:** `backlog`
+**Branch:** `feat/cost-guardrails`
+
+### Description
+
+Budget controls to prevent runaway spending:
+
+- Set max budget per agent, per session, or per day
+- Auto-pause agent when limit reached
+- Visual alert on character (red tint, warning bubble)
+- Budget dashboard showing spend vs limit
+- Configurable token price per model
+
+### Acceptance Criteria
+
+- [ ] Budget configuration in Settings: per-agent and global daily limit
+- [ ] Real-time cost tracking based on JSONL token estimates
+- [ ] Auto-pause: send interrupt to terminal when budget exceeded
+- [ ] Warning at 80% budget (yellow indicator on character)
+- [ ] Hard stop at 100% (red indicator, terminal paused)
+- [ ] Budget resets daily (configurable reset time)
+- [ ] Override option: "Continue anyway" button
+- [ ] Persistent budget tracking across sessions
+
+### Technical Notes
+
+- Depends on F05 (Agent Dashboard metrics) for token counting
+- Budget stored in `globalState`: `{ daily: number, perAgent: number, pricePerMToken: number }`
+- Terminal pause: `terminal.sendText('\x03')` (Ctrl+C) or custom signal
+- Warning/stop thresholds configurable
+- Daily reset via timestamp comparison
+
+### Files to modify
+
+- Builds on F05 files
+- `src/constants.ts` — budget defaults
+- `src/agentManager.ts` — budget checking on each transcript update
+- New: `webview-ui/src/components/BudgetIndicator.tsx`
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F07 — File Heatmap
+
+**Epic:** Visualization
+**Complexity:** M
+**Status:** `backlog`
+**Branch:** `feat/file-heatmap`
+
+### Description
+
+Visual overlay showing which files are being touched and by whom:
+
+- Heatmap panel listing files colored by activity intensity
+- Conflict detection: highlight when 2+ agents edit the same file
+- Per-agent file list (what each agent has read/written)
+- Click file → open in editor
+
+### Acceptance Criteria
+
+- [ ] Heatmap panel accessible via button or agent context menu
+- [ ] Files sorted by touch frequency (most active first)
+- [ ] Color coding: green (read), yellow (edited once), red (edited many times)
+- [ ] Conflict indicator: icon when 2+ agents touched same file
+- [ ] Per-agent filter: show files for selected agent only
+- [ ] Click to open file in editor
+- [ ] Real-time updates as agents work
+
+### Technical Notes
+
+- Track file paths from `tool_use` blocks: Read, Edit, Write, Glob results
+- Store in shared `Map<filePath, { agents: Set<agentId>, readCount, writeCount }>`
+- Conflict = `agents.size > 1 && writeCount > 0`
+- Render as scrollable list with pixel art styled bars
+
+### Files to modify
+
+- `src/types.ts` — `FileActivity` tracking
+- `src/transcriptParser.ts` — extract file paths from tool_use
+- `src/PixelAgentsViewProvider.ts` — forward file activity to webview
+- New: `webview-ui/src/components/FileHeatmap.tsx`
+- `webview-ui/src/hooks/useExtensionMessages.ts` — file activity state
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F08 — Git Awareness
+
+**Epic:** Integration
+**Complexity:** L
+**Status:** `backlog`
+**Branch:** `feat/git-awareness`
+
+### Description
+
+Each agent shows git context visually:
+
+- Current branch name displayed near character
+- Uncommitted changes count badge
+- Conflict indicator when agent's branch diverges
+- "View diff" action on character context menu
+- Mini branch indicator on agent's desk
+
+### Acceptance Criteria
+
+- [ ] Branch name label below agent name
+- [ ] Badge showing number of uncommitted files
+- [ ] Periodic git status polling (every 5s when agent is active)
+- [ ] Visual conflict warning when same file modified by multiple agents on different branches
+- [ ] Context menu: "View Diff", "Open Branch"
+- [ ] Worktree-aware: detect if agent is working in a git worktree
+
+### Technical Notes
+
+- Use `child_process.exec('git status --porcelain')` per agent's cwd
+- Branch name: `git branch --show-current`
+- Worktree detection: `git worktree list`
+- Poll only for active agents (have had tool activity in last 30s)
+- Send git state to webview as `agentGitStatus` message
+
+### Files to modify
+
+- New: `src/gitTracker.ts` — git status polling per agent
+- `src/types.ts` — `GitStatus` interface
+- `src/agentManager.ts` — start/stop git tracking per agent
+- `src/PixelAgentsViewProvider.ts` — forward git status messages
+- `webview-ui/src/office/components/ToolOverlay.tsx` — branch label, badge
+- `webview-ui/src/hooks/useExtensionMessages.ts` — git state
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F09 — Agent Orchestration / Teams
+
+**Epic:** Orchestration
+**Complexity:** L
+**Status:** `backlog`
+**Branch:** `feat/agent-orchestration`
+
+### Description
+
+Visual interface for multi-agent coordination:
+
+- Assign agents to "desks" representing tasks/directories
+- Define task dependencies (agent B waits for agent A)
+- Sub-agent tree visualization (from Task tool)
+- "Standup view" — summary of all agent activities
+
+### Acceptance Criteria
+
+- [ ] Desk assignment: drag agent to desk or click desk → assign dialog
+- [ ] Task dependency graph (simple DAG visualization)
+- [ ] Sub-agent tree view showing parent → child relationships
+- [ ] Standup summary: per-agent one-liner of current/last activity
+- [ ] Dependency enforcement: auto-launch agent B when A completes
+- [ ] Visual connection lines between dependent agents
+
+### Technical Notes
+
+- Desk-to-directory mapping stored in layout persistence
+- Dependencies: `Map<agentId, { blockedBy: agentId[], blocks: agentId[] }>`
+- Sub-agent tree: already tracked via `subagentMeta` in `OfficeState`
+- Standup: aggregate last tool_use description per agent
+- Auto-launch: watch for `agentStatus: waiting` + all tools cleared
+
+### Files to modify
+
+- `webview-ui/src/office/engine/officeState.ts` — desk assignments
+- New: `webview-ui/src/components/OrchestrationPanel.tsx`
+- New: `webview-ui/src/components/StandupView.tsx`
+- `src/agentManager.ts` — dependency-aware launch
+- `src/types.ts` — orchestration types
+- `webview-ui/src/office/components/OfficeCanvas.tsx` — desk click handling
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F10 — Agent Performance Scoring
+
+**Epic:** Analytics
+**Complexity:** L
+**Status:** `backlog`
+**Branch:** `feat/performance-scoring`
+
+### Description
+
+Analyze agent session history to provide efficiency scores:
+
+- Efficiency score: tasks completed vs tokens/time spent
+- Pattern detection: loops, reverted edits, repeated errors
+- Suggestions: "This agent works better with smaller tasks"
+- Historical comparison across sessions
+
+### Acceptance Criteria
+
+- [ ] Per-session efficiency score (0-100)
+- [ ] Loop detection: flag when agent repeats same action 5+ times
+- [ ] Revert detection: flag when an Edit is undone by another Edit
+- [ ] Score breakdown: time efficiency, token efficiency, error rate
+- [ ] Historical trend chart (last 10 sessions)
+- [ ] Actionable suggestions based on patterns
+- [ ] Score visible on agent hover tooltip (integrates with F01)
+
+### Technical Notes
+
+- Depends on F04 (Activity Timeline) and F05 (Dashboard) for data
+- Score algorithm: `100 - (loop_penalty + revert_penalty + idle_penalty)`
+- Revert detection: compare consecutive Edit operations on same file
+- Store session scores in `globalState` keyed by project
+- Trend chart: simple pixel art line chart
+
+### Files to modify
+
+- New: `src/performanceScorer.ts` — scoring algorithm
+- `src/transcriptParser.ts` — feed data to scorer
+- New: `webview-ui/src/components/PerformanceCard.tsx`
+- Integrates with F01 tooltip and F05 dashboard
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## F11 — Project Map View
+
+**Epic:** Visualization
+**Complexity:** XL
+**Status:** `backlog`
+**Branch:** `feat/project-map`
+
+### Description
+
+Alternative view: project structure as a pixel art city:
+
+- Directories = buildings, files = floors/rooms
+- Agents move through "buildings" they're editing
+- Semantic zoom: project overview → directory → file level
+- Color coding by file type or activity intensity
+
+### Acceptance Criteria
+
+- [ ] Toggle between Office View and Map View
+- [ ] Directory tree rendered as pixel art buildings
+- [ ] File activity shown as lit windows in buildings
+- [ ] Agent sprites move to the building they're currently editing
+- [ ] Zoom levels: project → directory → file
+- [ ] Building size proportional to directory contents
+- [ ] Color coding: file type (ts=blue, css=purple, etc.)
+- [ ] Click building → opens directory in explorer
+
+### Technical Notes
+
+- New rendering mode in `renderer.ts` — separate from office layout
+- Directory scanning: `vscode.workspace.findFiles('**/*')` at startup
+- Building sprites: procedurally generated based on directory depth/file count
+- Agent position: map file path from current tool_use to building coordinates
+- Heavy feature — consider as v2.0 milestone
+
+### Files to modify
+
+- New: `webview-ui/src/map/` — entire new rendering subsystem
+- New: `webview-ui/src/map/mapState.ts`
+- New: `webview-ui/src/map/mapRenderer.ts`
+- New: `webview-ui/src/map/buildingSprites.ts`
+- `webview-ui/src/App.tsx` — view toggle
+- `src/PixelAgentsViewProvider.ts` — file tree scanning
+
+### Implementation Notes
+
+_To be filled during/after implementation_
+
+---
+
+## Sprint Log
+
+### Sprint 1 — Agent UX Foundations
+
+**Goal:** Implement F01 (Tooltip) and F02 (Notifications)
+**Status:** `in_progress`
+**Start date:** 2026-03-15
+**End date:** —
+
+| Task                                | Feature | Status | Notes                              |
+| ----------------------------------- | ------- | ------ | ---------------------------------- |
+| Hover detection + tooltip component | F01     | `done` | Enhanced existing ToolOverlay      |
+| Extract current task from JSONL     | F01     | `done` | Uses existing agentTools status    |
+| Progress estimation logic           | F01     | `done` | Logarithmic curve on turnToolCount |
+| Sub-agent tooltip support           | F01     | `done` | Shows sub label, no progress bar   |
+| OS notification for permission wait | F02     | `todo` |                                    |
+| Long-task completion notification   | F02     | `todo` |                                    |
+| Loop detection alert                | F02     | `todo` |                                    |
+| Notification settings UI            | F02     | `todo` |                                    |
+
+### Sprint 2 — Agent Config
+
+**Goal:** Implement F03 (Templates)
+**Status:** `not_started`
+
+### Sprint 3 — Analytics Core
+
+**Goal:** Implement F04 (Timeline) and F05 (Dashboard)
+**Status:** `not_started`
+
+### Sprint 4 — Cost Control
+
+**Goal:** Implement F06 (Budget) and F07 (Heatmap)
+**Status:** `not_started`
+
+### Sprint 5 — Integration
+
+**Goal:** Implement F08 (Git Awareness)
+**Status:** `not_started`
+
+### Sprint 6 — Orchestration
+
+**Goal:** Implement F09 (Teams) and F10 (Scoring)
+**Status:** `not_started`
+
+### Sprint 7 — Vision
+
+**Goal:** Implement F11 (Project Map)
+**Status:** `not_started`
+
+---
+
+## Changelog
+
+| Date       | Change                                                     | By                |
+| ---------- | ---------------------------------------------------------- | ----------------- |
+| 2026-03-15 | Initial roadmap created with 11 features across 7 sprints  | Claude + Fernando |
+| 2026-03-15 | Cursor IDE support + auto-adopt terminals (v1.1.0) shipped | Claude + Fernando |
+| 2026-03-15 | F01 Agent Hover Tooltip implemented (Sprint 1 started)     | Claude + Fernando |

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -32,6 +32,7 @@ import {
 import { claudeProvider, copyHookScript } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
 import {
+  adoptExistingTerminals,
   getProjectDirPath,
   launchNewTerminal,
   restoreAgents,
@@ -50,6 +51,7 @@ import {
   GLOBAL_KEY_WATCH_ALL_SESSIONS,
   LAYOUT_REVISION_KEY,
 } from './constants.js';
+import type { IdeType } from './ideDetector.js';
 import { VscodeTerminalAdapter } from './vscodeTerminalAdapter.js';
 
 export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
@@ -79,10 +81,14 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   // session, even though webviewReady fires on every panel focus.
   private autoSpawnAttempted = false;
 
+  readonly ideType: IdeType;
+
   constructor(
     private readonly context: vscode.ExtensionContext,
     adapter: StateAdapter,
+    ideType: IdeType,
   ) {
+    this.ideType = ideType;
     this.adapter = adapter;
     this.store.setAdapter(this.adapter);
     this.store.on('agentAdded', (id, agent) => {
@@ -293,6 +299,26 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           this.runtime.registerAgent(agent.sessionId, agent.id);
         }
 
+        // Adopt existing Claude Code terminals not previously tracked
+        const registeredSessions = new Set(
+          [...this.store.values()].map((agent) => agent.sessionId),
+        );
+        adoptExistingTerminals(
+          this.store.nextAgentId,
+          this.store,
+          this.runtime.activeAgentId,
+          this.runtime.knownJsonlFiles,
+          this.runtime.fileWatchers,
+          this.runtime.pollingTimers,
+          this.runtime.waitingTimers,
+          this.runtime.permissionTimers,
+        );
+        for (const agent of this.store.values()) {
+          if (!registeredSessions.has(agent.sessionId)) {
+            this.runtime.registerAgent(agent.sessionId, agent.id);
+          }
+        }
+
         // Auto-spawn: launch one agent on first webviewReady if the setting is
         // enabled and no agents are currently running.
         if (
@@ -365,6 +391,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           hooksInfoShown,
           externalAssetDirectories: config.externalAssetDirectories,
         });
+        this.webview?.postMessage({ type: 'ideInfo', ide: this.ideType });
 
         // Send workspace folders to webview (only when multi-root)
         const wsFolders = vscode.workspace.workspaceFolders;

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -5,7 +5,10 @@ import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
-import { JSONL_POLL_INTERVAL_MS } from '../../server/src/constants.js';
+import {
+  GLOBAL_SCAN_ACTIVE_MAX_AGE_MS,
+  JSONL_POLL_INTERVAL_MS,
+} from '../../server/src/constants.js';
 import {
   ensureProjectScan,
   readNewLines,
@@ -102,6 +105,7 @@ export async function launchNewTerminal(
     isWaiting: false,
     permissionSent: false,
     hadToolsInTurn: false,
+    turnToolCount: 0,
     lastDataAt: 0,
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
@@ -339,6 +343,7 @@ export function restoreAgents(
       isWaiting: false,
       permissionSent: false,
       hadToolsInTurn: false,
+      turnToolCount: 0,
       lastDataAt: 0,
       linesProcessed: 0,
       seenUnknownRecordTypes: new Set(),
@@ -474,6 +479,156 @@ export function restoreAgents(
       waitingTimers,
       permissionTimers,
       () => store.persist(),
+    );
+  }
+}
+
+/**
+ * Detect and adopt existing Claude Code terminals that were opened before the extension started.
+ *
+ * Matches unowned terminals whose name contains "claude" to recent JSONL files
+ * in the current workspace project dir (modified within GLOBAL_SCAN_ACTIVE_MAX_AGE_MS).
+ */
+export function adoptExistingTerminals(
+  nextAgentIdRef: { current: number },
+  store: AgentStateStore,
+  activeAgentIdRef: { current: number | null },
+  knownJsonlFiles: Set<string>,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+): void {
+  let projectDir: string;
+  try {
+    projectDir = getProjectDirPath();
+  } catch {
+    return;
+  }
+
+  const ownedTerminals = new Set<vscode.Terminal>();
+  const ownedJsonlFiles = new Set<string>();
+  for (const agent of store.values()) {
+    if (agent.terminalRef) {
+      ownedTerminals.add(agent.terminalRef);
+    }
+    ownedJsonlFiles.add(agent.jsonlFile);
+  }
+
+  const candidateTerminals = vscode.window.terminals.filter((t) => {
+    if (ownedTerminals.has(t)) return false;
+    return t.name.toLowerCase().includes('claude');
+  });
+
+  if (candidateTerminals.length === 0) {
+    console.log('[Pixel Agents] adoptExistingTerminals: no unowned Claude Code terminals found');
+    return;
+  }
+
+  let jsonlFiles: Array<{ file: string; mtime: number }>;
+  try {
+    jsonlFiles = fs
+      .readdirSync(projectDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => {
+        const fullPath = path.join(projectDir, f);
+        try {
+          const stat = fs.statSync(fullPath);
+          return { file: fullPath, mtime: stat.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is { file: string; mtime: number } => entry !== null)
+      .sort((a, b) => b.mtime - a.mtime);
+  } catch {
+    return;
+  }
+
+  const recentFiles = jsonlFiles.filter(
+    (f) => Date.now() - f.mtime < GLOBAL_SCAN_ACTIVE_MAX_AGE_MS && !ownedJsonlFiles.has(f.file),
+  );
+
+  if (recentFiles.length === 0) {
+    console.log('[Pixel Agents] adoptExistingTerminals: no active JSONL files in project dir');
+    return;
+  }
+
+  const adoptCount = Math.min(candidateTerminals.length, recentFiles.length);
+  if (candidateTerminals.length !== recentFiles.length) {
+    console.log(
+      `[Pixel Agents] adoptExistingTerminals: count mismatch — ${candidateTerminals.length} terminals vs ${recentFiles.length} active JSONL files. Adopting ${adoptCount}.`,
+    );
+  }
+
+  let adopted = 0;
+  for (let i = 0; i < adoptCount; i++) {
+    const terminal = candidateTerminals[i];
+    const jsonl = recentFiles[i];
+
+    knownJsonlFiles.add(jsonl.file);
+
+    const id = nextAgentIdRef.current++;
+    const sessionId = path.basename(jsonl.file, '.jsonl');
+    const agent: AgentState = {
+      id,
+      sessionId,
+      terminalRef: terminal,
+      isExternal: false,
+      projectDir,
+      jsonlFile: jsonl.file,
+      fileOffset: 0,
+      lineBuffer: '',
+      activeToolIds: new Set(),
+      activeToolStatuses: new Map(),
+      activeToolNames: new Map(),
+      activeSubagentToolIds: new Map(),
+      activeSubagentToolNames: new Map(),
+      backgroundAgentToolIds: new Set(),
+      isWaiting: false,
+      permissionSent: false,
+      hadToolsInTurn: false,
+      turnToolCount: 0,
+      lastDataAt: 0,
+      linesProcessed: 0,
+      seenUnknownRecordTypes: new Set(),
+      hookDelivered: false,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+
+    store.set(id, agent);
+    activeAgentIdRef.current = id;
+
+    console.log(
+      `[Pixel Agents] Agent ${id}: auto-adopted terminal "${terminal.name}" → ${path.basename(jsonl.file)}`,
+    );
+
+    try {
+      if (fs.existsSync(jsonl.file)) {
+        const stat = fs.statSync(jsonl.file);
+        agent.fileOffset = stat.size;
+        startFileWatching(
+          id,
+          jsonl.file,
+          store,
+          fileWatchers,
+          pollingTimers,
+          waitingTimers,
+          permissionTimers,
+        );
+      }
+    } catch {
+      /* ignore */
+    }
+
+    adopted++;
+  }
+
+  if (adopted > 0) {
+    store.persist();
+    console.log(
+      `[Pixel Agents] Auto-adopted ${adopted} existing Claude Code terminal(s) for this project`,
     );
   }
 }

--- a/adapters/vscode/extension.ts
+++ b/adapters/vscode/extension.ts
@@ -7,12 +7,16 @@ import {
   CONFIG_KEY_AUTO_SHOW_PANEL,
   VIEW_ID,
 } from './constants.js';
+import { detectIde, getIdeDisplayName } from './ideDetector.js';
 import { migrateVsCodeState } from './migrateVsCodeState.js';
 import { PixelAgentsViewProvider } from './PixelAgentsViewProvider.js';
 
 let providerInstance: PixelAgentsViewProvider | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
+  const ide = detectIde();
+  const ideName = getIdeDisplayName(ide);
+  console.log(`[Pixel Agents] Activating in ${ideName} (appName: "${vscode.env.appName}")`);
   console.log(`[Pixel Agents] PIXEL_AGENTS_DEBUG=${process.env.PIXEL_AGENTS_DEBUG ?? 'not set'}`);
 
   // Shared file-backed state adapter (VS Code namespace in ~/.pixel-agents/config.json).
@@ -22,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
   // activate. Warns until all keys are cleared (e.g. if a disk error blocks writes).
   migrateVsCodeState(context, adapter);
 
-  const provider = new PixelAgentsViewProvider(context, adapter);
+  const provider = new PixelAgentsViewProvider(context, adapter, ide);
   providerInstance = provider;
 
   context.subscriptions.push(vscode.window.registerWebviewViewProvider(VIEW_ID, provider));

--- a/adapters/vscode/ideDetector.ts
+++ b/adapters/vscode/ideDetector.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+
+/**
+ * Supported IDE types where this extension can run.
+ */
+export const IDE_TYPE = {
+  VSCODE: 'vscode',
+  CURSOR: 'cursor',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type IdeType = (typeof IDE_TYPE)[keyof typeof IDE_TYPE];
+
+/**
+ * Detect which IDE is running by inspecting vscode.env.appName.
+ * Cursor reports "Cursor" while VS Code reports "Visual Studio Code".
+ */
+export function detectIde(): IdeType {
+  const appName = vscode.env.appName.toLowerCase();
+  if (appName.includes('cursor')) {
+    return IDE_TYPE.CURSOR;
+  }
+  if (appName.includes('visual studio code') || appName.includes('vscode')) {
+    return IDE_TYPE.VSCODE;
+  }
+  return IDE_TYPE.UNKNOWN;
+}
+
+/**
+ * Get a human-readable IDE display name.
+ */
+export function getIdeDisplayName(ide: IdeType): string {
+  switch (ide) {
+    case IDE_TYPE.CURSOR:
+      return 'Cursor';
+    case IDE_TYPE.VSCODE:
+      return 'VS Code';
+    default:
+      return vscode.env.appName;
+  }
+}

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -91,6 +91,7 @@ components:
         - $ref: '#/components/schemas/AgentToolsClear'
         - $ref: '#/components/schemas/AgentToolPermission'
         - $ref: '#/components/schemas/AgentToolPermissionClear'
+        - $ref: '#/components/schemas/AgentTurnProgress'
         # Sub-agent activity
         - $ref: '#/components/schemas/SubagentToolStart'
         - $ref: '#/components/schemas/SubagentToolDone'
@@ -110,6 +111,7 @@ components:
         - $ref: '#/components/schemas/SettingsLoaded'
         - $ref: '#/components/schemas/ExternalAssetDirectoriesUpdated'
         - $ref: '#/components/schemas/WorkspaceFolders'
+        - $ref: '#/components/schemas/IdeInfo'
         # Diagnostics
         - $ref: '#/components/schemas/AgentDiagnostics'
       discriminator: type
@@ -279,6 +281,19 @@ components:
           type: integer
         toolId:
           type: string
+
+    AgentTurnProgress:
+      description: Turn progress estimate based on completed tool count.
+      type: object
+      additionalProperties: false
+      required: [type, id, toolCount]
+      properties:
+        type:
+          const: agentTurnProgress
+        id:
+          type: integer
+        toolCount:
+          type: integer
 
     AgentToolsClear:
       description: All foreground tools cleared (turn end). Background agents preserved.
@@ -563,6 +578,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WorkspaceFolder'
+
+    IdeInfo:
+      description: Host IDE type (VS Code vs Cursor). VS Code adapter only.
+      type: object
+      additionalProperties: false
+      required: [type, ide]
+      properties:
+        type:
+          const: ideInfo
+        ide:
+          type: string
+          enum: [vscode, cursor, unknown]
 
     AgentDiagnostics:
       description: Connection diagnostics for all agents (response to requestDiagnostics).

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -16,6 +16,7 @@ export type ServerMessage =
   | AgentStatus
   | AgentToolStart
   | AgentToolDone
+  | AgentTurnProgress
   | AgentToolsClear
   | AgentToolPermission
   | AgentToolPermissionClear
@@ -33,6 +34,7 @@ export type ServerMessage =
   | SettingsLoaded
   | ExternalAssetDirectoriesUpdated
   | WorkspaceFolders
+  | IdeInfo
   | AgentDiagnostics;
 
 export type ClientMessage =
@@ -114,6 +116,12 @@ export interface AgentToolDone {
   type: 'agentToolDone';
   id: number;
   toolId: string;
+}
+
+export interface AgentTurnProgress {
+  type: 'agentTurnProgress';
+  id: number;
+  toolCount: number;
 }
 
 export interface AgentToolsClear {
@@ -256,6 +264,11 @@ export interface WorkspaceFolders {
 export interface WorkspaceFolder {
   name: string;
   path: string;
+}
+
+export interface IdeInfo {
+  type: 'ideInfo';
+  ide: 'vscode' | 'cursor' | 'unknown';
 }
 
 export interface AgentDiagnostics {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "typescript-eslint": "^8.54.0"
       },
       "engines": {
-        "vscode": "^1.105.0"
+        "vscode": "^1.85.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -6633,9 +6633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6653,9 +6650,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6673,9 +6667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6693,9 +6684,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-agents",
   "displayName": "Pixel Agents",
-  "description": "Pixel art office where your Claude Code agents come to life as animated characters",
+  "description": "Pixel art office where your Claude Code agents come to life as animated characters — works in VS Code and Cursor IDE",
   "version": "1.3.0",
   "publisher": "pablodelucca",
   "repository": {
@@ -11,10 +11,20 @@
   "icon": "icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.105.0"
+    "vscode": "^1.85.0"
   },
   "categories": [
-    "Other"
+    "Other",
+    "Visualization"
+  ],
+  "keywords": [
+    "pixel-art",
+    "claude",
+    "ai-agents",
+    "cursor",
+    "cursor-ide",
+    "vscode",
+    "claude-code"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/server/__tests__/agentStateStore.test.ts
+++ b/server/__tests__/agentStateStore.test.ts
@@ -34,6 +34,7 @@ function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
     isWaiting: false,
     permissionSent: false,
     hadToolsInTurn: false,
+    turnToolCount: 0,
     lastDataAt: 0,
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),

--- a/server/__tests__/hookEventHandler.test.ts
+++ b/server/__tests__/hookEventHandler.test.ts
@@ -26,6 +26,7 @@ function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
     isWaiting: false,
     permissionSent: false,
     hadToolsInTurn: false,
+    turnToolCount: 0,
     lastDataAt: 0,
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -786,9 +786,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +800,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +814,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +828,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +842,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,9 +856,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,9 +870,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -905,9 +884,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -922,9 +898,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,9 +912,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -956,9 +926,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,9 +940,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,9 +954,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -362,6 +362,7 @@ export class AgentRuntime {
         isWaiting: false,
         permissionSent: false,
         hadToolsInTurn: false,
+        turnToolCount: 0,
         lastDataAt: 0,
         linesProcessed: 0,
         seenUnknownRecordTypes: new Set(),

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -508,6 +508,7 @@ function adoptTerminalForFile(
     isWaiting: false,
     permissionSent: false,
     hadToolsInTurn: false,
+    turnToolCount: 0,
     lastDataAt: 0,
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
@@ -669,6 +670,7 @@ export function scanForTeammateFiles(
       isWaiting: false,
       permissionSent: false,
       hadToolsInTurn: false,
+      turnToolCount: 0,
       // Keep hookDelivered false: teammates need JSONL-based tool tracking
       // (agentToolStart messages). Permission events are routed from the lead's
       // hooks via handlePermissionRequest forwarding.
@@ -872,6 +874,7 @@ export function adoptExternalSessionFromHook(
       isWaiting: false,
       permissionSent: false,
       hadToolsInTurn: false,
+      turnToolCount: 0,
       hookDelivered: true,
       hooksOnly: true,
       lastDataAt: Date.now(),
@@ -932,6 +935,7 @@ function adoptExternalSession(
     isWaiting: false,
     permissionSent: false,
     hadToolsInTurn: false,
+    turnToolCount: 0,
     hookDelivered: false,
     lastDataAt: Date.now(),
     linesProcessed: 0,

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -234,6 +234,12 @@ export function processTranscriptLine(
               agent.activeToolIds.delete(completedToolId);
               agent.activeToolStatuses.delete(completedToolId);
               agent.activeToolNames.delete(completedToolId);
+              agent.turnToolCount++;
+              agents.broadcast({
+                type: 'agentTurnProgress',
+                id: agentId,
+                toolCount: agent.turnToolCount,
+              });
               // Send agentToolDone when hooks are off, or for Task/Agent tools
               // (which always use JSONL path for consistent sub-agent lifecycle).
               const isCompletedAgentTool =
@@ -260,12 +266,14 @@ export function processTranscriptLine(
           cancelWaitingTimer(agentId, waitingTimers);
           clearAgentActivity(agent, agentId, agents, permissionTimers);
           agent.hadToolsInTurn = false;
+          agent.turnToolCount = 0;
         }
       } else if (typeof content === 'string' && content.trim()) {
         // New user text prompt — new turn starting
         cancelWaitingTimer(agentId, waitingTimers);
         clearAgentActivity(agent, agentId, agents, permissionTimers);
         agent.hadToolsInTurn = false;
+        agent.turnToolCount = 0;
       }
     } else if (record.type === 'queue-operation' && record.operation === 'enqueue') {
       // Background agent completed — parse tool-use-id from XML content
@@ -352,6 +360,7 @@ export function processTranscriptLine(
       agent.isWaiting = true;
       agent.permissionSent = false;
       agent.hadToolsInTurn = false;
+      agent.turnToolCount = 0;
       // Skip status post when hooks already handled it
       if (!agent.hookDelivered) {
         agents.broadcast({

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -28,6 +28,8 @@ export interface AgentState {
   linesProcessed: number;
   /** Set of record.type values we've already warned about (prevents log spam) */
   seenUnknownRecordTypes: Set<string>;
+  /** Count of tool_use events completed in the current turn (for progress estimation) */
+  turnToolCount: number;
   /** Whether a hook event has been delivered for this agent (suppresses heuristic timers) */
   hookDelivered: boolean;
   /** True when agent has no transcript file (provider doesn't use JSONL). All state from hooks. */

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -59,6 +59,7 @@ function App() {
     selectedAgent,
     agentTools,
     agentStatuses,
+    agentProgress,
     subagentTools,
     subagentCharacters,
     layoutReady,
@@ -74,6 +75,7 @@ function App() {
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    ideType,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -245,6 +247,7 @@ function App() {
             officeState={officeState}
             agents={agents}
             agentTools={agentTools}
+            agentProgress={agentProgress}
             subagentCharacters={subagentCharacters}
             containerRef={containerRef}
             zoom={editor.zoom}
@@ -364,6 +367,7 @@ function App() {
           setHooksEnabled(newVal);
           transport.send({ type: 'setHooksEnabled', enabled: newVal });
         }}
+        ideType={ideType}
       />
 
       {showMigrationNotice && (

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import type { IdeType } from '../hooks/useExtensionMessages.js';
 import { isSoundEnabled, setSoundEnabled } from '../notificationSound.js';
 import { transport } from '../transport/index.js';
 import { Button } from './ui/Button.js';
@@ -19,7 +20,14 @@ interface SettingsModalProps {
   onToggleWatchAllSessions: () => void;
   hooksEnabled: boolean;
   onToggleHooksEnabled: () => void;
+  ideType: IdeType;
 }
+
+const ideDisplayNames: Record<IdeType, string> = {
+  vscode: 'VS Code',
+  cursor: 'Cursor',
+  unknown: 'Unknown IDE',
+};
 
 export function SettingsModal({
   isOpen,
@@ -33,6 +41,7 @@ export function SettingsModal({
   onToggleWatchAllSessions,
   hooksEnabled,
   onToggleHooksEnabled,
+  ideType,
 }: SettingsModalProps) {
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
 
@@ -114,6 +123,9 @@ export function SettingsModal({
         onChange={onToggleAlwaysShowOverlay}
       />
       <Checkbox label="Debug View" checked={isDebugMode} onChange={onToggleDebugMode} />
+      <div className="pt-6 mt-4 border-t border-border text-xs text-text-muted px-10">
+        Running in {ideDisplayNames[ideType]}
+      </div>
     </Modal>
   );
 }

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -133,6 +133,9 @@ export const AUTO_ON_SIDE_DEPTH = 2;
 export const CHARACTER_HIT_HALF_WIDTH = 8;
 export const CHARACTER_HIT_HEIGHT = 24;
 export const TOOL_OVERLAY_VERTICAL_OFFSET = 32;
+export const TURN_PROGRESS_AVG_TOOLS = 8;
+export const TURN_PROGRESS_MAX_PCT = 95;
+export const TURN_PROGRESS_BAR_BG = 'rgba(255,255,255,0.1)';
 
 // ── Agent Teams ─────────────────────────────────────────────
 export const MAX_CONTEXT_TOKENS = 200_000;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -50,11 +50,18 @@ export interface WorkspaceFolder {
   path: string;
 }
 
+export type IdeType = 'vscode' | 'cursor' | 'unknown';
+
+export interface AgentProgress {
+  toolCount: number;
+}
+
 interface ExtensionMessageState {
   agents: number[];
   selectedAgent: number | null;
   agentTools: Record<number, ToolActivity[]>;
   agentStatuses: Record<number, string>;
+  agentProgress: Record<number, AgentProgress>;
   subagentTools: Record<number, Record<string, ToolActivity[]>>;
   subagentCharacters: SubagentCharacter[];
   layoutReady: boolean;
@@ -70,6 +77,7 @@ interface ExtensionMessageState {
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
+  ideType: IdeType;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -107,6 +115,8 @@ export function useExtensionMessages(
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
+  const [ideType, setIdeType] = useState<IdeType>('vscode');
+  const [agentProgress, setAgentProgress] = useState<Record<number, AgentProgress>>({});
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -213,6 +223,12 @@ export function useExtensionMessages(
           delete next[id];
           return next;
         });
+        setAgentProgress((prev) => {
+          if (!(id in prev)) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
         // Remove all sub-agent characters belonging to this agent
         os.removeAllSubagents(id);
         setSubagentCharacters((prev) => prev.filter((s) => s.parentAgentId !== id));
@@ -294,9 +310,19 @@ export function useExtensionMessages(
             [id]: list.map((t) => (t.toolId === toolId ? { ...t, done: true } : t)),
           };
         });
+      } else if (msg.type === 'agentTurnProgress') {
+        const id = msg.id as number;
+        const toolCount = msg.toolCount as number;
+        setAgentProgress((prev) => ({ ...prev, [id]: { toolCount } }));
       } else if (msg.type === 'agentToolsClear') {
         const id = msg.id as number;
         setAgentTools((prev) => {
+          if (!(id in prev)) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+        setAgentProgress((prev) => {
           if (!(id in prev)) return prev;
           const next = { ...prev };
           delete next[id];
@@ -482,6 +508,8 @@ export function useExtensionMessages(
         if (typeof msg.extensionVersion === 'string') {
           setExtensionVersion(msg.extensionVersion as string);
         }
+      } else if (msg.type === 'ideInfo') {
+        setIdeType(msg.ide as IdeType);
       } else if (msg.type === 'externalAssetDirectoriesUpdated') {
         if (Array.isArray(msg.dirs)) {
           setExternalAssetDirectories(msg.dirs as string[]);
@@ -523,6 +551,7 @@ export function useExtensionMessages(
     selectedAgent,
     agentTools,
     agentStatuses,
+    agentProgress,
     subagentTools,
     subagentCharacters,
     layoutReady,
@@ -538,5 +567,6 @@ export function useExtensionMessages(
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    ideType,
   };
 }

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -17,8 +17,11 @@ import {
   TOKEN_DANGER_THRESHOLD,
   TOKEN_WARN_THRESHOLD,
   TOOL_OVERLAY_VERTICAL_OFFSET,
+  TURN_PROGRESS_AVG_TOOLS,
+  TURN_PROGRESS_BAR_BG,
+  TURN_PROGRESS_MAX_PCT,
 } from '../../constants.js';
-import type { SubagentCharacter } from '../../hooks/useExtensionMessages.js';
+import type { AgentProgress, SubagentCharacter } from '../../hooks/useExtensionMessages.js';
 import type { OfficeState } from '../engine/officeState.js';
 import type { ToolActivity } from '../types.js';
 import { CharacterState, TILE_SIZE } from '../types.js';
@@ -27,6 +30,7 @@ interface ToolOverlayProps {
   officeState: OfficeState;
   agents: number[];
   agentTools: Record<number, ToolActivity[]>;
+  agentProgress: Record<number, AgentProgress>;
   subagentCharacters: SubagentCharacter[];
   containerRef: React.RefObject<HTMLDivElement | null>;
   zoom: number;
@@ -59,6 +63,20 @@ function getActivityText(
   return 'Idle';
 }
 
+function estimateProgress(
+  agentId: number,
+  agentProgress: Record<number, AgentProgress>,
+  isActive: boolean,
+): number | null {
+  if (!isActive) return null;
+  const progress = agentProgress[agentId];
+  if (!progress || progress.toolCount === 0) return null;
+  return Math.min(
+    TURN_PROGRESS_MAX_PCT,
+    Math.round((1 - Math.exp(-progress.toolCount / TURN_PROGRESS_AVG_TOOLS)) * 100),
+  );
+}
+
 function getFuelColor(ratio: number): string {
   if (ratio >= TOKEN_CRITICAL_THRESHOLD) return FUEL_COLOR_CRITICAL;
   if (ratio >= TOKEN_DANGER_THRESHOLD) return FUEL_COLOR_DANGER;
@@ -70,6 +88,7 @@ export function ToolOverlay({
   officeState,
   agents,
   agentTools,
+  agentProgress,
   subagentCharacters,
   containerRef,
   zoom,
@@ -155,9 +174,11 @@ export function ToolOverlay({
         // Team info
         const isTeamAgent = !!ch.teamName;
         const teamRoleLabel = ch.isTeamLead ? 'LEAD' : ch.agentName || null;
+        const agentLabel = isSub ? undefined : ch.folderName || `Agent #${id}`;
+        const progress = isSub ? null : estimateProgress(id, agentProgress, isActive);
         const totalTokens = ch.inputTokens + ch.outputTokens;
         const tokenRatio = totalTokens / MAX_CONTEXT_TOKENS;
-        const hasExtraLines = !!(ch.folderName || teamRoleLabel);
+        const hasExtraLines = !!(agentLabel || teamRoleLabel || progress !== null);
 
         return (
           <div
@@ -171,54 +192,76 @@ export function ToolOverlay({
               zIndex: isSelected ? 42 : 41,
             }}
           >
-            <div className="flex items-center border-border px-8 pt-2 pb-4 gap-5 pixel-panel whitespace-nowrap max-w-2xs">
-              {dotColor && (
-                <span
-                  className={`w-6 h-6 rounded-full shrink-0 ${isActive && !hasPermission ? 'pixel-pulse' : ''}`}
-                  style={{ background: dotColor }}
-                />
-              )}
-              <div className="flex flex-col gap-0 overflow-hidden">
-                {teamRoleLabel && (
+            <div className="flex flex-col border-border px-8 pt-2 pb-4 gap-2 pixel-panel whitespace-nowrap max-w-2xs min-w-20">
+              <div className="flex items-center gap-5">
+                {dotColor && (
+                  <span
+                    className={`w-6 h-6 rounded-full shrink-0 ${isActive && !hasPermission ? 'pixel-pulse' : ''}`}
+                    style={{ background: dotColor }}
+                  />
+                )}
+                <div className="flex flex-col gap-0 overflow-hidden flex-1">
+                  {agentLabel && (
+                    <span className="text-2xs leading-none overflow-hidden text-ellipsis block text-text-muted">
+                      {agentLabel}
+                    </span>
+                  )}
+                  {teamRoleLabel && (
+                    <span
+                      className="overflow-hidden text-ellipsis block leading-none"
+                      style={{
+                        fontSize: '18px',
+                        color: ch.isTeamLead ? TEAM_LEAD_COLOR : TEAM_ROLE_COLOR,
+                        fontWeight: ch.isTeamLead ? 'bold' : undefined,
+                      }}
+                    >
+                      {teamRoleLabel}
+                    </span>
+                  )}
                   <span
                     className="overflow-hidden text-ellipsis block leading-none"
                     style={{
-                      fontSize: '18px',
-                      color: ch.isTeamLead ? TEAM_LEAD_COLOR : TEAM_ROLE_COLOR,
-                      fontWeight: ch.isTeamLead ? 'bold' : undefined,
+                      fontSize: isSub ? '20px' : '22px',
+                      fontStyle: isSub ? 'italic' : undefined,
                     }}
                   >
-                    {teamRoleLabel}
+                    {activityText}
                   </span>
-                )}
-                <span
-                  className="overflow-hidden text-ellipsis block leading-none"
-                  style={{
-                    fontSize: isSub ? '20px' : '22px',
-                    fontStyle: isSub ? 'italic' : undefined,
-                  }}
-                >
-                  {activityText}
-                </span>
-                {ch.folderName && (
-                  <span className="text-2xs leading-none overflow-hidden text-ellipsis block">
-                    {ch.folderName}
-                  </span>
+                </div>
+                {isSelected && !isSub && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCloseAgent(id);
+                    }}
+                    title="Close agent"
+                    className="ml-2 shrink-0 leading-none"
+                  >
+                    ×
+                  </Button>
                 )}
               </div>
-              {isSelected && !isSub && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onCloseAgent(id);
+              {progress !== null && (
+                <div
+                  className="overflow-hidden"
+                  style={{
+                    height: 4,
+                    background: TURN_PROGRESS_BAR_BG,
                   }}
-                  title="Close agent"
-                  className="ml-2 shrink-0 leading-none"
                 >
-                  ×
-                </Button>
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${progress}%`,
+                      background: hasPermission
+                        ? 'var(--color-status-permission)'
+                        : 'var(--color-status-active)',
+                      transition: 'width 0.3s ease-out',
+                    }}
+                  />
+                </div>
               )}
             </div>
             {isTeamAgent && totalTokens > 0 && (


### PR DESCRIPTION

- Port of [pixel-agents-hq/pixel-agents#136](https://github.com/pixel-agents-hq/pixel-agents/pull/136), adapted to the current `adapters/vscode/` + `server/` + `core/` architecture
- **Cursor IDE compatibility**: runtime IDE detection, `engines.vscode` lowered to `^1.85.0`, Settings footer shows host IDE
- **Auto-adopt terminals**: matches pre-open Claude terminals to recent JSONL files on startup
- **Agent hover tooltip (F01)**: agent label + logarithmic turn progress bar
- Adds `ROADMAP.md` from upstream PR
## Test plan
- [ ] VS Code — no regressions
- [ ] Cursor IDE — panel + "Running in Cursor" in Settings
- [ ] Terminal abierto antes de activar extensión → personaje adoptado
- [ ] Hover durante turno activo → barra de progreso
- [x] `npm run check-types` + server tests (209 passed)