### PR TITLE
fix(standalone): Windows build + hook-script install

### DIFF
--- a/scripts/generate-messages.ts
+++ b/scripts/generate-messages.ts
@@ -137,6 +137,13 @@ function exportify(decl: string): string {
 }
 
 function quote(s: string): string {
+  // cmd.exe (Windows) does not treat single quotes as string delimiters, so a
+  // single-quoted path is passed through literally and the tool can't find it.
+  // Windows paths cannot contain `"`, so double-quoting is safe there. POSIX
+  // shells keep single-quote escaping for paths that may contain quotes/spaces.
+  if (process.platform === 'win32') {
+    return `"${s}"`;
+  }
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -61,6 +61,10 @@ async function main(): Promise<void> {
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
   const staticDir = path.join(distRoot, 'webview');
+  // copyHookScript() joins `<root>/dist/hooks/...`, so it needs the app root that
+  // *contains* dist/. distRoot is already the dist dir → pass its parent, else the
+  // hook script is looked up at dist/dist/hooks/ and never installed (standalone).
+  const appRoot = path.join(distRoot, '..');
 
   // ── Load assets on startup (same pipeline as VS Code extension) ──
   console.log('[Pixel Agents] Loading assets...');
@@ -104,7 +108,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(appRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -132,7 +136,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(appRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);


### PR DESCRIPTION
Two bugs that break the standalone server (`node dist/cli.js` / `npx pixel-agents`):

### 1. Windows build failure (`npm run asyncapi:generate`)
`scripts/generate-messages.ts` wraps the prettier/eslint target path in POSIX single quotes via `quote()`. cmd.exe treats single quotes literally, so prettier receives a path that includes the quote characters → `No files matching the pattern` → `process.exit(1)` → the whole `npm run build` chain dies on Windows. Fixed by double-quoting on `win32` (Windows paths can't contain `"`).

### 2. Hook script never installed in standalone mode (all OSes)
`cli.ts` calls `copyHookScript(distRoot)`, but `copyHookScript()` joins `<root>/dist/hooks/<script>` internally. `distRoot` is already the `dist` dir, so it looks in `dist/dist/hooks/` (logs `Hook script not found at .../dist/dist/hooks/claude-hook.js`) and never copies the hook to `~/.pixel-agents/hooks/`. Result: the installed Claude Code hook points at a missing script and silently never fires in standalone mode (detection falls back to filesystem heuristics only). Fixed by passing the parent (the app root that contains `dist/`).

Both verified on Windows 11 + Node 24: the build now completes and `node dist/cli.js` installs the hook script and detects sessions via hooks. Found while building a standalone Electron desktop wrapper around the server.