### PR TITLE
feat: show user-set session names in agent labels

### DIFF
--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -46,6 +46,7 @@ import {
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
   GLOBAL_KEY_LAST_SEEN_VERSION,
+  GLOBAL_KEY_SHOW_SESSION_NAMES,
   GLOBAL_KEY_SOUND_ENABLED,
   GLOBAL_KEY_WATCH_ALL_SESSIONS,
   LAYOUT_REVISION_KEY,
@@ -214,6 +215,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.adapter.setSetting(GLOBAL_KEY_LAST_SEEN_VERSION, message.version as string);
       } else if (message.type === 'setAlwaysShowLabels') {
         this.adapter.setSetting(GLOBAL_KEY_ALWAYS_SHOW_LABELS, message.enabled);
+      } else if (message.type === 'setShowSessionNames') {
+        this.adapter.setSetting(GLOBAL_KEY_SHOW_SESSION_NAMES, message.enabled);
       } else if (message.type === 'setHooksEnabled') {
         const enabled = message.enabled as boolean;
         this.adapter.setSetting(GLOBAL_KEY_HOOKS_ENABLED, enabled);
@@ -350,6 +353,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           GLOBAL_KEY_ALWAYS_SHOW_LABELS,
           false,
         );
+        const showSessionNames = this.adapter.getSetting<boolean>(
+          GLOBAL_KEY_SHOW_SESSION_NAMES,
+          true,
+        );
         this.runtime.watchAllSessions.current = watchAllSessions;
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         const hooksInfoShown = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_INFO_SHOWN, false);
@@ -361,6 +368,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           extensionVersion,
           watchAllSessions,
           alwaysShowLabels,
+          showSessionNames,
           hooksEnabled,
           hooksInfoShown,
           externalAssetDirectories: config.externalAssetDirectories,

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -496,12 +496,16 @@ export function sendExistingAgents(
   // Include folderName and isExternal per agent
   const folderNames: Record<number, string> = {};
   const externalAgents: Record<number, boolean> = {};
+  const sessionNames: Record<number, string> = {};
   for (const [id, agent] of agents) {
     if (agent.folderName) {
       folderNames[id] = agent.folderName;
     }
     if (agent.isExternal) {
       externalAgents[id] = true;
+    }
+    if (agent.sessionName) {
+      sessionNames[id] = agent.sessionName;
     }
   }
   console.log(
@@ -514,6 +518,7 @@ export function sendExistingAgents(
     agentMeta,
     folderNames,
     externalAgents,
+    sessionNames,
   });
   // Note: sendCurrentAgentStatuses is called separately AFTER layoutLoaded
   // so that agentStatus/agentToolStart messages arrive after characters are created.

--- a/adapters/vscode/constants.ts
+++ b/adapters/vscode/constants.ts
@@ -11,6 +11,7 @@ export {
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 export const GLOBAL_KEY_LAST_SEEN_VERSION = 'pixel-agents.lastSeenVersion';
 export const GLOBAL_KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
+export const GLOBAL_KEY_SHOW_SESSION_NAMES = 'pixel-agents.showSessionNames';
 export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 export const GLOBAL_KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -99,6 +99,8 @@ components:
         # Agent Teams
         - $ref: '#/components/schemas/AgentTeamInfo'
         - $ref: '#/components/schemas/AgentTokenUsage'
+        # Session metadata
+        - $ref: '#/components/schemas/AgentSessionName'
         # Layout
         - $ref: '#/components/schemas/LayoutLoaded'
         # Assets
@@ -125,6 +127,7 @@ components:
         - $ref: '#/components/schemas/SetSoundEnabled'
         - $ref: '#/components/schemas/SetLastSeenVersion'
         - $ref: '#/components/schemas/SetAlwaysShowLabels'
+        - $ref: '#/components/schemas/SetShowSessionNames'
         - $ref: '#/components/schemas/SetHooksEnabled'
         - $ref: '#/components/schemas/SetHooksInfoShown'
         - $ref: '#/components/schemas/SetWatchAllSessions'
@@ -226,6 +229,13 @@ components:
           description: Map of agent ID (string) to external flag.
           additionalProperties:
             type: boolean
+        sessionNames:
+          type: object
+          description: |
+            Map of agent ID (string) to user-set session name (e.g. the title set
+            with Claude Code's /rename). Optional; absent for unnamed sessions.
+          additionalProperties:
+            type: string
 
     AgentStatus:
       description: Active vs waiting state for an agent (drives character animation).
@@ -407,6 +417,22 @@ components:
         outputTokens:
           type: integer
 
+    AgentSessionName:
+      description: |
+        User-set session name changed (e.g. the title set with Claude Code's
+        /rename, persisted as a custom-title transcript record). Clients show it
+        in the agent's label in place of the folder name.
+      type: object
+      additionalProperties: false
+      required: [type, id, name]
+      properties:
+        type:
+          const: agentSessionName
+        id:
+          type: integer
+        name:
+          type: string
+
     LayoutLoaded:
       description: |
         Office layout (tiles, furniture, colors). `null` when no layout file or
@@ -529,6 +555,9 @@ components:
           type: boolean
         alwaysShowLabels:
           type: boolean
+        showSessionNames:
+          type: boolean
+          description: Prefer user-set session names over folder names in labels.
         hooksEnabled:
           type: boolean
         hooksInfoShown:
@@ -678,6 +707,16 @@ components:
       properties:
         type:
           const: setAlwaysShowLabels
+        enabled:
+          type: boolean
+
+    SetShowSessionNames:
+      type: object
+      additionalProperties: false
+      required: [type, enabled]
+      properties:
+        type:
+          const: setShowSessionNames
         enabled:
           type: boolean
 

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -25,6 +25,7 @@ export type ServerMessage =
   | SubagentToolPermission
   | AgentTeamInfo
   | AgentTokenUsage
+  | AgentSessionName
   | LayoutLoaded
   | FurnitureAssetsLoaded
   | CharacterSpritesLoaded
@@ -45,6 +46,7 @@ export type ClientMessage =
   | SetSoundEnabled
   | SetLastSeenVersion
   | SetAlwaysShowLabels
+  | SetShowSessionNames
   | SetHooksEnabled
   | SetHooksInfoShown
   | SetWatchAllSessions
@@ -84,6 +86,7 @@ export interface ExistingAgents {
   agentMeta: Record<string, AgentSeatMeta>;
   folderNames: Record<string, string>;
   externalAgents: Record<string, boolean>;
+  sessionNames?: Record<string, string>;
 }
 
 export interface AgentSeatMeta {
@@ -175,6 +178,12 @@ export interface AgentTokenUsage {
   outputTokens: number;
 }
 
+export interface AgentSessionName {
+  type: 'agentSessionName';
+  id: number;
+  name: string;
+}
+
 export interface LayoutLoaded {
   type: 'layoutLoaded';
   layout: Record<string, any> | null;
@@ -238,6 +247,7 @@ export interface SettingsLoaded {
   extensionVersion: string;
   watchAllSessions: boolean;
   alwaysShowLabels: boolean;
+  showSessionNames?: boolean;
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
   externalAssetDirectories: string[];
@@ -311,6 +321,11 @@ export interface SetLastSeenVersion {
 
 export interface SetAlwaysShowLabels {
   type: 'setAlwaysShowLabels';
+  enabled: boolean;
+}
+
+export interface SetShowSessionNames {
+  type: 'setShowSessionNames';
   enabled: boolean;
 }
 

--- a/core/src/schemas.ts
+++ b/core/src/schemas.ts
@@ -19,6 +19,8 @@ export interface PersistedAgent {
   isTeamLead?: boolean;
   leadAgentId?: number;
   teamUsesTmux?: boolean;
+  /** User-set session name from the transcript (e.g. Claude's /rename) */
+  sessionName?: string;
 }
 
 /** Agent seat assignment with visual identity */

--- a/server/__tests__/transcriptParser.test.ts
+++ b/server/__tests__/transcriptParser.test.ts
@@ -1,7 +1,13 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { AgentStateStore } from '../src/agentStateStore.js';
-import { processTranscriptLine } from '../src/transcriptParser.js';
+import {
+  processTranscriptLine,
+  readSessionNameFromTranscriptTail,
+} from '../src/transcriptParser.js';
 import type { AgentState } from '../src/types.js';
 
 function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
@@ -97,5 +103,46 @@ describe('transcriptParser: session name (custom-title records)', () => {
       ),
     ).not.toThrow();
     expect(broadcasts.filter((m) => m.type === 'agentSessionName')).toHaveLength(0);
+  });
+});
+
+describe('readSessionNameFromTranscriptTail', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-tail-test-'));
+  });
+
+  function write(lines: string[]): string {
+    const f = path.join(dir, 'session.jsonl');
+    fs.writeFileSync(f, lines.join('\n') + '\n');
+    return f;
+  }
+
+  it('returns the most recent custom-title in the file', () => {
+    const f = write([
+      JSON.stringify({ type: 'custom-title', customTitle: 'Old Name' }),
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } }),
+      JSON.stringify({ type: 'custom-title', customTitle: 'New Name' }),
+    ]);
+    expect(readSessionNameFromTranscriptTail(f)).toBe('New Name');
+  });
+
+  it('returns undefined when no title exists', () => {
+    const f = write([JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } })]);
+    expect(readSessionNameFromTranscriptTail(f)).toBeUndefined();
+  });
+
+  it('returns undefined for a missing file', () => {
+    expect(readSessionNameFromTranscriptTail(path.join(dir, 'nope.jsonl'))).toBeUndefined();
+  });
+
+  it('skips malformed lines and empty titles', () => {
+    const f = write([
+      JSON.stringify({ type: 'custom-title', customTitle: 'Good' }),
+      '{"type":"custom-title", broken json',
+      JSON.stringify({ type: 'custom-title', customTitle: '   ' }),
+    ]);
+    expect(readSessionNameFromTranscriptTail(f)).toBe('Good');
   });
 });

--- a/server/__tests__/transcriptParser.test.ts
+++ b/server/__tests__/transcriptParser.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { processTranscriptLine } from '../src/transcriptParser.js';
+import type { AgentState } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: 'sess-1',
+    terminalRef: undefined,
+    isExternal: false,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    inputTokens: 0,
+    outputTokens: 0,
+    ...overrides,
+  };
+}
+
+describe('transcriptParser: session name (custom-title records)', () => {
+  let store: AgentStateStore;
+  let broadcasts: Array<Record<string, unknown>>;
+  let waitingTimers: Map<number, ReturnType<typeof setTimeout>>;
+  let permissionTimers: Map<number, ReturnType<typeof setTimeout>>;
+
+  beforeEach(() => {
+    store = new AgentStateStore();
+    store.set(1, createTestAgent());
+    broadcasts = [];
+    store.on('broadcast', (msg) => broadcasts.push(msg as Record<string, unknown>));
+    waitingTimers = new Map();
+    permissionTimers = new Map();
+  });
+
+  function process(line: string): void {
+    processTranscriptLine(1, line, store, waitingTimers, permissionTimers);
+  }
+
+  it('sets sessionName and broadcasts agentSessionName on custom-title', () => {
+    process(JSON.stringify({ type: 'custom-title', customTitle: 'My Session' }));
+    expect(store.get(1)?.sessionName).toBe('My Session');
+    expect(broadcasts).toContainEqual({ type: 'agentSessionName', id: 1, name: 'My Session' });
+  });
+
+  it('does not re-broadcast an unchanged title', () => {
+    process(JSON.stringify({ type: 'custom-title', customTitle: 'Same' }));
+    process(JSON.stringify({ type: 'custom-title', customTitle: 'Same' }));
+    const nameMsgs = broadcasts.filter((m) => m.type === 'agentSessionName');
+    expect(nameMsgs).toHaveLength(1);
+  });
+
+  it('broadcasts again when the title changes (rename)', () => {
+    process(JSON.stringify({ type: 'custom-title', customTitle: 'First' }));
+    process(JSON.stringify({ type: 'custom-title', customTitle: 'Second' }));
+    expect(store.get(1)?.sessionName).toBe('Second');
+    const nameMsgs = broadcasts.filter((m) => m.type === 'agentSessionName');
+    expect(nameMsgs).toHaveLength(2);
+  });
+
+  it('ignores empty or non-string titles', () => {
+    process(JSON.stringify({ type: 'custom-title', customTitle: '   ' }));
+    process(JSON.stringify({ type: 'custom-title', customTitle: 42 }));
+    process(JSON.stringify({ type: 'custom-title' }));
+    expect(store.get(1)?.sessionName).toBeUndefined();
+    expect(broadcasts.filter((m) => m.type === 'agentSessionName')).toHaveLength(0);
+  });
+
+  it('trims surrounding whitespace', () => {
+    process(JSON.stringify({ type: 'custom-title', customTitle: '  Spaced Out  ' }));
+    expect(store.get(1)?.sessionName).toBe('Spaced Out');
+  });
+
+  it('is a no-op for unknown agent ids', () => {
+    expect(() =>
+      processTranscriptLine(
+        99,
+        JSON.stringify({ type: 'custom-title', customTitle: 'X' }),
+        store,
+        waitingTimers,
+        permissionTimers,
+      ),
+    ).not.toThrow();
+    expect(broadcasts.filter((m) => m.type === 'agentSessionName')).toHaveLength(0);
+  });
+});

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -366,6 +366,7 @@ export class AgentRuntime {
         linesProcessed: 0,
         seenUnknownRecordTypes: new Set(),
         folderName: p.folderName,
+        sessionName: p.sessionName,
         hookDelivered: false,
         inputTokens: 0,
         outputTokens: 0,

--- a/server/src/agentStateStore.ts
+++ b/server/src/agentStateStore.ts
@@ -138,6 +138,7 @@ export class AgentStateStore {
         isTeamLead: agent.isTeamLead,
         leadAgentId: agent.leadAgentId,
         teamUsesTmux: agent.teamUsesTmux,
+        sessionName: agent.sessionName,
       });
     }
     this.adapter.saveAgents(persisted);

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -31,6 +31,7 @@ export interface ClientMessageContext {
 const KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 const KEY_LAST_SEEN_VERSION = 'pixel-agents.lastSeenVersion';
 const KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
+const KEY_SHOW_SESSION_NAMES = 'pixel-agents.showSessionNames';
 const KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 const KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 const KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
@@ -79,6 +80,10 @@ export function handleClientMessage(
 
     case 'setAlwaysShowLabels':
       adapter?.setSetting(KEY_ALWAYS_SHOW_LABELS, msg.enabled);
+      break;
+
+    case 'setShowSessionNames':
+      adapter?.setSetting(KEY_SHOW_SESSION_NAMES, msg.enabled);
       break;
 
     case 'setWatchAllSessions': {
@@ -175,6 +180,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     extensionVersion: process.env.PIXEL_AGENTS_VERSION ?? '',
     watchAllSessions,
     alwaysShowLabels: adapter?.getSetting(KEY_ALWAYS_SHOW_LABELS, false) ?? false,
+    showSessionNames: adapter?.getSetting(KEY_SHOW_SESSION_NAMES, true) ?? true,
     hooksEnabled,
     hooksInfoShown: adapter?.getSetting(KEY_HOOKS_INFO_SHOWN, false) ?? false,
     externalAssetDirectories: cfg.externalAssetDirectories,
@@ -194,6 +200,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   const agentIds: number[] = [];
   const folderNames: Record<number, string> = {};
   const externalAgents: Record<number, boolean> = {};
+  const sessionNames: Record<number, string> = {};
   for (const [id, agent] of store) {
     agentIds.push(id);
     if (agent.folderName) {
@@ -201,6 +208,9 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     }
     if (agent.isExternal) {
       externalAgents[id] = true;
+    }
+    if (agent.sessionName) {
+      sessionNames[id] = agent.sessionName;
     }
   }
   const seats = adapter?.loadSeats() ?? {};
@@ -210,5 +220,6 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     agentMeta: seats,
     folderNames,
     externalAgents,
+    sessionNames,
   });
 }

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -40,7 +40,7 @@ import {
 } from './constants.js';
 import type { DismissalTracker } from './dismissalTracker.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
-import { processTranscriptLine } from './transcriptParser.js';
+import { processTranscriptLine, readSessionNameFromTranscriptTail } from './transcriptParser.js';
 import type { AgentState } from './types.js';
 
 /** Dismissal tracker instance. Set once at startup via setDismissalTracker().
@@ -941,8 +941,15 @@ function adoptExternalSession(
     outputTokens: 0,
   };
 
+  // History is skipped (fileOffset starts at the end), so read any user-set
+  // session name from the transcript tail at adoption time.
+  agent.sessionName = readSessionNameFromTranscriptTail(jsonlFile);
+
   agents.set(id, agent);
   persistAgents();
+  if (agent.sessionName) {
+    agents.broadcast({ type: 'agentSessionName', id, name: agent.sessionName });
+  }
 
   // Log is emitted by the caller (adoptExternalSessionFromHook or scanExternalDir)
   // to use the correct prefix (Hook: vs Watcher:).

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -58,6 +58,17 @@ export function processTranscriptLine(
     // -- Agent Teams: extract team metadata via the active provider --
     // The provider reads its CLI's own field names (Claude: record.teamName + record.agentName).
     // Other CLIs would implement this differently or not at all.
+    // -- Session name: user-set title (e.g. Claude's /rename writes a
+    // custom-title record). Shown in the webview's agent label. --
+    if (record.type === 'custom-title' && typeof record.customTitle === 'string') {
+      const name = record.customTitle.trim();
+      if (name && name !== agent.sessionName) {
+        agent.sessionName = name;
+        agents.broadcast({ type: 'agentSessionName', id: agentId, name });
+      }
+      return;
+    }
+
     const teamMeta = hookProvider?.team?.extractTeamMetadataFromRecord(record);
     if (teamMeta?.teamName && teamMeta.teamName !== agent.teamName) {
       agent.teamName = teamMeta.teamName;

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -1,5 +1,7 @@
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
 
+import * as fs from 'fs';
+
 import type { HookProvider } from '../../core/src/provider.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import { TEXT_IDLE_DELAY_MS, TOOL_DONE_DELAY_MS } from './constants.js';
@@ -39,6 +41,43 @@ export function setHookProvider(provider: HookProvider): void {
  *  Invariant: a provider is registered before any transcript lines are parsed. */
 export function formatToolStatus(toolName: string, input: Record<string, unknown>): string {
   return hookProvider?.formatToolStatus(toolName, input) ?? `Using ${toolName}`;
+}
+
+/** Max bytes read from the end of a transcript when looking for a session name. */
+const SESSION_NAME_TAIL_BYTES = 256 * 1024;
+
+/**
+ * Read the most recent user-set session name (custom-title record) from the
+ * tail of a transcript file. Used at adoption/restore time, when reading
+ * starts at the file end and historical records would otherwise be skipped.
+ * The CLI re-appends the record periodically, so a tail scan is sufficient.
+ */
+export function readSessionNameFromTranscriptTail(jsonlFile: string): string | undefined {
+  try {
+    const stat = fs.statSync(jsonlFile);
+    const start = Math.max(0, stat.size - SESSION_NAME_TAIL_BYTES);
+    const fd = fs.openSync(jsonlFile, 'r');
+    const buf = Buffer.alloc(stat.size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    fs.closeSync(fd);
+    const lines = buf.toString('utf-8').split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line.includes('"custom-title"')) continue;
+      try {
+        const record = JSON.parse(line) as { type?: string; customTitle?: unknown };
+        if (record.type === 'custom-title' && typeof record.customTitle === 'string') {
+          const name = record.customTitle.trim();
+          if (name) return name;
+        }
+      } catch {
+        /* partial or malformed line — keep scanning */
+      }
+    }
+  } catch {
+    /* unreadable file — no name */
+  }
+  return undefined;
 }
 
 export function processTranscriptLine(

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -65,6 +65,7 @@ export function processTranscriptLine(
       if (name && name !== agent.sessionName) {
         agent.sessionName = name;
         agents.broadcast({ type: 'agentSessionName', id: agentId, name });
+        agents.persist();
       }
       return;
     }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -58,6 +58,9 @@ export interface AgentState {
   leadAgentId?: number;
   /** True when lead spawns teammates via tmux (run_in_background Agent calls) */
   teamUsesTmux?: boolean;
+
+  /** User-set session name from the transcript (e.g. Claude's /rename) */
+  sessionName?: string;
 }
 
 export interface PersistedAgent {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -81,4 +81,7 @@ export interface PersistedAgent {
   isTeamLead?: boolean;
   leadAgentId?: number;
   teamUsesTmux?: boolean;
+
+  /** User-set session name from the transcript (e.g. Claude's /rename) */
+  sessionName?: string;
 }

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -71,6 +71,8 @@ function App() {
     watchAllSessions,
     setWatchAllSessions,
     alwaysShowLabels,
+    showSessionNames,
+    setShowSessionNames,
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
@@ -251,6 +253,7 @@ function App() {
             panRef={editor.panRef}
             onCloseAgent={handleCloseAgent}
             alwaysShowOverlay={alwaysShowOverlay}
+            showSessionNames={showSessionNames}
           />
         </>
       ) : (
@@ -357,6 +360,12 @@ function App() {
           const newVal = !watchAllSessions;
           setWatchAllSessions(newVal);
           transport.send({ type: 'setWatchAllSessions', enabled: newVal });
+        }}
+        showSessionNames={showSessionNames}
+        onToggleShowSessionNames={() => {
+          const newVal = !showSessionNames;
+          setShowSessionNames(newVal);
+          transport.send({ type: 'setShowSessionNames', enabled: newVal });
         }}
         hooksEnabled={hooksEnabled}
         onToggleHooksEnabled={() => {

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -14,6 +14,8 @@ interface SettingsModalProps {
   onToggleDebugMode: () => void;
   alwaysShowOverlay: boolean;
   onToggleAlwaysShowOverlay: () => void;
+  showSessionNames: boolean;
+  onToggleShowSessionNames: () => void;
   externalAssetDirectories: string[];
   watchAllSessions: boolean;
   onToggleWatchAllSessions: () => void;
@@ -28,6 +30,8 @@ export function SettingsModal({
   onToggleDebugMode,
   alwaysShowOverlay,
   onToggleAlwaysShowOverlay,
+  showSessionNames,
+  onToggleShowSessionNames,
   externalAssetDirectories,
   watchAllSessions,
   onToggleWatchAllSessions,
@@ -112,6 +116,11 @@ export function SettingsModal({
         label="Always Show Labels"
         checked={alwaysShowOverlay}
         onChange={onToggleAlwaysShowOverlay}
+      />
+      <Checkbox
+        label="Session Names in Labels"
+        checked={showSessionNames}
+        onChange={onToggleShowSessionNames}
       />
       <Checkbox label="Debug View" checked={isDebugMode} onChange={onToggleDebugMode} />
     </Modal>

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -232,6 +232,7 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
+        const sessionNames = (msg.sessionNames || {}) as Record<number, string>;
         // Buffer agents — they'll be added in layoutLoaded after seats are built
         for (const id of incoming) {
           const m = meta[id];
@@ -241,6 +242,7 @@ export function useExtensionMessages(
             hueShift: m?.hueShift,
             seatId: m?.seatId,
             folderName: folderNames[id],
+            sessionName: sessionNames[id],
           });
         }
         setAgents((prev) => {

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -67,6 +67,8 @@ interface ExtensionMessageState {
   watchAllSessions: boolean;
   setWatchAllSessions: (v: boolean) => void;
   alwaysShowLabels: boolean;
+  showSessionNames: boolean;
+  setShowSessionNames: (v: boolean) => void;
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
@@ -105,6 +107,7 @@ export function useExtensionMessages(
   const [extensionVersion, setExtensionVersion] = useState('');
   const [watchAllSessions, setWatchAllSessions] = useState(false);
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
+  const [showSessionNames, setShowSessionNames] = useState(true);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
 
@@ -119,6 +122,7 @@ export function useExtensionMessages(
       hueShift?: number;
       seatId?: string;
       folderName?: string;
+      sessionName?: string;
     }> = [];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -151,6 +155,10 @@ export function useExtensionMessages(
         // Add buffered agents now that layout (and seats) are correct
         for (const p of pendingAgents) {
           os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+          if (p.sessionName) {
+            const ch = os.characters.get(p.id);
+            if (ch) ch.sessionName = p.sessionName;
+          }
         }
         pendingAgents = [];
         layoutReadyRef.current = true;
@@ -467,6 +475,9 @@ export function useExtensionMessages(
         if (typeof msg.alwaysShowLabels === 'boolean') {
           setAlwaysShowLabels(msg.alwaysShowLabels as boolean);
         }
+        if (typeof msg.showSessionNames === 'boolean') {
+          setShowSessionNames(msg.showSessionNames as boolean);
+        }
         if (typeof msg.hooksEnabled === 'boolean') {
           setHooksEnabled(msg.hooksEnabled as boolean);
         }
@@ -507,6 +518,11 @@ export function useExtensionMessages(
           msg.leadAgentId as number | undefined,
           msg.teamUsesTmux as boolean | undefined,
         );
+      } else if (msg.type === 'agentSessionName') {
+        const id = msg.id as number;
+        const name = msg.name as string;
+        const ch = os.characters.get(id);
+        if (ch) ch.sessionName = name;
       } else if (msg.type === 'agentTokenUsage') {
         const id = msg.id as number;
         os.setAgentTokens(id, msg.inputTokens as number, msg.outputTokens as number);
@@ -535,6 +551,8 @@ export function useExtensionMessages(
     watchAllSessions,
     setWatchAllSessions,
     alwaysShowLabels,
+    showSessionNames,
+    setShowSessionNames,
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -33,6 +33,7 @@ interface ToolOverlayProps {
   panRef: React.RefObject<{ x: number; y: number }>;
   onCloseAgent: (id: number) => void;
   alwaysShowOverlay: boolean;
+  showSessionNames: boolean;
 }
 
 /** Derive a short human-readable activity string from tools/status */
@@ -76,6 +77,7 @@ export function ToolOverlay({
   panRef,
   onCloseAgent,
   alwaysShowOverlay,
+  showSessionNames,
 }: ToolOverlayProps) {
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -157,7 +159,9 @@ export function ToolOverlay({
         const teamRoleLabel = ch.isTeamLead ? 'LEAD' : ch.agentName || null;
         const totalTokens = ch.inputTokens + ch.outputTokens;
         const tokenRatio = totalTokens / MAX_CONTEXT_TOKENS;
-        const hasExtraLines = !!(ch.folderName || teamRoleLabel);
+        // Prefer the user-set session name (e.g. /rename) over the folder name
+        const contextLabel = showSessionNames && ch.sessionName ? ch.sessionName : ch.folderName;
+        const hasExtraLines = !!(contextLabel || teamRoleLabel);
 
         return (
           <div
@@ -200,9 +204,9 @@ export function ToolOverlay({
                 >
                   {activityText}
                 </span>
-                {ch.folderName && (
+                {contextLabel && (
                   <span className="text-2xs leading-none overflow-hidden text-ellipsis block">
-                    {ch.folderName}
+                    {contextLabel}
                   </span>
                 )}
               </div>

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -180,6 +180,8 @@ export interface Character {
   matrixEffectSeeds: number[];
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** User-set session name (e.g. Claude's /rename), preferred over folderName in labels */
+  sessionName?: string;
 
   // -- Agent Teams --
   /** Team name this agent belongs to */


### PR DESCRIPTION
## Description

The small line under an agent's activity label always shows the workspace folder name. With several sessions running from the same folder (or generic folder names), agents are hard to tell apart — while users often already give their sessions meaningful names (Claude Code's `/rename`, persisted as `custom-title` records in the transcript).

This PR shows the user-set session name in that line when one exists, falling back to the folder name otherwise:

- The transcript parser picks up `custom-title` records live, stores the name on the agent, persists it, and broadcasts a new `agentSessionName` message.
- Adopted sessions start reading at the file end, so the most recent `custom-title` is read from the transcript tail at adoption time (the CLI re-appends it periodically, so a tail scan suffices).
- `existingAgents` carries a `sessionNames` map so freshly connected clients label agents immediately; names survive server restarts via agent persistence.
- Controlled by a new **Session Names in Labels** setting (default on), persisted like the other toggles and wired for both the standalone server and the VS Code extension.
- Protocol additions live in `core/asyncapi.yaml` (`agentSessionName`, `setShowSessionNames`, `existingAgents.sessionNames`, `settingsLoaded.showSessionNames`) with `messages.ts` regenerated via `npm run asyncapi:generate`.

## Type of change
- [x] New feature

## Related issues

None found.

## Screenshots / GIFs

Two sessions from the same project: the renamed one shows its session name, the unnamed one falls back as before. The toggle lives in Settings as "Session Names in Labels".

![session names in labels](https://raw.githubusercontent.com/Ralphive/pixel-agents/pr-assets/session-name-labels.gif)

## Test plan
- [x] Rebased on latest `main`
- [x] `npm run lint`, `npm run build`, `npm test` all pass
- [x] New tests in `server/__tests__/transcriptParser.test.ts`: custom-title parsing (set/change/no-op/trim/unknown agent, 6 cases) and tail reading (latest wins, missing file, malformed lines, 4 cases)
- [x] Manually verified against the standalone server: a renamed session shows its name on adoption, on rename mid-session, after server restart (persistence), and on fresh client connect (existingAgents); unnamed sessions keep showing the folder name; toggling the setting off restores folder names everywhere
