### PR TITLE
feat: org roles & departments with webview profile display

### DIFF
--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -96,6 +96,11 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         parentAgentId: agent.leadAgentId,
         teamName: agent.teamName,
         hooksOnly: agent.hooksOnly || undefined,
+        name: agent.name,
+        role: agent.role,
+        department: agent.department,
+        palette: agent.palette,
+        hueShift: agent.hueShift,
       });
     });
     this.store.on('agentRemoved', (id) => {

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -174,6 +174,21 @@ components:
           type: string
         isExternal:
           type: boolean
+        name:
+          type: string
+          description: Persona display name (e.g. "Sakura").
+        role:
+          type: string
+          description: Org role (e.g. "社長" for the main session, "部員" for teammates).
+        department:
+          type: string
+          description: Department (e.g. "役員室", "SNSマーケティング部-Instagram課").
+        palette:
+          type: integer
+          description: Fixed base character sprite index (0-5). Omitted = auto-assigned.
+        hueShift:
+          type: integer
+          description: Hue rotation in degrees for the sprite (e.g. 320 ≈ pink).
 
     AgentClosed:
       description: An agent has been removed from the office.

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -66,6 +66,11 @@ export interface AgentCreated {
   id: number;
   folderName?: string;
   isExternal?: boolean;
+  name?: string;
+  role?: string;
+  department?: string;
+  palette?: number;
+  hueShift?: number;
 }
 
 export interface AgentClosed {

--- a/core/src/schemas.ts
+++ b/core/src/schemas.ts
@@ -19,6 +19,11 @@ export interface PersistedAgent {
   isTeamLead?: boolean;
   leadAgentId?: number;
   teamUsesTmux?: boolean;
+
+  // -- Org profile (name / role / department) --
+  name?: string;
+  role?: string;
+  department?: string;
 }
 
 /** Agent seat assignment with visual identity */

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -374,6 +374,9 @@ export class AgentRuntime {
         isTeamLead: p.isTeamLead,
         leadAgentId: p.leadAgentId,
         teamUsesTmux: p.teamUsesTmux,
+        name: p.name,
+        role: p.role,
+        department: p.department,
       };
 
       this.store.set(p.id, agent);

--- a/server/src/agentStateStore.ts
+++ b/server/src/agentStateStore.ts
@@ -138,6 +138,9 @@ export class AgentStateStore {
         isTeamLead: agent.isTeamLead,
         leadAgentId: agent.leadAgentId,
         teamUsesTmux: agent.teamUsesTmux,
+        name: agent.name,
+        role: agent.role,
+        department: agent.department,
       });
     }
     this.adapter.saveAgents(persisted);

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -39,6 +39,7 @@ import {
   PROJECT_SCAN_INTERVAL_MS,
 } from './constants.js';
 import type { DismissalTracker } from './dismissalTracker.js';
+import { mainSessionProfile, teammateProfile } from './profiles.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
 import { processTranscriptLine } from './transcriptParser.js';
 import type { AgentState } from './types.js';
@@ -514,6 +515,8 @@ function adoptTerminalForFile(
     hookDelivered: false,
     inputTokens: 0,
     outputTokens: 0,
+    // Main session (the user themself) -> boss profile: Sakura / 社長 / 役員室.
+    ...mainSessionProfile(),
   };
 
   agents.set(id, agent);
@@ -682,6 +685,8 @@ export function scanForTeammateFiles(
       agentName: teammateName,
       leadAgentId: parentAgentId,
       teamName: parentAgent?.teamName,
+      // Teammate -> a random SNS marketing department + 部員 role.
+      ...teammateProfile(teammateName),
     };
 
     agents.set(id, agent);
@@ -880,6 +885,8 @@ export function adoptExternalSessionFromHook(
       folderName,
       inputTokens: 0,
       outputTokens: 0,
+      // Primary external session (the user themself) -> boss profile.
+      ...mainSessionProfile(),
     };
     agents.set(id, agent);
     persistAgents();
@@ -939,6 +946,8 @@ function adoptExternalSession(
     folderName,
     inputTokens: 0,
     outputTokens: 0,
+    // Primary external session (the user themself) -> boss profile.
+    ...mainSessionProfile(),
   };
 
   agents.set(id, agent);

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -161,6 +161,11 @@ function registerWebSocketRoute(app: FastifyInstance, options: HttpServerOptions
         parentAgentId: agent.leadAgentId,
         teamName: agent.teamName,
         hooksOnly: agent.hooksOnly || undefined,
+        name: agent.name,
+        role: agent.role,
+        department: agent.department,
+        palette: agent.palette,
+        hueShift: agent.hueShift,
       });
     };
 

--- a/server/src/profiles.ts
+++ b/server/src/profiles.ts
@@ -1,0 +1,120 @@
+/**
+ * Org-chart profiles for agents: name, role, and department.
+ *
+ * - The user's own main session (the primary detected Claude session) is the
+ *   "boss": Sakura / 社長（CEO / Claude 4.7） / 役員室.
+ * - Spawned teammates / sub-sessions are randomly assigned to one of the six
+ *   company departments, each with its own model and duties.
+ */
+
+/** Profile fields attached to an agent (all optional on AgentState). */
+export interface AgentProfile {
+  /** Display name of the persona (e.g. "Sakura"). */
+  name?: string;
+  /** Role within the org, incl. model (e.g. "社長（CEO / Claude 4.7）", "開発担当 (Sonnet 4.6)"). */
+  role?: string;
+  /** Department + duties (e.g. "エンジニアリング部（コード設計・実装・デバッグ）"). */
+  department?: string;
+  /**
+   * Base character sprite index (0-5, matching char_0.png..char_5.png). When
+   * set, the webview uses this fixed sprite instead of an auto-assigned one.
+   */
+  palette?: number;
+  /** Hue rotation in degrees applied to the sprite (e.g. 320 ≈ pink). */
+  hueShift?: number;
+}
+
+/**
+ * Default profile for the user's own main session (the boss).
+ *
+ * Appearance: char_3 is the long-haired, light-toned base sprite; a hue shift
+ * of 320° tints the hair pink while skin tones are preserved (see adjustSprite
+ * `preserveSkin`) — a pink long-haired, fair-skinned "president" look.
+ */
+export const MAIN_SESSION_PROFILE: Readonly<Required<AgentProfile>> = {
+  name: 'Sakura',
+  role: '社長（CEO / Claude 4.7）',
+  department: '役員室',
+  palette: 3,
+  hueShift: 320,
+};
+
+/** One department in the company org chart. */
+export interface DepartmentDef {
+  /** Department name (e.g. "エンジニアリング部"). */
+  name: string;
+  /** Claude model the department's agents run on. */
+  model: string;
+  /** Short role/title label for members (incl. model). */
+  role: string;
+  /** Duties / area of responsibility. */
+  duties: string;
+}
+
+/**
+ * The six company departments a teammate / sub-session can be assigned to.
+ * Add or edit departments here to update the org chart.
+ */
+export const ORG_DEPARTMENTS: readonly DepartmentDef[] = [
+  {
+    name: 'エンジニアリング部',
+    model: 'Sonnet 4.6',
+    role: '開発担当 (Sonnet 4.6)',
+    duties: 'コード設計・実装・デバッグ',
+  },
+  {
+    name: 'マーケティング部',
+    model: 'Sonnet 4.6',
+    role: 'マーケ担当 (Sonnet 4.6)',
+    duties: '戦略・コピーライティング・SNS',
+  },
+  {
+    name: 'デザイン部',
+    model: 'Sonnet 4.6',
+    role: 'デザイン担当 (Sonnet 4.6)',
+    duties: 'UI/UX・ブランディング・ビジュアル',
+  },
+  {
+    name: 'リサーチ部',
+    model: 'Sonnet 4.6',
+    role: 'リサーチ担当 (Sonnet 4.6)',
+    duties: '市場調査・競合分析・トレンド',
+  },
+  {
+    name: '人事部',
+    model: 'Haiku 4.5',
+    role: '人事担当 (Haiku 4.5)',
+    duties: '採用・組織設計・人材育成',
+  },
+  {
+    name: '財務部',
+    model: 'Haiku 4.5',
+    role: '財務担当 (Haiku 4.5)',
+    duties: '予算・コスト分析・財務戦略',
+  },
+];
+
+/** Pick a department at random for a newly spawned teammate / sub-session. */
+export function pickRandomDepartment(): DepartmentDef {
+  const index = Math.floor(Math.random() * ORG_DEPARTMENTS.length);
+  return ORG_DEPARTMENTS[index];
+}
+
+/** Profile applied to the user's main session (the boss). */
+export function mainSessionProfile(): Required<AgentProfile> {
+  return { ...MAIN_SESSION_PROFILE };
+}
+
+/**
+ * Profile applied to a spawned teammate / sub-session: a random department with
+ * its role (incl. model) and a department-plus-duties label. Optionally carries
+ * the teammate's name.
+ */
+export function teammateProfile(name?: string): AgentProfile {
+  const dept = pickRandomDepartment();
+  return {
+    name,
+    role: dept.role,
+    department: `${dept.name}（${dept.duties}）`,
+  };
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -58,6 +58,18 @@ export interface AgentState {
   leadAgentId?: number;
   /** True when lead spawns teammates via tmux (run_in_background Agent calls) */
   teamUsesTmux?: boolean;
+
+  // -- Org profile (name / role / department) --
+  /** Persona display name (e.g. "Sakura"). */
+  name?: string;
+  /** Org role (e.g. "社長" for the main session, "部員" for teammates). */
+  role?: string;
+  /** Department (e.g. "役員室", "SNSマーケティング部-Instagram課"). */
+  department?: string;
+  /** Fixed base character sprite index (0-5). Undefined = auto-assigned. */
+  palette?: number;
+  /** Hue rotation in degrees for the sprite (e.g. 320 ≈ pink). */
+  hueShift?: number;
 }
 
 export interface PersistedAgent {
@@ -78,4 +90,9 @@ export interface PersistedAgent {
   isTeamLead?: boolean;
   leadAgentId?: number;
   teamUsesTmux?: boolean;
+
+  // -- Org profile (name / role / department) --
+  name?: string;
+  role?: string;
+  department?: string;
 }

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -168,6 +168,11 @@ export function useExtensionMessages(
         const teammateName = msg.teammateName as string | undefined;
         const teammateParentId = msg.parentAgentId as number | undefined;
         const teamName = msg.teamName as string | undefined;
+        const profileName = msg.name as string | undefined;
+        const profileRole = msg.role as string | undefined;
+        const profileDepartment = msg.department as string | undefined;
+        const profilePalette = msg.palette as number | undefined;
+        const profileHueShift = msg.hueShift as number | undefined;
         setAgents((prev) => (prev.includes(id) ? prev : [...prev, id]));
         // Don't auto-select teammates (keep focus on lead)
         if (!isTeammate) {
@@ -186,9 +191,20 @@ export function useExtensionMessages(
             ch.leadAgentId = teammateParentId;
             ch.teamName = teamName ?? parentCh?.teamName;
             ch.agentName = teammateName;
+            ch.name = profileName;
+            ch.role = profileRole;
+            ch.department = profileDepartment;
           }
         } else {
-          os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+          // Main session: honor a fixed profile look (e.g. Sakura = char_3 + pink
+          // hueShift) when provided; otherwise fall back to auto-assignment.
+          os.addAgent(id, profilePalette, profileHueShift, undefined, undefined, folderName);
+          const ch = os.characters.get(id);
+          if (ch) {
+            ch.name = profileName;
+            ch.role = profileRole;
+            ch.department = profileDepartment;
+          }
         }
         saveAgentSeats(os);
       } else if (msg.type === 'agentClosed') {

--- a/webview-ui/src/office/colorize.ts
+++ b/webview-ui/src/office/colorize.ts
@@ -168,14 +168,33 @@ function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
 }
 
 /**
+ * Heuristic: is this HSL color a human skin tone?
+ *
+ * Skin (light/Japanese complexion included) sits in the warm orange-peach hue
+ * band with moderate saturation and high lightness. Used to exclude skin pixels
+ * from character hue shifts so e.g. a pink-haired persona keeps a natural skin
+ * color instead of turning fully pink.
+ */
+export function isSkinTone(h: number, s: number, l: number): boolean {
+  return h >= 10 && h <= 55 && s >= 0.1 && s <= 0.8 && l >= 0.35 && l <= 0.95;
+}
+
+/**
  * Adjust a sprite's colors by shifting HSL values (default mode for furniture).
  *
  * H slider (-180 to +180): rotates hue
  * S slider (-100 to +100): shifts saturation
  * B slider (-100 to 100): shifts lightness
  * C slider (-100 to 100): adjusts contrast around midpoint
+ *
+ * When `preserveSkin` is true, pixels detected as skin tones are left unchanged
+ * (used for character hue shifts so skin keeps its natural color).
  */
-export function adjustSprite(sprite: SpriteData, color: ColorValue): SpriteData {
+export function adjustSprite(
+  sprite: SpriteData,
+  color: ColorValue,
+  preserveSkin = false,
+): SpriteData {
   const { h: hShift, s: sShift, b, c } = color;
   const result: SpriteData = [];
 
@@ -192,6 +211,12 @@ export function adjustSprite(sprite: SpriteData, color: ColorValue): SpriteData 
       const bv = parseInt(pixel.slice(5, 7), 16);
       const alpha = extractAlpha(pixel);
       const [origH, origS, origL] = rgbToHsl(r, g, bv);
+
+      // Keep skin tones as-is so they don't get tinted by the hue shift.
+      if (preserveSkin && isSkinTone(origH, origS, origL)) {
+        newRow.push(pixel);
+        continue;
+      }
 
       // Shift hue
       const newH = (((origH + hShift) % 360) + 360) % 360;

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -157,7 +157,14 @@ export function ToolOverlay({
         const teamRoleLabel = ch.isTeamLead ? 'LEAD' : ch.agentName || null;
         const totalTokens = ch.inputTokens + ch.outputTokens;
         const tokenRatio = totalTokens / MAX_CONTEXT_TOKENS;
-        const hasExtraLines = !!(ch.folderName || teamRoleLabel);
+        // Org profile: "名前 ・ 役割" headline + department subline.
+        const profileNameRole = [ch.name, ch.role].filter(Boolean).join(' ・ ') || null;
+        const hasExtraLines = !!(
+          ch.folderName ||
+          teamRoleLabel ||
+          profileNameRole ||
+          ch.department
+        );
 
         return (
           <div
@@ -179,6 +186,22 @@ export function ToolOverlay({
                 />
               )}
               <div className="flex flex-col gap-0 overflow-hidden">
+                {profileNameRole && (
+                  <span
+                    className="overflow-hidden text-ellipsis block leading-none"
+                    style={{ fontSize: '18px', fontWeight: 'bold' }}
+                  >
+                    {profileNameRole}
+                  </span>
+                )}
+                {ch.department && (
+                  <span
+                    className="text-2xs leading-none overflow-hidden text-ellipsis block"
+                    style={{ color: TEAM_ROLE_COLOR }}
+                  >
+                    {ch.department}
+                  </span>
+                )}
                 {teamRoleLabel && (
                   <span
                     className="overflow-hidden text-ellipsis block leading-none"

--- a/webview-ui/src/office/sprites/spriteData.ts
+++ b/webview-ui/src/office/sprites/spriteData.ts
@@ -67,7 +67,9 @@ const spriteCache = new Map<string, CharacterSprites>();
 /** Apply hue shift to every sprite in a CharacterSprites set */
 function hueShiftSprites(sprites: CharacterSprites, hueShift: number): CharacterSprites {
   const color: ColorValue = { h: hueShift, s: 0, b: 0, c: 0 };
-  const shift = (s: SpriteData) => adjustSprite(s, color);
+  // preserveSkin=true: skin-tone pixels keep their natural color (so e.g. a
+  // pink-haired persona doesn't get pink skin); hair/clothes still shift.
+  const shift = (s: SpriteData) => adjustSprite(s, color, true);
   const shiftWalk = (
     arr: [SpriteData, SpriteData, SpriteData, SpriteData],
   ): [SpriteData, SpriteData, SpriteData, SpriteData] => [

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -192,6 +192,14 @@ export interface Character {
   leadAgentId?: number;
   /** True when lead spawns teammates via tmux (run_in_background Agent calls) */
   teamUsesTmux?: boolean;
+
+  // -- Org profile (name / role / department) --
+  /** Persona display name (e.g. "Sakura") */
+  name?: string;
+  /** Org role (e.g. "社長", "部員") */
+  role?: string;
+  /** Department (e.g. "役員室", "SNSマーケティング部-Instagram課") */
+  department?: string;
   /** Cumulative input tokens consumed */
   inputTokens: number;
   /** Cumulative output tokens consumed */


### PR DESCRIPTION
Adds an org-chart identity model for agents (name / role / department) and shows it above each character in the office.

## What it does
- **Main session = the boss.** The user's own detected session is assigned `Sakura` / `社長（CEO / Claude 4.7）` / `役員室`, with a fixed look: base sprite `char_3` (long hair) + `hueShift` 320 (pink).
- **Teammates get a department.** Spawned teammates / sub-sessions are randomly assigned to one of six departments, each with its model, role label, and duties:
  | 部署 | モデル | 役割 | 担当業務 |
  |---|---|---|---|
  | エンジニアリング部 | Sonnet 4.6 | 開発担当 | コード設計・実装・デバッグ |
  | マーケティング部 | Sonnet 4.6 | マーケ担当 | 戦略・コピーライティング・SNS |
  | デザイン部 | Sonnet 4.6 | デザイン担当 | UI/UX・ブランディング・ビジュアル |
  | リサーチ部 | Sonnet 4.6 | リサーチ担当 | 市場調査・競合分析・トレンド |
  | 人事部 | Haiku 4.5 | 人事担当 | 採用・組織設計・人材育成 |
  | 財務部 | Haiku 4.5 | 財務担当 | 予算・コスト分析・財務戦略 |

## Changes
- `server/src/profiles.ts` (new): profile + org-chart definitions and assignment helpers.
- `server/src/fileWatcher.ts`: assign profiles at session-detection sites.
- Plumb `name/role/department` (+`palette/hueShift`) through `AgentState`, `PersistedAgent`, persistence/restore, the `agentCreated` message, and the asyncapi schema (regenerated `messages.ts`).
- webview: store fields on `Character`; render `name・role` + a department/duties line in `ToolOverlay`; apply the fixed palette/hueShift for the main session.
- `colorize.ts`: `adjustSprite` gains a `preserveSkin` option; the character hue shift skips skin-tone pixels so a pink-haired persona keeps natural (fair) skin instead of turning fully pink.

## Verification
`npm run build` passes (type regen + check-types + lint + esbuild + vite).