### PR TITLE
chore(deps): override vulnerable devDependencies in asyncapi tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10001,13 +10001,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/@stoplight/spectral-cli/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@stoplight/spectral-cli/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16088,9 +16081,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -24976,16 +24969,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parserapiv1/node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/parserapiv1/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -25085,16 +25068,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/parserapiv2/node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/parserapiv2/node_modules/node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0"
   },
+  "overrides": {
+    "jsonpath-plus": "^10.4.0",
+    "fast-uri": "^3.1.2",
+    "lodash": "^4.18.1"
+  },
   "lint-staged": {
     "adapters/vscode/**/*.ts": "eslint --fix",
     "server/**/*.ts": "eslint --fix",


### PR DESCRIPTION
The `@asyncapi/cli` dependency tree introduces several high/critical vulnerabilities (such as a critical RCE in `jsonpath-plus`). Since running `npm audit fix --force` incorrectly downgrades `@asyncapi/cli` from 6.x to 2.x and increases vulnerabilities, this PR uses explicit npm `overrides` to safely remediate them without breaking the build.

### Changes
- `jsonpath-plus`: Overridden to `^10.4.0` (fixes critical RCE)
- `fast-uri`: Overridden to `^3.1.2` (fixes high path traversal)
- `lodash`: Overridden to `^4.18.1` (fixes high code injection / prototype pollution)

### Verification
- Verified that `npm run build` / `asyncapi:generate` completes successfully (Exit 0, 52 models generated).
- Critical vulnerabilities dropped from 6 to 0. Residual devDependency issues (like `next`) are kept as-is to avoid breaking CLI subcommands.

> Note: the requested `lodash ^4.17.21` / `jsonpath-plus ^10.2.1` were adjusted to the actually-published fixed versions (`4.18.1` / `10.4.0`), since `npm audit` flags `lodash <=4.17.23` and `jsonpath-plus <=10.2.0` as vulnerable.