### PR TITLE
fix: cross-platform build script and server tests

### DIFF
--- a/server/__tests__/claude-hook.test.ts
+++ b/server/__tests__/claude-hook.test.ts
@@ -63,7 +63,9 @@ function runHookScript(
 ): Promise<{ code: number | null; stdout: string }> {
   return new Promise((resolve) => {
     const child = spawn('node', [HOOK_SCRIPT], {
-      env: { ...process.env, HOME: tmpBase, ...extraEnv },
+      // Set both HOME (POSIX) and USERPROFILE (Windows) so the child's
+      // os.homedir() resolves to the isolated temp dir on every platform.
+      env: { ...process.env, HOME: tmpBase, USERPROFILE: tmpBase, ...extraEnv },
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     });

--- a/server/__tests__/fileStateAdapter.test.ts
+++ b/server/__tests__/fileStateAdapter.test.ts
@@ -1,27 +1,29 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PersistedAgent } from '../../core/src/schemas.js';
-import { FileStateAdapter } from '../src/fileStateAdapter.js';
+
+// Mock os.homedir() so the adapter resolves to an isolated temp dir on every
+// platform. Overriding process.env.HOME is not portable: os.homedir() reads
+// USERPROFILE on Windows, so a HOME-only override would still hit the real
+// home directory.
+let tempHome: string;
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tempHome };
+});
+
+// Must import AFTER mock setup.
+const { FileStateAdapter } = await import('../src/fileStateAdapter.js');
 
 describe('FileStateAdapter', () => {
-  let tempHome: string;
-  let originalHome: string | undefined;
-
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-adapter-test-'));
-    originalHome = process.env.HOME;
-    process.env.HOME = tempHome;
   });
 
   afterEach(() => {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 

--- a/server/__tests__/migrateVsCodeState.test.ts
+++ b/server/__tests__/migrateVsCodeState.test.ts
@@ -10,6 +10,17 @@ vi.mock('vscode', () => ({
   window: { showWarningMessage },
 }));
 
+// Mock os.homedir() for cross-platform temp-home isolation. Overriding
+// process.env.HOME is not portable: os.homedir() reads USERPROFILE on Windows.
+// `tempHome` is the temp dir we always clean up; `homeOverride` is what
+// homedir() returns (usually tempHome, but a bogus path in the write-failure test).
+let tempHome: string;
+let homeOverride: string;
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => homeOverride };
+});
+
 import { migrateVsCodeState } from '../../adapters/vscode/migrateVsCodeState.js';
 import { FileStateAdapter } from '../src/fileStateAdapter.js';
 import { readLayoutFromFile, writeLayoutToFile } from '../src/layoutPersistence.js';
@@ -50,19 +61,13 @@ function makeContext(globalSeed = {}, workspaceSeed = {}) {
 }
 
 describe('migrateVsCodeState', () => {
-  let tempHome: string;
-  let originalHome: string | undefined;
-
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-migrate-test-'));
-    originalHome = process.env.HOME;
-    process.env.HOME = tempHome;
+    homeOverride = tempHome;
     showWarningMessage.mockReset();
   });
 
   afterEach(() => {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 
@@ -172,7 +177,7 @@ describe('migrateVsCodeState', () => {
     // Simulate by replacing with a file (so mkdirSync fails on subpath).
     const blocker = path.join(tempHome, 'blocker');
     fs.writeFileSync(blocker, 'x');
-    process.env.HOME = blocker; // HOME is now a file; can't mkdir inside
+    homeOverride = blocker; // home is now a file; can't mkdir inside
 
     const { context, globalStore } = makeContext({
       'pixel-agents.soundEnabled': false,


### PR DESCRIPTION
## Summary

`npm run build` and `npm test` assumed POSIX semantics and failed on Windows — particularly when the user's home path contains a space (e.g. `C:\Users\Nouvel Utilisateur`). This PR makes both cross-platform. Changes are POSIX-safe (no behavior change on macOS/Linux).

## Problems fixed

### 1. Build broke on paths with spaces (`scripts/generate-messages.ts`)
`quote()` wrapped the output path in **single quotes**, which `cmd.exe` does not interpret. `prettier`/`eslint` then received the path split on the first space:

```
[error] No files matching the pattern were found: "'C:\Users\Nouvel".
[error] No files matching the pattern were found: "Utilisateur\pixel-agents\core\src\messages.ts'".
```

This aborted `npm run build` entirely. Fixed by using double quotes on `win32`.

### 2. Six server tests failed on Windows (`HOME` vs `USERPROFILE`)
The tests overrode `process.env.HOME` for temp-home isolation, but `os.homedir()` reads `USERPROFILE` on Windows, so the override was ignored and the tests touched the real `~/.pixel-agents`:

- **`fileStateAdapter.test.ts`** and **`migrateVsCodeState.test.ts`** — mock `os.homedir()` directly, matching the pattern already used in `server.test.ts` and `claudeHookInstaller.test.ts`. The write-failure case now repoints the mocked home at a *file* (so `mkdir` fails portably) instead of relying on a `HOME` override.
- **`claude-hook.test.ts`** — the hook runs in a spawned subprocess that can't be mocked, so the test now passes **both** `HOME` and `USERPROFILE` to the child's env.

## Testing

- `npm test` → **211/211 pass** on Windows (was 205/211).
- `npm run build` → green (type-check + lint + esbuild + Vite).
- No changes to runtime behavior; the extension code already used `os.homedir()` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
