### PR TITLE
fix: use double-quoted paths in generate-messages on Windows

### DIFF
--- a/scripts/generate-messages.ts
+++ b/scripts/generate-messages.ts
@@ -137,6 +137,8 @@ function exportify(decl: string): string {
 }
 
 function quote(s: string): string {
+  // Windows cmd does not strip single quotes; use double quotes there.
+  if (process.platform === 'win32') return `"${s}"`;
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 


### PR DESCRIPTION
## Description

Fixes a Windows-only failure of `npm run build`.

`scripts/generate-messages.ts` shells out to `npx prettier --write <path>` and
`npx eslint --fix <path>` after generating `core/src/messages.ts`. The `quote()`
helper wrapped the path in **single** quotes. On Windows, `cmd.exe` does not strip
single quotes, so the tools received a literal `'…\messages.ts'` argument and
failed with:

```
[error] No files matching the pattern were found: "'…\core\src\messages.ts'".
```

That made `npm run asyncapi:generate` exit with code 2, which aborted the whole
`npm run build` chain (`asyncapi:generate && check-types && lint && esbuild && build:webview`).

The fix uses double quotes on `win32` (which `cmd.exe` does strip) while keeping
the existing POSIX single-quote escaping on macOS/Linux.

## Type of change
- [x] Bug fix

## Related issues
<!-- none -->

## Screenshots / GIFs
N/A — build tooling change.

## Test plan
- [x] Reproduced the failure on Windows (Node 24.16, npm 11) — `npm run build` aborted at `asyncapi:generate`
- [x] After the fix, `asyncapi:generate` completes (prettier + eslint run on the generated file) and `npm run build` proceeds to a successful build
- [x] No behavior change on macOS/Linux (single-quote path unchanged)
