### PR TITLE
fix: existing agents not appearing in standalone mode

### DIFF
--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -224,16 +224,27 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
-        // Buffer agents — they'll be added in layoutLoaded after seats are built
-        for (const id of incoming) {
-          const m = meta[id];
-          pendingAgents.push({
-            id,
-            palette: m?.palette,
-            hueShift: m?.hueShift,
-            seatId: m?.seatId,
-            folderName: folderNames[id],
-          });
+        if (layoutReadyRef.current) {
+          // Layout already loaded — add agents directly (standalone mode:
+          // existingAgents can arrive after layoutLoaded)
+          for (const id of incoming) {
+            if (os.characters.has(id)) continue;
+            const m = meta[id];
+            os.addAgent(id, m?.palette, m?.hueShift, m?.seatId, true, folderNames[id]);
+          }
+          saveAgentSeats(os);
+        } else {
+          // Buffer agents — they'll be added in layoutLoaded after seats are built
+          for (const id of incoming) {
+            const m = meta[id];
+            pendingAgents.push({
+              id,
+              palette: m?.palette,
+              hueShift: m?.hueShift,
+              seatId: m?.seatId,
+              folderName: folderNames[id],
+            });
+          }
         }
         setAgents((prev) => {
           const ids = new Set(prev);


### PR DESCRIPTION
## Summary

- In standalone server mode, `existingAgents` WebSocket message can arrive **after** `layoutLoaded` has already fired
- When this happens, agents are buffered into `pendingAgents` but never flushed — the flush only runs inside the `layoutLoaded` handler which already executed
- Fix: check `layoutReadyRef.current` in `existingAgents` handler — if layout is already loaded, add agents directly via `os.addAgent()` instead of buffering

## Reproduce

1. Run standalone server: `node dist/cli.js --port 3100`
2. Have active Claude Code sessions in `~/.claude/projects/`
3. Open `http://localhost:3100` — no characters appear despite agents being detected by the server

After this fix, characters appear correctly regardless of message ordering.

## Test plan

- [x] `npm run lint` — no new errors (pre-existing dist/e2e errors unchanged)
- [x] `npm run test:webview` — 2/2 pass
- [x] `npm run test:server` — 209/209 pass
- [x] Manual: standalone server shows agents after page load
- [x] Manual: VS Code extension still works (buffering path unchanged when layout loads first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)