### PR TITLE
feat: add experimental codex provider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}"
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Pixel Agents turns multi-agent AI systems into something you can actually see and manage. Each agent becomes a character in a pixel art office. They walk around, sit at their desk, and visually reflect what they are doing — typing when writing code, reading when searching files, waiting when it needs your attention.
 
-Right now it works as a VS Code extension with Claude Code. The vision though, is a fully agent-agnostic, platform-agnostic interface for orchestrating any AI agents, deployable anywhere.
+Right now it works as a VS Code extension with Claude Code, with experimental Codex support available through the `pixel-agents.provider` setting. The vision though, is a fully agent-agnostic, platform-agnostic interface for orchestrating any AI agents, deployable anywhere.
 
 This is the source code for the free Pixel Agents extension for VS Code — install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) or [Open VSX](https://open-vsx.org/extension/pablodelucca/pixel-agents) with the full furniture catalog included.
 
@@ -34,7 +34,7 @@ This is the source code for the free Pixel Agents extension for VS Code — inst
 
 ## Features
 
-- **One agent, one character** — every Claude Code terminal gets its own animated character
+- **One agent, one character** — every supported agent terminal gets its own animated character
 - **Live activity tracking** — characters animate based on what the agent is actually doing (writing, reading, running commands)
 - **Office layout editor** — design your office with floors, walls, and furniture using a built-in editor
 - **Speech bubbles** — visual indicators when an agent is waiting for input or needs permission
@@ -51,7 +51,7 @@ This is the source code for the free Pixel Agents extension for VS Code — inst
 ## Requirements
 
 - VS Code 1.105.0 or later
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured, or Codex installed and configured for the experimental Codex provider
 - **Platform**: Windows, Linux, and macOS are supported
 
 ## Getting Started
@@ -73,10 +73,22 @@ Then press **F5** in VS Code to launch the Extension Development Host.
 ### Usage
 
 1. Open the **Pixel Agents** panel (it appears in the bottom panel area alongside your terminal)
-2. Click **+ Agent** to spawn a new Claude Code terminal and its character. Right-click for the option to launch with `--dangerously-skip-permissions` (bypasses all tool approval prompts)
-3. Start coding with Claude — watch the character react in real time
+2. Click **+ Agent** to spawn a new agent terminal and its character. Right-click for the option to launch Claude Code with `--dangerously-skip-permissions` (bypasses all tool approval prompts)
+3. Start coding with your agent — watch the character react in real time
 4. Click a character to select it, then click a seat to reassign it
 5. Click **Layout** to open the office editor and customize your space
+
+### Provider selection
+
+Pixel Agents defaults to Claude Code. To try the experimental Codex provider, set:
+
+```json
+{
+  "pixel-agents.provider": "codex"
+}
+```
+
+Supported values are `claude` and `codex`.
 
 ## Layout Editor
 
@@ -104,7 +116,7 @@ Characters are based on the amazing work of [JIK-A-4, Metro City](https://jik-a-
 
 ## How It Works
 
-Pixel Agents watches Claude Code's JSONL transcript files to track what each agent is doing. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to Claude Code are needed — it's purely observational.
+Pixel Agents watches provider-specific JSONL transcript files to track what each agent is doing. Claude Code sessions are read from `~/.claude/projects/`; Codex sessions are read from `~/.codex/sessions/`. When an agent uses a tool (like writing a file or running a command), the extension detects it and updates the character's animation accordingly. No modifications to the agent CLI are needed — it's purely observational.
 
 The webview runs a lightweight game loop with canvas rendering, BFS pathfinding, and a character state machine (idle → walk → type/read). Everything is pixel-perfect at integer zoom levels.
 
@@ -117,6 +129,7 @@ The webview runs a lightweight game loop with canvas rendering, BFS pathfinding,
 
 - **Agent-terminal sync** — the way agents are connected to Claude Code terminal instances is not super robust and sometimes desyncs, especially when terminals are rapidly opened/closed or restored across sessions.
 - **Heuristic-based status detection** — Claude Code's JSONL transcript format does not provide clear signals for when an agent is waiting for user input or when it has finished its turn. The current detection is based on heuristics (idle timers, turn-duration events) and often misfires — agents may briefly show the wrong status or miss transitions.
+- **Codex support is experimental** — Codex currently uses JSONL session polling only. It tracks common tool calls such as shell commands and patch application, but it does not have Claude's hook integration or Agent Teams support yet.
 - **Linux/macOS tip** — if you launch VS Code without a folder open (e.g. bare `code` command), agents will start in your home directory. This is fully supported; just be aware your Claude sessions will be tracked under `~/.claude/projects/` using your home directory as the project root.
 
 ## Troubleshooting

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
+import type { HookProvider } from '../../core/src/provider.js';
 import { AgentRuntime } from '../../server/src/agentRuntime.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
 import type { LoadedAssets, LoadedCharacterSprites } from '../../server/src/assetLoader.js';
@@ -29,7 +30,7 @@ import {
   watchLayoutFile,
   writeLayoutToFile,
 } from '../../server/src/layoutPersistence.js';
-import { claudeProvider, copyHookScript } from '../../server/src/providers/index.js';
+import { claudeProvider, codexProvider, copyHookScript } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
 import {
   getProjectDirPath,
@@ -42,6 +43,7 @@ import {
 import {
   CONFIG_KEY_AUTO_SHOW_PANEL,
   CONFIG_KEY_AUTO_SPAWN_AGENT,
+  CONFIG_KEY_PROVIDER,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
@@ -74,6 +76,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   // Pixel Agents Server (hook event reception)
   private pixelAgentsServer: PixelAgentsServer | null = null;
   private adapter: StateAdapter;
+  private provider: HookProvider;
 
   // Auto-spawn guard: ensures the startup spawn fires at most once per VS Code
   // session, even though webviewReady fires on every panel focus.
@@ -84,6 +87,11 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     adapter: StateAdapter,
   ) {
     this.adapter = adapter;
+    const providerId =
+      process.env.PIXEL_AGENTS_PROVIDER ??
+      vscode.workspace.getConfiguration().get<string>(CONFIG_KEY_PROVIDER, 'claude');
+    this.provider = providerId === 'codex' ? codexProvider : claudeProvider;
+    console.log(`[Pixel Agents] Provider: ${this.provider.id}`);
     this.store.setAdapter(this.adapter);
     this.store.on('agentAdded', (id, agent) => {
       this.webview?.postMessage({
@@ -108,7 +116,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     setTerminalAdapter(new VscodeTerminalAdapter());
 
     // Create shared runtime (owns timer Maps, scanners, hook handler, dismissal tracker)
-    this.runtime = new AgentRuntime(this.store, claudeProvider);
+    this.runtime = new AgentRuntime(this.store, this.provider);
 
     this.initServer();
   }
@@ -134,9 +142,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // It's the foundation for WebSocket transport and health monitoring.
         // Only hook installation/script-copy is gated by the toggle.
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
-        this.runtime.hooksEnabled.current = hooksEnabled;
-        if (hooksEnabled) {
-          void claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
+        this.runtime.hooksEnabled.current = this.provider.id === 'claude' && hooksEnabled;
+        if (this.provider.id === 'claude' && hooksEnabled) {
+          void this.provider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
           copyHookScript(this.context.extensionPath);
         }
         console.log(`[Pixel Agents] Server: ready on port ${config.port}`);
@@ -167,6 +175,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           this.runtime.jsonlPollTimers,
           this.runtime.projectScanTimer,
           () => this.store.persist(),
+          this.provider,
           message.folderPath as string | undefined,
           message.bypassPermissions as boolean | undefined,
         );
@@ -217,17 +226,17 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
       } else if (message.type === 'setHooksEnabled') {
         const enabled = message.enabled as boolean;
         this.adapter.setSetting(GLOBAL_KEY_HOOKS_ENABLED, enabled);
-        this.runtime.hooksEnabled.current = enabled;
-        if (enabled) {
+        this.runtime.hooksEnabled.current = this.provider.id === 'claude' && enabled;
+        if (this.provider.id === 'claude' && enabled) {
           const serverConfig = this.pixelAgentsServer?.getConfig();
-          void claudeProvider.installHooks(
+          void this.provider.installHooks(
             serverConfig ? `http://127.0.0.1:${serverConfig.port}` : '',
             serverConfig?.token ?? '',
           );
           copyHookScript(this.context.extensionPath);
           console.log('[Pixel Agents] Hooks enabled by user');
         } else {
-          void claudeProvider.uninstallHooks();
+          void this.provider.uninstallHooks();
           console.log('[Pixel Agents] Hooks disabled by user');
         }
       } else if (message.type === 'setHooksInfoShown') {
@@ -246,7 +255,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           // Remove all external agents not from the current workspace folders
           const workspaceDirs = new Set<string>();
           for (const folder of vscode.workspace.workspaceFolders ?? []) {
-            const dir = getProjectDirPath(folder.uri.fsPath);
+            const dir = getProjectDirPath(this.provider, folder.uri.fsPath);
             if (dir) workspaceDirs.add(dir);
           }
           const toRemove: number[] = [];
@@ -271,8 +280,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // from the first frame.
         this.webview?.postMessage({
           type: 'providerCapabilities',
-          readingTools: [...claudeProvider.readingTools],
-          subagentToolNames: [...claudeProvider.subagentToolNames],
+          readingTools: [...this.provider.readingTools],
+          subagentToolNames: [...this.provider.subagentToolNames],
         });
         restoreAgents(
           this.adapter,
@@ -322,6 +331,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.runtime.jsonlPollTimers,
             this.runtime.projectScanTimer,
             () => this.store.persist(),
+            this.provider,
             undefined,
             undefined,
             autoShowPanel,
@@ -353,6 +363,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.runtime.watchAllSessions.current = watchAllSessions;
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         const hooksInfoShown = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_INFO_SHOWN, false);
+        this.runtime.hooksEnabled.current = this.provider.id === 'claude' && hooksEnabled;
         const config = readConfig();
         this.webview?.postMessage({
           type: 'settingsLoaded',
@@ -376,7 +387,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
 
         // Ensure project scan runs even with no restored agents (to adopt external terminals)
-        const projectDir = getProjectDirPath();
+        const projectDir = getProjectDirPath(this.provider);
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         console.log(`[Pixel Agents] Debug: Platform: ${process.platform}, arch: ${process.arch}`);
         console.log('[Extension] workspaceRoot:', workspaceRoot);
@@ -390,7 +401,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // so agents running in any workspace folder are discovered
         if (wsFolders && wsFolders.length > 1) {
           for (const folder of wsFolders) {
-            const folderProjectDir = getProjectDirPath(folder.uri.fsPath);
+            const folderProjectDir = getProjectDirPath(this.provider, folder.uri.fsPath);
             if (folderProjectDir && folderProjectDir !== projectDir) {
               console.log(`[Pixel Agents] Registering additional project dir: ${folderProjectDir}`);
               this.runtime.startProjectScan(folderProjectDir);
@@ -504,7 +515,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
         this.webview?.postMessage({ type: 'agentDiagnostics', agents: diagnostics });
       } else if (message.type === 'openSessionsFolder') {
-        const projectDir = getProjectDirPath();
+        const projectDir = getProjectDirPath(this.provider);
         if (projectDir && fs.existsSync(projectDir)) {
           vscode.env.openExternal(vscode.Uri.file(projectDir));
         }

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
+import type { HookProvider } from '../../core/src/provider.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
 import { JSONL_POLL_INTERVAL_MS } from '../../server/src/constants.js';
 import {
@@ -13,19 +14,18 @@ import {
   startFileWatching,
 } from '../../server/src/fileWatcher.js';
 import { loadLayout } from '../../server/src/layoutPersistence.js';
-import { CLAUDE_TERMINAL_NAME_PREFIX } from '../../server/src/providers/hook/claude/constants.js';
-import { claudeProvider } from '../../server/src/providers/index.js';
+import { findNewestCodexSessionFile } from '../../server/src/providers/index.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from '../../server/src/timerManager.js';
 import type { AgentState, PersistedAgent } from '../../server/src/types.js';
 
-export function getProjectDirPath(cwd?: string): string {
+export function getProjectDirPath(provider: HookProvider, cwd?: string): string {
   // Fall back to home directory when no workspace folder is open (common on Linux/macOS
   // when VS Code is launched without a folder). The provider's getSessionDirs already
   // implements the Windows case-insensitive fallback for drive-letter casing.
   const workspacePath = cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-  const dirs = claudeProvider.getSessionDirs?.(workspacePath) ?? [];
+  const dirs = provider.getSessionDirs?.(workspacePath) ?? [];
   if (dirs.length === 0) {
-    throw new Error('claudeProvider.getSessionDirs returned no directories');
+    throw new Error(`${provider.id}.getSessionDirs returned no directories`);
   }
   const projectDir = dirs[0];
   console.log(`[Pixel Agents] Terminal: Project dir: ${workspacePath} → ${projectDir}`);
@@ -45,6 +45,7 @@ export async function launchNewTerminal(
   jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
   projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
   persistAgents: () => void,
+  provider: HookProvider,
   folderPath?: string,
   bypassPermissions?: boolean,
   suppressShow?: boolean,
@@ -57,7 +58,7 @@ export async function launchNewTerminal(
   const isMultiRoot = !!(folders && folders.length > 1);
   const idx = nextTerminalIndexRef.current++;
   const terminal = vscode.window.createTerminal({
-    name: `${CLAUDE_TERMINAL_NAME_PREFIX} #${idx}`,
+    name: `${provider.terminalNamePrefix ?? provider.displayName} #${idx}`,
     cwd,
   });
   // When suppressShow is set (auto-spawn + autoShowPanel), keep the panel view
@@ -69,16 +70,19 @@ export async function launchNewTerminal(
   }
 
   const sessionId = crypto.randomUUID();
-  const launch = claudeProvider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });
+  const launch = provider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });
   if (!launch) {
-    throw new Error('claudeProvider.buildLaunchCommand is not implemented');
+    throw new Error(`${provider.id}.buildLaunchCommand is not implemented`);
   }
   terminal.sendText([launch.command, ...launch.args].join(' '));
 
-  const projectDir = getProjectDirPath(cwd);
+  const projectDir = getProjectDirPath(provider, cwd);
 
   // Pre-register expected JSONL file so project scan won't treat it as a /clear file
-  const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);
+  const expectedFile =
+    provider.id === 'codex'
+      ? path.join(projectDir, `${sessionId}.pending.jsonl`)
+      : path.join(projectDir, `${sessionId}.jsonl`);
   knownJsonlFiles.add(expectedFile);
 
   // Create agent immediately (before JSONL file exists)
@@ -107,6 +111,7 @@ export async function launchNewTerminal(
     seenUnknownRecordTypes: new Set(),
     folderName,
     hookDelivered: false,
+    providerId: provider.id,
     inputTokens: 0,
     outputTokens: 0,
   };
@@ -179,17 +184,21 @@ export async function launchNewTerminal(
         // Check every tick for a file modified after the agent was created.
         try {
           const trackedFiles = new Set([...agents.values()].map((a) => path.resolve(a.jsonlFile)));
-          const candidates = fs
-            .readdirSync(projectDir)
-            .filter((f) => f.endsWith('.jsonl'))
-            .map((f) => {
-              const full = path.join(projectDir, f);
-              return { file: full, mtime: fs.statSync(full).mtimeMs };
-            })
-            .filter((c) => !trackedFiles.has(path.resolve(c.file)) && c.mtime > createdAt)
-            .sort((a, b) => b.mtime - a.mtime); // newest first
+          const codexFile =
+            provider.id === 'codex' ? findNewestCodexSessionFile(createdAt, cwd) : null;
+          const candidates = codexFile
+            ? [{ file: codexFile, mtime: fs.statSync(codexFile).mtimeMs }]
+            : fs
+                .readdirSync(projectDir)
+                .filter((f) => f.endsWith('.jsonl'))
+                .map((f) => {
+                  const full = path.join(projectDir, f);
+                  return { file: full, mtime: fs.statSync(full).mtimeMs };
+                })
+                .filter((c) => !trackedFiles.has(path.resolve(c.file)) && c.mtime > createdAt)
+                .sort((a, b) => b.mtime - a.mtime); // newest first
 
-          if (candidates.length > 0) {
+          if (candidates.length > 0 && !trackedFiles.has(path.resolve(candidates[0].file))) {
             console.log(
               `[Pixel Agents] Terminal: Agent ${id} - /resume detected, reassigning to ${path.basename(candidates[0].file)}`,
             );
@@ -270,6 +279,7 @@ export function persistAgents(agents: AgentStateStore, adapter: StateAdapter): v
       isTeamLead: agent.isTeamLead,
       leadAgentId: agent.leadAgentId,
       teamUsesTmux: agent.teamUsesTmux,
+      providerId: agent.providerId,
     });
   }
   adapter.saveAgents(persisted);
@@ -351,6 +361,7 @@ export function restoreAgents(
       isTeamLead: p.isTeamLead,
       leadAgentId: p.leadAgentId,
       teamUsesTmux: p.teamUsesTmux,
+      providerId: p.providerId,
     };
 
     store.set(p.id, agent);

--- a/adapters/vscode/constants.ts
+++ b/adapters/vscode/constants.ts
@@ -18,6 +18,7 @@ export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
 // ── VS Code Settings (contributes.configuration keys) ───────
 export const CONFIG_KEY_AUTO_SHOW_PANEL = 'pixel-agents.autoShowPanel';
 export const CONFIG_KEY_AUTO_SPAWN_AGENT = 'pixel-agents.autoSpawnAgent';
+export const CONFIG_KEY_PROVIDER = 'pixel-agents.provider';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';

--- a/core/src/schemas.ts
+++ b/core/src/schemas.ts
@@ -13,6 +13,7 @@ export interface PersistedAgent {
   isExternal?: boolean;
   jsonlFile: string;
   projectDir: string;
+  providerId?: string;
   folderName?: string;
   teamName?: string;
   agentName?: string;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,16 @@
         "pixel-agents.autoSpawnAgent": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically spawn a Claude Code agent when VS Code starts, if no agents are currently running."
+          "description": "Automatically spawn an agent when VS Code starts, if no agents are currently running."
+        },
+        "pixel-agents.provider": {
+          "type": "string",
+          "enum": [
+            "claude",
+            "codex"
+          ],
+          "default": "claude",
+          "description": "AI coding CLI provider used by the + Agent button and session parser."
         }
       }
     }

--- a/server/__tests__/codex.test.ts
+++ b/server/__tests__/codex.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+import { processTranscriptLine, setHookProvider } from '../src/transcriptParser.js';
+import type { AgentState } from '../src/types.js';
+
+function makeAgent(): AgentState {
+  return {
+    id: 1,
+    sessionId: 'codex-session',
+    isExternal: false,
+    projectDir: '',
+    jsonlFile: '',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    providerId: 'codex',
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+}
+
+describe('codexProvider', () => {
+  it('exposes Codex provider metadata', () => {
+    expect(codexProvider.kind).toBe('hook');
+    expect(codexProvider.id).toBe('codex');
+    expect(codexProvider.displayName).toBe('Codex');
+    expect(codexProvider.protocolVersion).toBe(1);
+    expect(codexProvider.subagentToolNames.size).toBe(0);
+  });
+
+  it('parses Codex function_call records as toolStart events', () => {
+    const event = codexProvider.parseTranscriptLine?.(
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'function_call',
+          name: 'shell_command',
+          call_id: 'call_1',
+          arguments: JSON.stringify({ command: 'npm test' }),
+        },
+      }),
+    );
+
+    expect(event?.kind).toBe('toolStart');
+    if (event?.kind === 'toolStart') {
+      expect(event.toolId).toBe('call_1');
+      expect(event.toolName).toBe('shell_command');
+      expect(event.input).toEqual({ command: 'npm test' });
+    }
+  });
+
+  it('parses Codex function_call_output records as toolEnd events', () => {
+    expect(
+      codexProvider.parseTranscriptLine?.(
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call_1', output: '{}' },
+        }),
+      ),
+    ).toEqual({ kind: 'toolEnd', toolId: 'call_1' });
+  });
+
+  it('parses Codex custom_tool_call records as toolStart events', () => {
+    const event = codexProvider.parseTranscriptLine?.(
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          status: 'completed',
+          call_id: 'call_patch',
+          name: 'apply_patch',
+          input: { operation: 'update' },
+        },
+      }),
+    );
+
+    expect(event?.kind).toBe('toolStart');
+    if (event?.kind === 'toolStart') {
+      expect(event.toolId).toBe('call_patch');
+      expect(event.toolName).toBe('apply_patch');
+      expect(event.input).toEqual({ operation: 'update' });
+    }
+  });
+
+  it('drives AgentStateStore broadcasts through the normalized parser path', () => {
+    setHookProvider(codexProvider);
+    const store = new AgentStateStore();
+    const agent = makeAgent();
+    const broadcasts: Record<string, unknown>[] = [];
+    store.on('broadcast', (message) => broadcasts.push(message));
+    store.set(1, agent);
+
+    processTranscriptLine(
+      1,
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'function_call',
+          name: 'shell_command',
+          call_id: 'call_1',
+          arguments: JSON.stringify({ command: 'npm test' }),
+        },
+      }),
+      store,
+      new Map(),
+      new Map(),
+    );
+
+    expect(agent.activeToolIds.has('call_1')).toBe(true);
+    expect(agent.activeToolNames.get('call_1')).toBe('shell_command');
+    expect(broadcasts).toContainEqual({ type: 'agentStatus', id: 1, status: 'active' });
+    expect(broadcasts).toContainEqual({
+      type: 'agentToolStart',
+      id: 1,
+      toolId: 'call_1',
+      status: 'Running: npm test',
+      toolName: 'shell_command',
+      permissionActive: false,
+      runInBackground: undefined,
+    });
+
+    processTranscriptLine(
+      1,
+      JSON.stringify({
+        type: 'response_item',
+        payload: { type: 'function_call_output', call_id: 'call_1', output: '{}' },
+      }),
+      store,
+      new Map(),
+      new Map(),
+    );
+
+    expect(agent.activeToolIds.has('call_1')).toBe(false);
+  });
+});

--- a/server/src/agentStateStore.ts
+++ b/server/src/agentStateStore.ts
@@ -132,6 +132,7 @@ export class AgentStateStore {
         isExternal: agent.isExternal || undefined,
         jsonlFile: agent.jsonlFile,
         projectDir: agent.projectDir,
+        providerId: agent.providerId,
         folderName: agent.folderName,
         teamName: agent.teamName,
         agentName: agent.agentName,

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -1,0 +1,246 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import { BASH_COMMAND_DISPLAY_MAX_LENGTH } from '../../../constants.js';
+import { CODEX_TERMINAL_NAME_PREFIX } from './constants.js';
+
+function sessionsRoot(): string {
+  return path.join(os.homedir(), '.codex', 'sessions');
+}
+
+function currentSessionDir(): string {
+  const now = new Date();
+  return path.join(
+    sessionsRoot(),
+    String(now.getFullYear()),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  );
+}
+
+function getSessionDirs(_workspacePath: string): string[] {
+  return [currentSessionDir()];
+}
+
+function getAllSessionRoots(): string[] {
+  return [sessionsRoot()];
+}
+
+function buildLaunchCommand(
+  _sessionId: string,
+  _cwd: string,
+  _opts?: { bypassPermissions?: boolean },
+): { command: string; args: string[] } {
+  return { command: findCodexExecutable(), args: [] };
+}
+
+function findCodexExecutable(): string {
+  const candidates = [
+    path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'OpenAI', 'Codex', 'bin', 'codex.exe'),
+    path.join(os.homedir(), 'AppData', 'Roaming', 'npm', 'codex.cmd'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return 'codex';
+}
+
+function parseArguments(input?: unknown): Record<string, unknown> {
+  if (typeof input !== 'string') return {};
+  try {
+    const parsed = JSON.parse(input);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseTranscriptLine(line: string): AgentEvent | null {
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const payload = record.payload as Record<string, unknown> | undefined;
+  if (!payload || typeof payload.type !== 'string') return null;
+
+  if (
+    record.type === 'response_item' &&
+    (payload.type === 'function_call' || payload.type === 'custom_tool_call')
+  ) {
+    const toolName = typeof payload.name === 'string' ? payload.name : 'tool';
+    const callId =
+      typeof payload.call_id === 'string'
+        ? payload.call_id
+        : `codex-tool-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    return {
+      kind: 'toolStart',
+      toolId: callId,
+      toolName,
+      input:
+        payload.type === 'custom_tool_call'
+          ? ((payload.input ?? {}) as Record<string, unknown>)
+          : parseArguments(payload.arguments),
+    };
+  }
+
+  if (
+    record.type === 'response_item' &&
+    (payload.type === 'function_call_output' || payload.type === 'custom_tool_call_output')
+  ) {
+    const callId = typeof payload.call_id === 'string' ? payload.call_id : undefined;
+    if (!callId) return null;
+    return { kind: 'toolEnd', toolId: callId };
+  }
+
+  if (record.type === 'response_item' && payload.type === 'message') {
+    const role = typeof payload.role === 'string' ? payload.role : '';
+    if (role === 'assistant') return { kind: 'turnEnd' };
+  }
+
+  return null;
+}
+
+export function formatCodexToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  switch (toolName) {
+    case 'shell_command': {
+      const command = typeof inp.command === 'string' ? inp.command : '';
+      return command
+        ? `Running: ${command.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? command.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '\u2026' : command}`
+        : 'Running command';
+    }
+    case 'apply_patch':
+      return 'Editing files';
+    case 'update_plan':
+      return 'Updating plan';
+    case 'view_image':
+      return 'Inspecting image';
+    case 'read_mcp_resource':
+    case 'list_mcp_resources':
+    case 'list_mcp_resource_templates':
+      return 'Reading connected resource';
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+function normalizeHookEvent(
+  _raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  return null;
+}
+
+function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(false);
+}
+
+export function findNewestCodexSessionFile(afterMs: number, cwd?: string): string | null {
+  const root = sessionsRoot();
+  const candidates: Array<{ file: string; mtime: number; cwdMatches: boolean }> = [];
+  const expectedCwd = cwd ? path.resolve(cwd).toLowerCase() : undefined;
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        try {
+          const stat = fs.statSync(full);
+          if (stat.mtimeMs >= afterMs) {
+            const sessionCwd = readLatestCwd(full);
+            const cwdMatches =
+              expectedCwd !== undefined &&
+              sessionCwd !== null &&
+              path.resolve(sessionCwd).toLowerCase() === expectedCwd;
+            candidates.push({ file: full, mtime: stat.mtimeMs, cwdMatches });
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
+  walk(root);
+  candidates.sort((a, b) => {
+    if (a.cwdMatches !== b.cwdMatches) return a.cwdMatches ? -1 : 1;
+    return b.mtime - a.mtime;
+  });
+  return candidates[0]?.file ?? null;
+}
+
+function readLatestCwd(file: string): string | null {
+  try {
+    const stat = fs.statSync(file);
+    const readSize = Math.min(stat.size, 128 * 1024);
+    const fd = fs.openSync(file, 'r');
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, stat.size - readSize);
+    fs.closeSync(fd);
+    const lines = buf.toString('utf-8').split('\n').reverse();
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const record = JSON.parse(line) as Record<string, unknown>;
+        const payload = record.payload as Record<string, unknown> | undefined;
+        const cwd = payload?.cwd;
+        if (record.type === 'turn_context' && typeof cwd === 'string') return cwd;
+      } catch {
+        /* ignore malformed tail line */
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: 'codex',
+  displayName: 'Codex',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus: formatCodexToolStatus,
+  permissionExemptTools: new Set(['update_plan']),
+  subagentToolNames: new Set(),
+  readingTools: new Set([
+    'shell_command',
+    'view_image',
+    'read_mcp_resource',
+    'list_mcp_resources',
+    'list_mcp_resource_templates',
+  ]),
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+
+  getSessionDirs,
+  getAllSessionRoots,
+  sessionFilePattern: '*.jsonl',
+  parseTranscriptLine,
+  buildLaunchCommand,
+};

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -1,0 +1,1 @@
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -13,3 +13,4 @@
 
 export { claudeProvider } from './hook/claude/claude.js';
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { codexProvider, findNewestCodexSessionFile } from './hook/codex/codex.js';

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -1,6 +1,6 @@
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
 
-import type { HookProvider } from '../../core/src/provider.js';
+import type { AgentEvent, HookProvider } from '../../core/src/provider.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import { TEXT_IDLE_DELAY_MS, TOOL_DONE_DELAY_MS } from './constants.js';
 import {
@@ -54,6 +54,11 @@ export function processTranscriptLine(
   agent.linesProcessed++;
   try {
     const record = JSON.parse(line);
+    const providerEvent = hookProvider?.parseTranscriptLine?.(line);
+    if (providerEvent) {
+      processProviderEvent(agentId, providerEvent, agents, waitingTimers, permissionTimers);
+      return;
+    }
 
     // -- Agent Teams: extract team metadata via the active provider --
     // The provider reads its CLI's own field names (Claude: record.teamName + record.agentName).
@@ -377,6 +382,86 @@ export function processTranscriptLine(
     }
   } catch {
     // Ignore malformed lines
+  }
+}
+
+function processProviderEvent(
+  agentId: number,
+  event: AgentEvent,
+  agents: AgentStateStore,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+
+  switch (event.kind) {
+    case 'toolStart': {
+      cancelWaitingTimer(agentId, waitingTimers);
+      agent.isWaiting = false;
+      agent.hadToolsInTurn = true;
+      agents.broadcast({ type: 'agentStatus', id: agentId, status: 'active' });
+
+      const input = (event.input ?? {}) as Record<string, unknown>;
+      const status = formatToolStatus(event.toolName, input);
+      agent.activeToolIds.add(event.toolId);
+      agent.activeToolStatuses.set(event.toolId, status);
+      agent.activeToolNames.set(event.toolId, event.toolName);
+      agents.broadcast({
+        type: 'agentToolStart',
+        id: agentId,
+        toolId: event.toolId,
+        status,
+        toolName: event.toolName,
+        permissionActive: agent.permissionSent,
+        runInBackground: event.runInBackground,
+      });
+
+      if (!exemptTools().has(event.toolName) && !agent.hookDelivered && !agent.leadAgentId) {
+        startPermissionTimer(agentId, agents, permissionTimers, exemptTools());
+      }
+      break;
+    }
+
+    case 'toolEnd': {
+      agent.activeToolIds.delete(event.toolId);
+      agent.activeToolStatuses.delete(event.toolId);
+      agent.activeToolNames.delete(event.toolId);
+      setTimeout(() => {
+        agents.broadcast({
+          type: 'agentToolDone',
+          id: agentId,
+          toolId: event.toolId,
+        });
+      }, TOOL_DONE_DELAY_MS);
+      if (agent.activeToolIds.size === 0) {
+        agent.hadToolsInTurn = false;
+      }
+      break;
+    }
+
+    case 'turnEnd': {
+      cancelWaitingTimer(agentId, waitingTimers);
+      cancelPermissionTimer(agentId, permissionTimers);
+      agent.activeToolIds.clear();
+      agent.activeToolStatuses.clear();
+      agent.activeToolNames.clear();
+      agent.activeSubagentToolIds.clear();
+      agent.activeSubagentToolNames.clear();
+      agent.isWaiting = true;
+      agent.permissionSent = false;
+      agent.hadToolsInTurn = false;
+      agents.broadcast({ type: 'agentToolsClear', id: agentId });
+      agents.broadcast({ type: 'agentStatus', id: agentId, status: 'waiting' });
+      break;
+    }
+
+    case 'permissionRequest':
+      startPermissionTimer(agentId, agents, permissionTimers, exemptTools());
+      break;
+
+    default:
+      break;
   }
 }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -69,6 +69,8 @@ export interface PersistedAgent {
   isExternal?: boolean;
   jsonlFile: string;
   projectDir: string;
+  /** Provider that created this agent (defaults to 'claude' for old persisted data) */
+  providerId?: string;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
 


### PR DESCRIPTION
  ## Summary

  Adds experimental Codex provider support alongside the existing Claude Code provider.

  ## Changes

  - Added a new `codex` provider that launches Codex and watches `~/.codex/sessions/**/*.jsonl`
  - Added `pixel-agents.provider` setting with supported values: `claude` and `codex`
  - Made VS Code agent launch/session handling provider-aware
  - Added Codex JSONL parsing for:
    - `function_call`
    - `function_call_output`
    - `custom_tool_call`
    - `custom_tool_call_output`
  - Matches Codex session files by `turn_context.cwd` to avoid attaching to the wrong active Codex session
  - Persists `providerId` with agent state
  - Updated README with Codex setup, usage, and current limitations
  - Added focused Codex provider/parser tests

  ## Notes

  Codex support is experimental and currently uses JSONL polling only. It does not include Claude hook integration or Agent Teams support yet.