### PR TITLE
fix: existing agents not shown when webview connects after layout load

### DIFF
--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -224,16 +224,31 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
-        // Buffer agents — they'll be added in layoutLoaded after seats are built
+        // If the layout (and its seats) is already built, add agents right away;
+        // otherwise buffer them — they'll be added in layoutLoaded. Handles both
+        // message orders: VS Code sends existingAgents before layoutLoaded, the
+        // standalone server sends it after.
+        let addedDirectly = false;
         for (const id of incoming) {
           const m = meta[id];
-          pendingAgents.push({
+          const p = {
             id,
             palette: m?.palette,
             hueShift: m?.hueShift,
             seatId: m?.seatId,
             folderName: folderNames[id],
-          });
+          };
+          if (layoutReadyRef.current) {
+            if (!os.characters.has(p.id)) {
+              os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+              addedDirectly = true;
+            }
+          } else {
+            pendingAgents.push(p);
+          }
+        }
+        if (addedDirectly) {
+          saveAgentSeats(os);
         }
         setAgents((prev) => {
           const ids = new Set(prev);


### PR DESCRIPTION
## Description

A browser tab that connects to the standalone server (or reloads) after agents are already running shows an empty office. Only agents that produce new activity after the connection appear; everything already tracked stays invisible. The Debug View lists all agents correctly, so detection is fine — the characters just never spawn.

Cause: the `existingAgents` handler unconditionally buffers incoming agents to be added on the next `layoutLoaded` message. That matches the VS Code extension's send order (agents before layout), but the standalone server's `webviewReady` reply sends `layoutLoaded` (step 3) **before** `existingAgents` (step 6) — so the buffer is never flushed.

The handler now adds agents to the office immediately when the layout is already loaded, and keeps buffering when it isn't, making it correct for both message orders. It skips ids that already have a character (idempotent if both paths fire) and persists seat assignments after a direct add.

## Type of change
- [x] Bug fix

## Related issues

None found.

## Screenshots / GIFs

No visual change beyond agents appearing where they should — happy to add a before/after if useful.

## Test plan
- [x] Rebased on latest `main`
- [x] `npm run lint`, `npm run build`, `npm test` all pass
- [x] Repro on `main`: start `node dist/cli.js` with two active Claude Code sessions, open a browser tab → office is empty (agents only appear on their next activity). Reload → empty again.
- [x] With this fix: a freshly opened or reloaded tab seats all tracked agents immediately; live `agentAdded` flow unchanged; VS Code webview order (existingAgents before layoutLoaded) still goes through the buffer path.
