### PR TITLE
test: fix Windows homedir sandbox isolation in server tests

### DIFF
--- a/server/__tests__/claude-hook.test.ts
+++ b/server/__tests__/claude-hook.test.ts
@@ -23,7 +23,9 @@ function writeServerJson(port: number, token: string): void {
 function runHookScript(stdin: string): Promise<{ code: number | null; stdout: string }> {
   return new Promise((resolve) => {
     const child = spawn('node', [HOOK_SCRIPT], {
-      env: { ...process.env, HOME: tmpBase },
+      // Set both HOME (POSIX) and USERPROFILE (Windows) so the child's
+      // os.homedir() resolves to the sandbox on every platform.
+      env: { ...process.env, HOME: tmpBase, USERPROFILE: tmpBase },
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     });

--- a/server/__tests__/fileStateAdapter.test.ts
+++ b/server/__tests__/fileStateAdapter.test.ts
@@ -1,27 +1,27 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PersistedAgent } from '../../core/src/schemas.js';
 import { FileStateAdapter } from '../src/fileStateAdapter.js';
 
-describe('FileStateAdapter', () => {
-  let tempHome: string;
-  let originalHome: string | undefined;
+// Mock os.homedir() so all ~/.pixel-agents I/O is sandboxed. Setting
+// process.env.HOME is insufficient on Windows, where os.homedir() reads
+// USERPROFILE and ignores HOME, causing tests to escape the sandbox and
+// read/write the real ~/.pixel-agents dir.
+let tempHome: string;
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tempHome };
+});
 
+describe('FileStateAdapter', () => {
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-adapter-test-'));
-    originalHome = process.env.HOME;
-    process.env.HOME = tempHome;
   });
 
   afterEach(() => {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 

--- a/server/__tests__/migrateVsCodeState.test.ts
+++ b/server/__tests__/migrateVsCodeState.test.ts
@@ -10,6 +10,16 @@ vi.mock('vscode', () => ({
   window: { showWarningMessage },
 }));
 
+// Mock os.homedir() so all ~/.pixel-agents I/O is sandboxed. Setting
+// process.env.HOME is insufficient on Windows, where os.homedir() reads
+// USERPROFILE and ignores HOME, causing tests to escape the sandbox and
+// read/write the real ~/.pixel-agents dir.
+let tempHome: string;
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tempHome };
+});
+
 import { migrateVsCodeState } from '../../adapters/vscode/migrateVsCodeState.js';
 import { FileStateAdapter } from '../src/fileStateAdapter.js';
 import { readLayoutFromFile, writeLayoutToFile } from '../src/layoutPersistence.js';
@@ -50,19 +60,12 @@ function makeContext(globalSeed = {}, workspaceSeed = {}) {
 }
 
 describe('migrateVsCodeState', () => {
-  let tempHome: string;
-  let originalHome: string | undefined;
-
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-migrate-test-'));
-    originalHome = process.env.HOME;
-    process.env.HOME = tempHome;
     showWarningMessage.mockReset();
   });
 
   afterEach(() => {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 
@@ -172,7 +175,9 @@ describe('migrateVsCodeState', () => {
     // Simulate by replacing with a file (so mkdirSync fails on subpath).
     const blocker = path.join(tempHome, 'blocker');
     fs.writeFileSync(blocker, 'x');
-    process.env.HOME = blocker; // HOME is now a file; can't mkdir inside
+    // Point homedir at a file (the mock reads tempHome at call time); mkdir of
+    // ~/.pixel-agents inside it will fail, simulating an unwritable home.
+    tempHome = blocker;
 
     const { context, globalStore } = makeContext({
       'pixel-agents.soundEnabled': false,


### PR DESCRIPTION
In Windows environments, `os.homedir()` ignores `process.env.HOME` and resolves to `USERPROFILE`. As a result, server tests were bypassing the intended sandbox, polluting the user's real home directory (`~/.pixel-agents/` and `~/.claude/settings.json`), and causing 6-10 test failures.

This PR replaces the `HOME` env variable overrides with a consistent `vi.mock('os')` pattern to ensure proper sandbox isolation on all platforms. All server and webview tests now pass successfully on Windows without real home pollution.

## Details
- `fileStateAdapter.test.ts` / `migrateVsCodeState.test.ts`: drop `process.env.HOME` override; mock `os.homedir()` via `vi.mock('os')` (mirrors the existing pattern in `claudeHookInstaller.test.ts`). `vi.spyOn(os, 'homedir')` is not usable here — the ESM `os` namespace property is non-configurable (`Cannot redefine property`).
- `claude-hook.test.ts`: the hook runs in a spawned child process, so set both `HOME` and `USERPROFILE` in its env so the child's `os.homedir()` resolves to the sandbox cross-platform.

## Verification
- `npm run test:server` → 209/209 pass (was 6-10 failing on Windows)
- `npm run test:webview` → 2/2 pass
- Confirmed no real-home pollution after the run.