### PR TITLE
fix: copy hook script from extension root in standalone CLI

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -60,6 +60,10 @@ async function main(): Promise<void> {
 
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
+  // copyHookScript() joins '<root>/dist/hooks', so it expects the EXTENSION ROOT
+  // (the parent of dist/), not dist/ itself. Passing distRoot produced a
+  // dist/dist/hooks path and the hook script was never copied in standalone mode.
+  const extensionRoot = path.dirname(distRoot);
   const staticDir = path.join(distRoot, 'webview');
 
   // ── Load assets on startup (same pipeline as VS Code extension) ──
@@ -104,7 +108,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(extensionRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -132,7 +136,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(extensionRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);


### PR DESCRIPTION
## Description

Fixes the standalone CLI never copying the Claude hook script (so instant
hook-based detection silently fell back to JSONL polling).

`copyHookScript(extensionPath)` joins `extensionPath/dist/hooks/claude-hook.js`.
In `server/src/cli.ts` it was called with `distRoot` (`__dirname`, i.e. the
`dist/` folder itself), producing a `dist/dist/hooks/...` path. At runtime the
standalone server logged:

```
[Pixel Agents] Hook script not found at <repo>\dist\dist\hooks\claude-hook.js
```

and the hook script was never installed to `~/.pixel-agents/hooks/`.

Pass the extension root (`path.dirname(distRoot)`) instead, mirroring the VS Code
adapter which passes the extension path (the parent of `dist/`). Applied to both
`copyHookScript` call sites (startup + the hooks-enabled toggle).

After the fix the standalone server logs:

```
[Pixel Agents] Hook script installed at ~/.pixel-agents/hooks/claude-hook.js
```

## Type of change
- [x] Bug fix

## Related issues
<!-- none -->

## Screenshots / GIFs
N/A — standalone CLI / hook installation.

## Test plan
- [x] `node esbuild.js` rebuilds `dist/cli.js`
- [x] `node dist/cli.js` now logs "Hook script installed at ~/.pixel-agents/hooks/claude-hook.js" (previously "not found at …/dist/dist/hooks/…")
- [x] Server still serves the SPA and `/api/health` (200)
