### PR TITLE
fix: standalone CLI fails to install hook script (dist/dist/hooks path)

### DIFF
--- a/server/__tests__/claudeHookInstaller.test.ts
+++ b/server/__tests__/claudeHookInstaller.test.ts
@@ -124,4 +124,47 @@ describe('claudeHookInstaller', () => {
     // Check owner execute bit
     expect(stat.mode & 0o100).toBeTruthy();
   });
+
+  // 11. copyHookScript supports the standalone CLI layout (hooks/ next to the bundle).
+  // The CLI passes its own directory inside dist/, where the script lives at
+  // <root>/hooks/ rather than <root>/dist/hooks/.
+  it('copyHookScript falls back to <root>/hooks/ (standalone CLI layout)', () => {
+    const mockDistPath = path.join(tmpBase, 'mock-dist');
+    const hookSrc = path.join(mockDistPath, 'hooks');
+    fs.mkdirSync(hookSrc, { recursive: true });
+    fs.writeFileSync(path.join(hookSrc, 'claude-hook.js'), '// cli hook script');
+
+    copyHookScript(mockDistPath);
+
+    const dst = path.join(tmpBase, '.pixel-agents', 'hooks', 'claude-hook.js');
+    expect(fs.existsSync(dst)).toBe(true);
+    expect(fs.readFileSync(dst, 'utf-8')).toBe('// cli hook script');
+  });
+
+  // 12. <root>/dist/hooks/ wins when both layouts exist
+  it('copyHookScript prefers <root>/dist/hooks/ over <root>/hooks/', () => {
+    const mockExtPath = path.join(tmpBase, 'mock-ext');
+    const distSrc = path.join(mockExtPath, 'dist', 'hooks');
+    const flatSrc = path.join(mockExtPath, 'hooks');
+    fs.mkdirSync(distSrc, { recursive: true });
+    fs.mkdirSync(flatSrc, { recursive: true });
+    fs.writeFileSync(path.join(distSrc, 'claude-hook.js'), '// dist hook');
+    fs.writeFileSync(path.join(flatSrc, 'claude-hook.js'), '// flat hook');
+
+    copyHookScript(mockExtPath);
+
+    const dst = path.join(tmpBase, '.pixel-agents', 'hooks', 'claude-hook.js');
+    expect(fs.readFileSync(dst, 'utf-8')).toBe('// dist hook');
+  });
+
+  // 13. copyHookScript warns without throwing when no layout matches
+  it('copyHookScript handles a missing hook script gracefully', () => {
+    const mockExtPath = path.join(tmpBase, 'mock-empty');
+    fs.mkdirSync(mockExtPath, { recursive: true });
+
+    expect(() => copyHookScript(mockExtPath)).not.toThrow();
+
+    const dst = path.join(tmpBase, '.pixel-agents', 'hooks', 'claude-hook.js');
+    expect(fs.existsSync(dst)).toBe(false);
+  });
 });

--- a/server/src/providers/hook/claude/claudeHookInstaller.ts
+++ b/server/src/providers/hook/claude/claudeHookInstaller.ts
@@ -167,9 +167,20 @@ export function uninstallHooks(): void {
   }
 }
 
-/** Copy the shipped hook script from the extension to ~/.pixel-agents/hooks/ */
-export function copyHookScript(extensionPath: string): void {
-  const src = path.join(extensionPath, 'dist', 'hooks', CLAUDE_HOOK_SCRIPT_NAME);
+/**
+ * Copy the shipped hook script to ~/.pixel-agents/hooks/.
+ *
+ * `rootPath` is either the extension root with the hook script at
+ * `<root>/dist/hooks/` (VS Code mode), or the built output directory itself
+ * with the hook script at `<root>/hooks/` (standalone CLI mode, where the
+ * caller passes its own directory inside `dist/`).
+ */
+export function copyHookScript(rootPath: string): void {
+  const candidates = [
+    path.join(rootPath, 'dist', 'hooks', CLAUDE_HOOK_SCRIPT_NAME),
+    path.join(rootPath, 'hooks', CLAUDE_HOOK_SCRIPT_NAME),
+  ];
+  const src = candidates.find((p) => fs.existsSync(p));
   const dst = getHookScriptPath();
   const dstDir = path.dirname(dst);
 
@@ -177,8 +188,8 @@ export function copyHookScript(extensionPath: string): void {
     if (!fs.existsSync(dstDir)) {
       fs.mkdirSync(dstDir, { recursive: true, mode: 0o700 });
     }
-    if (!fs.existsSync(src)) {
-      console.warn(`[Pixel Agents] Hook script not found at ${src}`);
+    if (!src) {
+      console.warn(`[Pixel Agents] Hook script not found at ${candidates.join(' or ')}`);
       return;
     }
     fs.copyFileSync(src, dst);


### PR DESCRIPTION
## Description

The standalone CLI never installs the Claude Code hook script. `cli.ts` passes its own directory (already inside `dist/`) to `copyHookScript`, which unconditionally appends `dist/hooks/` — so it looks for the script at `dist/dist/hooks/claude-hook.js`, logs `Hook script not found`, and silently falls back to transcript scanning only. Hook events (instant tool/status updates) never reach a standalone server, while the VS Code extension is unaffected.

Repro on `main`:

```
npm run build
node dist/cli.js
# [Pixel Agents] Hook script not found at <repo>/dist/dist/hooks/claude-hook.js
```

`copyHookScript` now resolves the script from `<root>/dist/hooks/` (VS Code extension layout, unchanged behavior) and falls back to `<root>/hooks/` (standalone CLI layout, where the bundle and `hooks/` sit side by side inside `dist/`). When neither exists, the warning lists both candidate paths.

## Type of change
- [x] Bug fix

## Related issues

None found.

## Screenshots / GIFs

Not a UI change. CLI startup log after the fix:

```
[Pixel Agents] Hooks installed in ~/.claude/settings.json
[Pixel Agents] Hook script installed at ~/.pixel-agents/hooks/claude-hook.js
[Pixel Agents] Hooks installed
```

## Test plan
- [x] Rebased on latest `main`
- [x] `npm run lint`, `npm run build`, `npm test` all pass
- [x] New tests in `server/__tests__/claudeHookInstaller.test.ts`: fallback to `<root>/hooks/` (CLI layout), `<root>/dist/hooks/` preferred when both exist, graceful warning when neither exists
- [x] Manually verified by running `node dist/cli.js` with an isolated `HOME`: the script is copied to `~/.pixel-agents/hooks/` on startup (previously only the warning appeared)
