### PR TITLE
fix: furniture pick tool duplicates items instead of moving them

### DIFF
--- a/webview-ui/src/hooks/useEditorActions.ts
+++ b/webview-ui/src/hooks/useEditorActions.ts
@@ -127,6 +127,7 @@ export function useEditorActions(
         editorState.clearSelection();
         editorState.clearGhost();
         editorState.clearDrag();
+        editorState.clearPickedItem();
         wallColorEditActiveRef.current = false;
       }
       return next;
@@ -144,6 +145,7 @@ export function useEditorActions(
       editorState.clearSelection();
       editorState.clearGhost();
       editorState.clearDrag();
+      editorState.clearPickedItem();
       colorEditUidRef.current = null;
       wallColorEditActiveRef.current = false;
       setEditorTick((n) => n + 1);
@@ -247,6 +249,8 @@ export function useEditorActions(
 
   const handleFurnitureTypeChange = useCallback(
     (type: string) => {
+      // Switching to a catalog item cancels any pick-tool carry (fresh stamp)
+      editorState.clearPickedItem();
       // Clicking the same item deselects it (no ghost), stays in furniture mode
       if (editorState.selectedFurnitureType === type) {
         editorState.selectedFurnitureType = '';
@@ -521,6 +525,19 @@ export function useEditorActions(
           setEditorTick((n) => n + 1);
         } else {
           const placementRow = getWallPlacementRow(type, row);
+          // Carrying an item grabbed with the pick tool: move it instead of
+          // stamping a copy, then disarm so the next click doesn't duplicate.
+          const pickedUid = editorState.pickedFurnitureUid;
+          if (pickedUid) {
+            const newLayout = moveFurniture(layout, pickedUid, col, placementRow);
+            if (newLayout !== layout) {
+              applyEdit(newLayout);
+              editorState.selectedFurnitureType = '';
+              editorState.clearPickedItem();
+              editorState.clearGhost();
+            }
+            return;
+          }
           if (!canPlaceFurniture(layout, type, col, placementRow)) return;
           const uid = `f-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
           const placed: PlacedFurniture = { uid, type, col, row: placementRow };
@@ -547,6 +564,8 @@ export function useEditorActions(
         if (hit) {
           editorState.selectedFurnitureType = hit.type;
           editorState.pickedFurnitureColor = hit.color ? { ...hit.color } : null;
+          // Remember the source item: placement will MOVE it rather than clone it
+          editorState.pickedFurnitureUid = hit.uid;
           editorState.activeTool = EditTool.FURNITURE_PLACE;
         }
         setEditorTick((n) => n + 1);

--- a/webview-ui/src/hooks/useEditorKeyboard.ts
+++ b/webview-ui/src/hooks/useEditorKeyboard.ts
@@ -27,6 +27,7 @@ export function useEditorKeyboard(
           editorState.selectedFurnitureType !== ''
         ) {
           editorState.selectedFurnitureType = '';
+          editorState.clearPickedItem();
           editorState.clearGhost();
         } else if (editorState.activeTool !== EditTool.SELECT) {
           editorState.activeTool = EditTool.SELECT;

--- a/webview-ui/src/office/components/OfficeCanvas.tsx
+++ b/webview-ui/src/office/components/OfficeCanvas.tsx
@@ -169,6 +169,7 @@ export function OfficeCanvas({
                 editorState.selectedFurnitureType,
                 editorState.ghostCol,
                 placementRow,
+                editorState.pickedFurnitureUid ?? undefined,
               );
             }
           }

--- a/webview-ui/src/office/editor/editorState.ts
+++ b/webview-ui/src/office/editor/editorState.ts
@@ -24,6 +24,10 @@ export class EditorState {
   // Picked furniture color (copied by pick tool, applied on placement)
   pickedFurnitureColor: ColorValue | null = null;
 
+  // Uid of the placed item grabbed by the pick tool. While set, placement
+  // moves this item instead of stamping a new copy.
+  pickedFurnitureUid: string | null = null;
+
   // Ghost preview position
   ghostCol = -1;
   ghostRow = -1;
@@ -87,6 +91,12 @@ export class EditorState {
     this.ghostValid = false;
   }
 
+  /** Cancel a pick-tool carry (item stays where it was). */
+  clearPickedItem(): void {
+    this.pickedFurnitureUid = null;
+    this.pickedFurnitureColor = null;
+  }
+
   startDrag(
     uid: string,
     startCol: number,
@@ -110,6 +120,8 @@ export class EditorState {
   reset(): void {
     this.activeTool = EditTool.SELECT;
     this.selectedFurnitureUid = null;
+    this.pickedFurnitureUid = null;
+    this.pickedFurnitureColor = null;
     this.ghostCol = -1;
     this.ghostRow = -1;
     this.ghostValid = false;

--- a/webview-ui/test/editorActions.test.ts
+++ b/webview-ui/test/editorActions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the pure furniture layout operations in editorActions.ts,
+ * focused on the invariants the editor's pick-to-move flow relies on:
+ *
+ * - placeFurniture rejects overlapping placements (no silent duplicates)
+ * - moveFurniture relocates an item while preserving its uid and color
+ * - moveFurniture allows a target that overlaps the item's own footprint
+ * - canPlaceFurniture's excludeUid ignores only the excluded item
+ * - removeFurniture removes by uid and is a no-op for unknown uids
+ *
+ * Run with: npm test
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  canPlaceFurniture,
+  moveFurniture,
+  placeFurniture,
+  removeFurniture,
+} from '../src/office/editor/editorActions.ts';
+import type { LoadedAssetData } from '../src/office/layout/furnitureCatalog.ts';
+import { buildDynamicCatalog } from '../src/office/layout/furnitureCatalog.ts';
+import type { OfficeLayout, PlacedFurniture } from '../src/office/types.ts';
+import { TileType } from '../src/office/types.ts';
+
+// ── Minimal synthetic catalog ──────────────────────────────────────────────
+
+/** 1x1 transparent sprite placeholder */
+const SPRITE = [['transparent']];
+
+const assets: LoadedAssetData = {
+  catalog: [
+    {
+      id: 'test-stool',
+      label: 'Stool',
+      category: 'chairs',
+      width: 16,
+      height: 16,
+      footprintW: 1,
+      footprintH: 1,
+      isDesk: false,
+    },
+    {
+      id: 'test-desk',
+      label: 'Desk',
+      category: 'desks',
+      width: 32,
+      height: 16,
+      footprintW: 2,
+      footprintH: 1,
+      isDesk: true,
+    },
+  ],
+  sprites: {
+    'test-stool': SPRITE,
+    'test-desk': SPRITE,
+  },
+};
+
+assert.equal(buildDynamicCatalog(assets), true, 'test catalog must build');
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** All-floor layout with the given furniture */
+function makeLayout(cols: number, rows: number, furniture: PlacedFurniture[]): OfficeLayout {
+  return {
+    version: 1,
+    cols,
+    rows,
+    tiles: new Array(cols * rows).fill(TileType.FLOOR_1),
+    furniture,
+  };
+}
+
+// ── placeFurniture ─────────────────────────────────────────────────────────
+
+test('placeFurniture adds an item on free floor', () => {
+  const layout = makeLayout(5, 5, []);
+  const next = placeFurniture(layout, { uid: 'a', type: 'test-stool', col: 1, row: 1 });
+  assert.notEqual(next, layout);
+  assert.equal(next.furniture.length, 1);
+});
+
+test('placeFurniture rejects a placement overlapping an existing item', () => {
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-stool', col: 1, row: 1 }]);
+  const next = placeFurniture(layout, { uid: 'b', type: 'test-stool', col: 1, row: 1 });
+  assert.equal(next, layout, 'overlapping placement must return the unchanged layout');
+});
+
+// ── moveFurniture (pick-to-move core) ──────────────────────────────────────
+
+test('moveFurniture relocates the item and preserves uid and color', () => {
+  const color = { h: 10, s: 20, b: 30, c: 0 };
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-stool', col: 1, row: 1, color }]);
+  const next = moveFurniture(layout, 'a', 3, 3);
+  assert.notEqual(next, layout);
+  assert.equal(next.furniture.length, 1, 'move must never duplicate');
+  const moved = next.furniture[0];
+  assert.equal(moved.uid, 'a');
+  assert.equal(moved.col, 3);
+  assert.equal(moved.row, 3);
+  assert.deepEqual(moved.color, color, 'color must survive the move');
+});
+
+test('moveFurniture allows a target overlapping its own footprint', () => {
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-desk', col: 1, row: 1 }]);
+  // 2x1 desk shifted one tile right still covers (2,1) — overlaps itself only
+  const next = moveFurniture(layout, 'a', 2, 1);
+  assert.notEqual(next, layout, 'self-overlap must not block the move');
+  assert.equal(next.furniture[0].col, 2);
+});
+
+test('moveFurniture rejects a target overlapping another item', () => {
+  const layout = makeLayout(5, 5, [
+    { uid: 'a', type: 'test-stool', col: 1, row: 1 },
+    { uid: 'b', type: 'test-stool', col: 3, row: 3 },
+  ]);
+  const next = moveFurniture(layout, 'a', 3, 3);
+  assert.equal(next, layout);
+});
+
+test('moveFurniture is a no-op for an unknown uid', () => {
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-stool', col: 1, row: 1 }]);
+  assert.equal(moveFurniture(layout, 'nope', 2, 2), layout);
+});
+
+// ── canPlaceFurniture excludeUid ───────────────────────────────────────────
+
+test('canPlaceFurniture blocks occupied tiles unless the occupant is excluded', () => {
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-stool', col: 1, row: 1 }]);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 1, 1), false);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 1, 1, 'a'), true);
+});
+
+test('canPlaceFurniture excludeUid does not ignore other items', () => {
+  const layout = makeLayout(5, 5, [
+    { uid: 'a', type: 'test-stool', col: 1, row: 1 },
+    { uid: 'b', type: 'test-stool', col: 2, row: 1 },
+  ]);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 2, 1, 'a'), false);
+});
+
+test('canPlaceFurniture rejects walls, void, and out-of-bounds targets', () => {
+  const layout = makeLayout(3, 3, []);
+  layout.tiles[0] = TileType.WALL; // (0,0)
+  layout.tiles[4] = TileType.VOID; // (1,1)
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 0, 0), false);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 1, 1), false);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', -1, 0), false);
+  assert.equal(canPlaceFurniture(layout, 'test-stool', 2, 2), true);
+  assert.equal(canPlaceFurniture(layout, 'test-desk', 2, 2), false, '2x1 desk exceeds map edge');
+});
+
+// ── removeFurniture ────────────────────────────────────────────────────────
+
+test('removeFurniture removes by uid', () => {
+  const layout = makeLayout(5, 5, [
+    { uid: 'a', type: 'test-stool', col: 1, row: 1 },
+    { uid: 'b', type: 'test-stool', col: 3, row: 3 },
+  ]);
+  const next = removeFurniture(layout, 'a');
+  assert.equal(next.furniture.length, 1);
+  assert.equal(next.furniture[0].uid, 'b');
+});
+
+test('removeFurniture is a no-op for an unknown uid', () => {
+  const layout = makeLayout(5, 5, [{ uid: 'a', type: 'test-stool', col: 1, row: 1 }]);
+  assert.equal(removeFurniture(layout, 'nope'), layout);
+});


### PR DESCRIPTION
## Description

Picking a placed furniture item with the Pick tool arms the placement tool with the item's type while leaving the original on the map. The next click stamps a copy, and because the tool stays armed, every further click stamps another one. Picking up an item to reposition it — the natural reading of "Pick" — instead duplicates it every time.

This PR makes picking from the map carry the actual item:

- The pick remembers the picked item's uid; the placement click performs a single undoable **move** of that item (uid and color preserved) instead of placing a clone.
- After the drop the tool disarms, so a follow-up click doesn't place anything.
- Escape, switching tools, or selecting a catalog item cancels the carry without touching the layout (nothing is removed on pick, so there's no data-loss window).
- The placement ghost passes the carried uid as `excludeUid` to `canPlaceFurniture`, so dropping onto a spot that overlaps the item's old footprint shows valid (green) and works.

Placing from the catalog palette is unchanged: it still stamps new items and stays armed for repeated placement.

## Type of change
- [x] Bug fix

## Related issues

None found.

## Screenshots / GIFs

Pick the stool, drop it two tiles away — it moves (no duplicate), and the tool disarms (the last click on empty floor places nothing):

![pick moves the item](https://raw.githubusercontent.com/Ralphive/pixel-agents/pr-assets/furniture-pick-move.gif)

## Test plan
- [x] Rebased on latest `main`
- [x] `npm run lint`, `npm run build`, `npm test` all pass
- [x] New unit tests in `webview-ui/test/editorActions.test.ts` cover the layout invariants the flow relies on: move never duplicates and preserves uid/color, self-overlap allowed via `excludeUid`, overlap with other items rejected, walls/void/bounds rejected
- [x] Manually verified in the standalone server: pick→drop moves; drop overlapping old footprint works; Esc cancels with no layout change; undo restores the move as one step; catalog placement still stamps repeatedly
