### PR TITLE
fix: resolve hook script source path in standalone CLI

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -61,6 +61,10 @@ async function main(): Promise<void> {
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
   const staticDir = path.join(distRoot, 'webview');
+  // copyHookScript() expects the extension/package root and appends "dist/hooks"
+  // itself, so pass the parent of distRoot (the package root) — not distRoot,
+  // which would resolve to dist/dist/hooks and fail to find the hook script.
+  const extensionRoot = path.dirname(distRoot);
 
   // ── Load assets on startup (same pipeline as VS Code extension) ──
   console.log('[Pixel Agents] Loading assets...');
@@ -104,7 +108,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(extensionRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -132,7 +136,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(extensionRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);


### PR DESCRIPTION
## Problem
Starting the standalone server (`node dist/cli.js`) logs:

```
[Pixel Agents] Hooks installed in ~/.claude/settings.json
[Pixel Agents] Hook script not found at <root>/dist/dist/hooks/claude-hook.js
```

`copyHookScript(extensionPath)` appends `dist/hooks` to its argument, expecting the **extension/package root**. The CLI passed `distRoot` (`__dirname`, which is the `dist` directory itself), so the source resolved to `dist/dist/hooks/claude-hook.js` — a path that never exists.

As a result the hook script was **never copied** to `~/.pixel-agents/hooks/`, yet the hook entries pointing there were still written into `~/.claude/settings.json`. Every subsequent Claude Code session then tried to run a missing script on every hook event.

## Fix
Pass `path.dirname(distRoot)` (the package root) so the source correctly resolves to `dist/hooks/claude-hook.js`. The VS Code caller (`PixelAgentsViewProvider`) already passes `context.extensionPath` (the extension root) and is unaffected — `copyHookScript`'s contract is unchanged.

## Verification
Before: `Hook script not found at ...\dist\dist\hooks\claude-hook.js`
After:  `Hook script installed at C:\Users\<user>\.pixel-agents\hooks\claude-hook.js` (file present, 2651 bytes).

`npm run build` passes.