### PR TITLE
Windows portability fixes + interact with agents from the office window

### DIFF
--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -201,6 +201,26 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.runtime.removeAgent(message.id);
           }
         }
+      } else if (message.type === 'sendAgentMessage') {
+        const agent = this.store.get(message.id);
+        const text = ((message.text as string) ?? '').trim();
+        if (agent && text) {
+          // Resolve the terminal: own terminal, or the lead's for tmux teammates.
+          const terminal =
+            agent.terminalRef ??
+            (agent.leadAgentId !== undefined
+              ? this.store.get(agent.leadAgentId)?.terminalRef
+              : undefined);
+          if (terminal) {
+            terminal.show();
+            // addNewLine defaults to true, which submits the prompt to Claude.
+            terminal.sendText(text);
+          } else {
+            console.log(
+              `[Pixel Agents] sendAgentMessage: agent ${message.id} has no terminal (external/standalone), ignoring`,
+            );
+          }
+        }
       } else if (message.type === 'saveAgentSeats') {
         // Store seat assignments in a separate key (never touched by persistAgents)
         console.log(`[Pixel Agents] State: saveAgentSeats:`, JSON.stringify(message.seats));

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -43,6 +43,7 @@ import {
   CONFIG_KEY_AUTO_SHOW_PANEL,
   CONFIG_KEY_AUTO_SPAWN_AGENT,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
+  GLOBAL_KEY_APPROVALS_FROM_WINDOW,
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
   GLOBAL_KEY_LAST_SEEN_VERSION,
@@ -285,6 +286,16 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.runtime.removeAgent(id);
           }
         }
+      } else if (message.type === 'setApprovalsFromWindow') {
+        const enabled = message.enabled as boolean;
+        this.adapter.setSetting(GLOBAL_KEY_APPROVALS_FROM_WINDOW, enabled);
+        this.runtime.approvalsFromWindow.current = enabled;
+      } else if (message.type === 'respondApproval') {
+        const approvalId = message.approvalId as string | undefined;
+        const decision = message.decision as 'allow' | 'deny' | undefined;
+        if (approvalId && (decision === 'allow' || decision === 'deny')) {
+          this.runtime.resolveApproval(approvalId, decision);
+        }
       } else if (message.type === 'webviewReady') {
         // Provider capabilities: tool taxonomy for webview animation + subagent rendering.
         // Sent once before restoreAgents so characters render with correct animations
@@ -373,6 +384,11 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.runtime.watchAllSessions.current = watchAllSessions;
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         const hooksInfoShown = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_INFO_SHOWN, false);
+        const approvalsFromWindow = this.adapter.getSetting<boolean>(
+          GLOBAL_KEY_APPROVALS_FROM_WINDOW,
+          false,
+        );
+        this.runtime.approvalsFromWindow.current = approvalsFromWindow;
         const config = readConfig();
         this.webview?.postMessage({
           type: 'settingsLoaded',
@@ -383,6 +399,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           alwaysShowLabels,
           hooksEnabled,
           hooksInfoShown,
+          approvalsFromWindow,
           externalAssetDirectories: config.externalAssetDirectories,
         });
 

--- a/adapters/vscode/constants.ts
+++ b/adapters/vscode/constants.ts
@@ -14,6 +14,7 @@ export const GLOBAL_KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
 export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 export const GLOBAL_KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
+export const GLOBAL_KEY_APPROVALS_FROM_WINDOW = 'pixel-agents.approvalsFromWindow';
 
 // ── VS Code Settings (contributes.configuration keys) ───────
 export const CONFIG_KEY_AUTO_SHOW_PANEL = 'pixel-agents.autoShowPanel';

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -91,6 +91,9 @@ components:
         - $ref: '#/components/schemas/AgentToolsClear'
         - $ref: '#/components/schemas/AgentToolPermission'
         - $ref: '#/components/schemas/AgentToolPermissionClear'
+        # Window approvals (opt-in)
+        - $ref: '#/components/schemas/AgentApprovalRequest'
+        - $ref: '#/components/schemas/AgentApprovalResolved'
         # Sub-agent activity
         - $ref: '#/components/schemas/SubagentToolStart'
         - $ref: '#/components/schemas/SubagentToolDone'
@@ -129,6 +132,8 @@ components:
         - $ref: '#/components/schemas/SetHooksEnabled'
         - $ref: '#/components/schemas/SetHooksInfoShown'
         - $ref: '#/components/schemas/SetWatchAllSessions'
+        - $ref: '#/components/schemas/SetApprovalsFromWindow'
+        - $ref: '#/components/schemas/RespondApproval'
         - $ref: '#/components/schemas/ExportLayout'
         - $ref: '#/components/schemas/ImportLayout'
         - $ref: '#/components/schemas/OpenSessionsFolder'
@@ -313,6 +318,39 @@ components:
           const: agentToolPermissionClear
         id:
           type: integer
+
+    AgentApprovalRequest:
+      description: >-
+        A tool-use is awaiting the user's Allow/Deny decision in the window
+        (sent only when "Approvals from window" is enabled). The hook HTTP
+        response is held open until a RespondApproval arrives or it times out.
+      type: object
+      additionalProperties: false
+      required: [type, id, approvalId, toolName, status]
+      properties:
+        type:
+          const: agentApprovalRequest
+        id:
+          type: integer
+        approvalId:
+          type: string
+        toolName:
+          type: string
+        status:
+          type: string
+
+    AgentApprovalResolved:
+      description: A pending window approval was resolved (decided or timed out); clear its UI.
+      type: object
+      additionalProperties: false
+      required: [type, id, approvalId]
+      properties:
+        type:
+          const: agentApprovalResolved
+        id:
+          type: integer
+        approvalId:
+          type: string
 
     SubagentToolStart:
       description: Sub-agent (e.g. Task) started a tool.
@@ -516,6 +554,7 @@ components:
         - alwaysShowLabels
         - hooksEnabled
         - hooksInfoShown
+        - approvalsFromWindow
         - externalAssetDirectories
       properties:
         type:
@@ -533,6 +572,8 @@ components:
         hooksEnabled:
           type: boolean
         hooksInfoShown:
+          type: boolean
+        approvalsFromWindow:
           type: boolean
         externalAssetDirectories:
           type: array
@@ -726,6 +767,31 @@ components:
           const: setWatchAllSessions
         enabled:
           type: boolean
+
+    SetApprovalsFromWindow:
+      description: Toggle the opt-in "approve tool use from the window" mode.
+      type: object
+      additionalProperties: false
+      required: [type, enabled]
+      properties:
+        type:
+          const: setApprovalsFromWindow
+        enabled:
+          type: boolean
+
+    RespondApproval:
+      description: The user's Allow/Deny decision for a pending window approval.
+      type: object
+      additionalProperties: false
+      required: [type, approvalId, decision]
+      properties:
+        type:
+          const: respondApproval
+        approvalId:
+          type: string
+        decision:
+          type: string
+          enum: [allow, deny]
 
     ExportLayout:
       description: Trigger layout export via host-native save dialog.

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -120,6 +120,7 @@ components:
         - $ref: '#/components/schemas/LaunchAgent'
         - $ref: '#/components/schemas/FocusAgent'
         - $ref: '#/components/schemas/CloseAgent'
+        - $ref: '#/components/schemas/SendAgentMessage'
         - $ref: '#/components/schemas/SaveAgentSeats'
         - $ref: '#/components/schemas/SaveLayout'
         - $ref: '#/components/schemas/SetSoundEnabled'
@@ -624,6 +625,23 @@ components:
           const: closeAgent
         id:
           type: integer
+
+    SendAgentMessage:
+      description: >-
+        Send a text message/prompt to an agent's terminal. The extension writes
+        the text to the agent's terminal as if typed and submits it (newline).
+        Only works for agents the extension owns a terminal for (VS Code mode);
+        ignored for external/standalone agents with no terminal.
+      type: object
+      additionalProperties: false
+      required: [type, id, text]
+      properties:
+        type:
+          const: sendAgentMessage
+        id:
+          type: integer
+        text:
+          type: string
 
     SaveAgentSeats:
       description: Persist seat assignments for current agents.

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -19,6 +19,8 @@ export type ServerMessage =
   | AgentToolsClear
   | AgentToolPermission
   | AgentToolPermissionClear
+  | AgentApprovalRequest
+  | AgentApprovalResolved
   | SubagentToolStart
   | SubagentToolDone
   | SubagentClear
@@ -49,6 +51,8 @@ export type ClientMessage =
   | SetHooksEnabled
   | SetHooksInfoShown
   | SetWatchAllSessions
+  | SetApprovalsFromWindow
+  | RespondApproval
   | ExportLayout
   | ImportLayout
   | OpenSessionsFolder
@@ -130,6 +134,20 @@ export interface AgentToolPermission {
 export interface AgentToolPermissionClear {
   type: 'agentToolPermissionClear';
   id: number;
+}
+
+export interface AgentApprovalRequest {
+  type: 'agentApprovalRequest';
+  id: number;
+  approvalId: string;
+  toolName: string;
+  status: string;
+}
+
+export interface AgentApprovalResolved {
+  type: 'agentApprovalResolved';
+  id: number;
+  approvalId: string;
 }
 
 export interface SubagentToolStart {
@@ -241,6 +259,7 @@ export interface SettingsLoaded {
   alwaysShowLabels: boolean;
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
+  approvalsFromWindow: boolean;
   externalAssetDirectories: string[];
 }
 
@@ -334,6 +353,19 @@ export interface SetWatchAllSessions {
   type: 'setWatchAllSessions';
   enabled: boolean;
 }
+
+export interface SetApprovalsFromWindow {
+  type: 'setApprovalsFromWindow';
+  enabled: boolean;
+}
+
+export interface RespondApproval {
+  type: 'respondApproval';
+  approvalId: string;
+  decision: AnonymousSchema_187;
+}
+
+export type AnonymousSchema_187 = 'allow' | 'deny';
 
 export interface ExportLayout {
   type: 'exportLayout';

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -40,6 +40,7 @@ export type ClientMessage =
   | LaunchAgent
   | FocusAgent
   | CloseAgent
+  | SendAgentMessage
   | SaveAgentSeats
   | SaveLayout
   | SetSoundEnabled
@@ -281,6 +282,12 @@ export interface FocusAgent {
 export interface CloseAgent {
   type: 'closeAgent';
   id: number;
+}
+
+export interface SendAgentMessage {
+  type: 'sendAgentMessage';
+  id: number;
+  text: string;
 }
 
 export interface SaveAgentSeats {

--- a/scripts/generate-messages.ts
+++ b/scripts/generate-messages.ts
@@ -137,7 +137,9 @@ function exportify(decl: string): string {
 }
 
 function quote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
+  // Use double quotes so the path survives both POSIX shells and Windows cmd.exe
+  // (cmd.exe does not strip single quotes, which breaks the spawned prettier/eslint).
+  return `"${s.replace(/"/g, '\\"')}"`;
 }
 
 main().catch((err) => {

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -30,7 +30,7 @@ import {
   startFileWatching,
   startStaleExternalAgentCheck,
 } from './fileWatcher.js';
-import type { HookEvent } from './hookEventHandler.js';
+import type { ApprovalDecision, HookEvent } from './hookEventHandler.js';
 import { HookEventHandler } from './hookEventHandler.js';
 import { SessionRouter } from './sessionRouter.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
@@ -63,6 +63,7 @@ export class AgentRuntime {
   // Configuration refs (mutable, shared with scanners)
   readonly watchAllSessions = { current: false };
   readonly hooksEnabled = { current: true };
+  readonly approvalsFromWindow = { current: false };
 
   // Dependencies
   readonly dismissalTracker = new DismissalTracker();
@@ -90,6 +91,7 @@ export class AgentRuntime {
       provider,
       new SessionRouter(),
       this.watchAllSessions,
+      this.approvalsFromWindow,
     );
 
     // Wire hook lifecycle callbacks to shared agent operations
@@ -186,6 +188,25 @@ export class AgentRuntime {
   /** Route an incoming hook event to the appropriate agent. */
   handleHookEvent(providerId: string, event: Record<string, unknown>): void {
     this.hookEventHandler.handleEvent(providerId, event as HookEvent);
+  }
+
+  /** True when "Approvals from window" is on. */
+  isApprovalMode(): boolean {
+    return this.hookEventHandler.isApprovalMode();
+  }
+
+  /**
+   * If window-approval applies to this PreToolUse event, returns a promise that
+   * resolves with the user's decision (or null to fall back to Claude's prompt);
+   * returns null synchronously when approval does not apply.
+   */
+  maybeRequestApproval(event: Record<string, unknown>): Promise<ApprovalDecision | null> | null {
+    return this.hookEventHandler.maybeRequestApproval(event as HookEvent);
+  }
+
+  /** Resolve a pending approval with the user's decision (from the window). */
+  resolveApproval(approvalId: string, decision: ApprovalDecision): void {
+    this.hookEventHandler.resolveApproval(approvalId, decision);
   }
 
   /** Register an agent with the hook event handler for session->agent mapping. */

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -130,6 +130,10 @@ async function main(): Promise<void> {
     // Sync runtime refs with persisted settings BEFORE first scan tick
     runtime.hooksEnabled.current = adapter.getSetting('pixel-agents.hooksEnabled', true);
     runtime.watchAllSessions.current = adapter.getSetting('pixel-agents.watchAllSessions', false);
+    runtime.approvalsFromWindow.current = adapter.getSetting(
+      'pixel-agents.approvalsFromWindow',
+      false,
+    );
 
     // Install hooks on startup if the persisted setting says so
     if (runtime.hooksEnabled.current) {

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -61,6 +61,9 @@ async function main(): Promise<void> {
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
   const staticDir = path.join(distRoot, 'webview');
+  // copyHookScript() expects the package root (it appends "dist/hooks" itself),
+  // so pass the parent of dist/ — not distRoot, which would yield dist/dist/hooks.
+  const packageRoot = path.dirname(distRoot);
 
   // ── Load assets on startup (same pipeline as VS Code extension) ──
   console.log('[Pixel Agents] Loading assets...');
@@ -104,7 +107,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(packageRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -132,7 +135,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(packageRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -34,6 +34,7 @@ const KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
 const KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 const KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 const KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
+const KEY_APPROVALS_FROM_WINDOW = 'pixel-agents.approvalsFromWindow';
 
 /**
  * Handle incoming ClientMessage from a WebSocket client.
@@ -99,6 +100,22 @@ export function handleClientMessage(
     case 'setHooksInfoShown':
       adapter?.setSetting(KEY_HOOKS_INFO_SHOWN, true);
       break;
+
+    case 'setApprovalsFromWindow': {
+      const enabled = msg.enabled as boolean;
+      adapter?.setSetting(KEY_APPROVALS_FROM_WINDOW, enabled);
+      if (runtime) runtime.approvalsFromWindow.current = enabled;
+      break;
+    }
+
+    case 'respondApproval': {
+      const approvalId = msg.approvalId as string | undefined;
+      const decision = msg.decision as 'allow' | 'deny' | undefined;
+      if (runtime && approvalId && (decision === 'allow' || decision === 'deny')) {
+        runtime.resolveApproval(approvalId, decision);
+      }
+      break;
+    }
 
     case 'addExternalAssetDirectory': {
       const newPath = msg.path as string | undefined;
@@ -168,6 +185,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   const cfg = readConfig();
   const watchAllSessions = adapter?.getSetting(KEY_WATCH_ALL_SESSIONS, false) ?? false;
   const hooksEnabled = adapter?.getSetting(KEY_HOOKS_ENABLED, true) ?? true;
+  const approvalsFromWindow = adapter?.getSetting(KEY_APPROVALS_FROM_WINDOW, false) ?? false;
   send({
     type: 'settingsLoaded',
     soundEnabled: adapter?.getSetting(KEY_SOUND_ENABLED, true) ?? true,
@@ -177,6 +195,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     alwaysShowLabels: adapter?.getSetting(KEY_ALWAYS_SHOW_LABELS, false) ?? false,
     hooksEnabled,
     hooksInfoShown: adapter?.getSetting(KEY_HOOKS_INFO_SHOWN, false) ?? false,
+    approvalsFromWindow,
     externalAssetDirectories: cfg.externalAssetDirectories,
   });
 
@@ -185,6 +204,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   if (runtime) {
     runtime.watchAllSessions.current = watchAllSessions;
     runtime.hooksEnabled.current = hooksEnabled;
+    runtime.approvalsFromWindow.current = approvalsFromWindow;
   }
 
   // 5. Restore persisted external agents (standalone only; VS Code handles its own restore)

--- a/server/src/configPersistence.ts
+++ b/server/src/configPersistence.ts
@@ -11,6 +11,7 @@ export interface AdapterSettings {
   watchAllSessions: boolean;
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
+  approvalsFromWindow: boolean;
 }
 
 /** All keys in AdapterSettings. Used by adapters to map `pixel-agents.foo` → `foo`. */
@@ -21,6 +22,7 @@ export const ADAPTER_SETTING_KEYS = [
   'watchAllSessions',
   'hooksEnabled',
   'hooksInfoShown',
+  'approvalsFromWindow',
 ] as const;
 
 export type AdapterSettingKey = (typeof ADAPTER_SETTING_KEYS)[number];
@@ -41,6 +43,7 @@ const DEFAULT_ADAPTER_SETTINGS: AdapterSettings = {
   watchAllSessions: false,
   hooksEnabled: true,
   hooksInfoShown: false,
+  approvalsFromWindow: false,
 };
 
 function getConfigFilePath(): string {
@@ -75,6 +78,10 @@ function parseAdapterSettings(raw: unknown): AdapterSettings {
       typeof obj.hooksInfoShown === 'boolean'
         ? obj.hooksInfoShown
         : DEFAULT_ADAPTER_SETTINGS.hooksInfoShown,
+    approvalsFromWindow:
+      typeof obj.approvalsFromWindow === 'boolean'
+        ? obj.approvalsFromWindow
+        : DEFAULT_ADAPTER_SETTINGS.approvalsFromWindow,
   };
 }
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -53,6 +53,10 @@ export const HOOK_EVENT_BUFFER_MS = 5_000;
  *  the agent is cleaned up instead of staying as a zombie with pendingClear forever. */
 export const SESSION_END_GRACE_MS = 2000;
 export const MAX_HOOK_BODY_SIZE = 65_536; // 64KB
+// How long the server blocks a PreToolUse hook waiting for a window approval
+// decision before giving up and letting Claude prompt in the terminal. Must stay
+// safely under Claude's 10-minute command-hook timeout.
+export const APPROVAL_TIMEOUT_MS = 540_000; // 9 minutes
 
 // ── Layout/Config Persistence ──────────────────────────────
 export const LAYOUT_FILE_DIR = '.pixel-agents';

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -2,13 +2,22 @@ import * as path from 'path';
 
 import type { AgentEvent, HookProvider } from '../../core/src/provider.js';
 import type { AgentStateStore } from './agentStateStore.js';
-import { SESSION_END_GRACE_MS } from './constants.js';
+import { APPROVAL_TIMEOUT_MS, SESSION_END_GRACE_MS } from './constants.js';
 import type { SessionRouter } from './sessionRouter.js';
 import { getInlineTeammates, hasInlineTeammates } from './teamUtils.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
 import type { AgentState } from './types.js';
 
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
+
+/** A tool-approval decision returned to the Claude PreToolUse hook. */
+export type ApprovalDecision = 'allow' | 'deny';
+
+/** A pending approval awaiting a decision from the office window. */
+interface PendingApproval {
+  resolve: (decision: ApprovalDecision | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 /** Normalized hook event received from any provider's hook script via the HTTP server. */
 export interface HookEvent {
@@ -68,6 +77,7 @@ export class HookEventHandler {
     private provider: HookProvider,
     private sessionRouter: SessionRouter,
     private watchAllSessionsRef?: { current: boolean },
+    private approvalsFromWindowRef?: { current: boolean },
   ) {
     if (provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
       console.warn(
@@ -103,6 +113,82 @@ export class HookEventHandler {
   /** Set callbacks for session lifecycle events (SessionStart/SessionEnd). */
   setLifecycleCallbacks(callbacks: SessionLifecycleCallbacks): void {
     this.lifecycleCallbacks = callbacks;
+  }
+
+  // ── Window approvals (opt-in) ──────────────────────────────────────────────
+  // When "Approvals from window" is on, a PreToolUse for a non-exempt tool blocks
+  // the hook HTTP response until the user clicks Allow/Deny in the office window
+  // (or the timeout elapses, in which case Claude falls back to its terminal prompt).
+
+  private readonly pendingApprovals = new Map<string, PendingApproval>();
+  private approvalCounter = 0;
+
+  /** Whether window-approval mode is currently enabled. */
+  isApprovalMode(): boolean {
+    return this.approvalsFromWindowRef?.current === true;
+  }
+
+  /**
+   * If approval mode applies to this PreToolUse event, broadcast an approval
+   * request to the window and return a promise that resolves with the user's
+   * decision (or null to fall back to Claude's own prompt). Returns null
+   * synchronously when approval does not apply (mode off, exempt tool, or no
+   * known agent for the session).
+   */
+  maybeRequestApproval(event: HookEvent): Promise<ApprovalDecision | null> | null {
+    if (!this.isApprovalMode()) return null;
+    const toolName = typeof event.tool_name === 'string' ? event.tool_name : '';
+    if (!toolName || this.provider.permissionExemptTools.has(toolName)) return null;
+
+    // Resolve the agent so we can show the request on its character.
+    let agentId = this.sessionRouter.resolve(event.session_id);
+    if (agentId === undefined) {
+      for (const [id, agent] of this.agents) {
+        if (agent.sessionId === event.session_id) {
+          agentId = id;
+          break;
+        }
+      }
+    }
+    if (agentId === undefined) return null;
+
+    const toolInput = (event.tool_input as Record<string, unknown> | undefined) ?? {};
+    const status = this.provider.formatToolStatus(toolName, toolInput);
+    const approvalId = `appr-${agentId}-${++this.approvalCounter}`;
+
+    this.agents.broadcast({
+      type: 'agentApprovalRequest',
+      id: agentId,
+      approvalId,
+      toolName,
+      status,
+    });
+    if (debug)
+      console.log(
+        `[Pixel Agents] Approval: requested ${approvalId} (agent ${agentId}, ${toolName})`,
+      );
+
+    return new Promise<ApprovalDecision | null>((resolve) => {
+      const settle = (decision: ApprovalDecision | null) => {
+        const pending = this.pendingApprovals.get(approvalId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingApprovals.delete(approvalId);
+        this.agents.broadcast({ type: 'agentApprovalResolved', id: agentId, approvalId });
+        resolve(decision);
+      };
+      const timer = setTimeout(() => settle(null), APPROVAL_TIMEOUT_MS);
+      this.pendingApprovals.set(approvalId, { resolve: settle, timer });
+    });
+  }
+
+  /** Resolve a pending approval with the user's decision (from the window). */
+  resolveApproval(approvalId: string, decision: ApprovalDecision): void {
+    const pending = this.pendingApprovals.get(approvalId);
+    if (pending) {
+      if (debug) console.log(`[Pixel Agents] Approval: ${approvalId} -> ${decision}`);
+      pending.resolve(decision);
+    }
   }
 
   /** Register an agent for hook event routing. Flushes any buffered events for this session. */

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -121,7 +121,20 @@ function registerHookRoute(app: FastifyInstance, options: HttpServerOptions): vo
       const event = request.body;
 
       if (event.session_id && event.hook_event_name) {
-        options.onHookEvent?.(providerId, event);
+        // Window-approval path: a PreToolUse for a non-exempt tool blocks here
+        // until the user clicks Allow/Deny in the office window (or it times out).
+        // The decision is returned to the hook script, which forwards it to Claude.
+        if (event.hook_event_name === 'PreToolUse' && options.runtime?.isApprovalMode()) {
+          options.onHookEvent?.(providerId, event);
+          const pending = options.runtime.maybeRequestApproval(event);
+          if (pending) {
+            const decision = await pending;
+            reply.send(decision ? { decision } : 'ok');
+            return;
+          }
+        } else {
+          options.onHookEvent?.(providerId, event);
+        }
       }
 
       reply.send('ok');

--- a/server/src/providers/hook/claude/hooks/claude-hook.ts
+++ b/server/src/providers/hook/claude/hooks/claude-hook.ts
@@ -27,6 +27,10 @@ async function main(): Promise<void> {
   }
 
   const body = JSON.stringify(data);
+  // For PreToolUse, the server may hold the response while it waits for a window
+  // approval, so allow a long socket timeout (kept under Claude's 10-min hook cap).
+  // If the server replies with {"decision":"allow"|"deny"}, forward it to Claude.
+  const isPreToolUse = data.hook_event_name === 'PreToolUse';
   return new Promise((resolve) => {
     const req = http.request(
       {
@@ -39,9 +43,37 @@ async function main(): Promise<void> {
           'Content-Length': Buffer.byteLength(body),
           Authorization: `Bearer ${server.token}`,
         },
-        timeout: 2000,
+        timeout: isPreToolUse ? 595_000 : 2000,
       },
-      () => resolve(),
+      (res) => {
+        if (!isPreToolUse) {
+          // Drain and ignore the response for non-PreToolUse events.
+          res.resume();
+          res.on('end', () => resolve());
+          return;
+        }
+        let respBody = '';
+        res.on('data', (chunk) => (respBody += chunk));
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(respBody) as { decision?: string };
+            if (parsed.decision === 'allow' || parsed.decision === 'deny') {
+              process.stdout.write(
+                JSON.stringify({
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse',
+                    permissionDecision: parsed.decision,
+                    permissionDecisionReason: 'Decided from the Pixel Agents window',
+                  },
+                }),
+              );
+            }
+          } catch {
+            // Plain "ok" (no decision): let Claude handle permissions normally.
+          }
+          resolve();
+        });
+      },
     );
     req.on('error', () => resolve());
     req.on('timeout', () => {

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -135,6 +135,10 @@ function App() {
     transport.send({ type: 'closeAgent', id });
   }, []);
 
+  const handleSendMessage = useCallback((id: number, text: string) => {
+    transport.send({ type: 'sendAgentMessage', id, text });
+  }, []);
+
   const handleClick = useCallback((agentId: number) => {
     // If clicked agent is a sub-agent, focus the parent's terminal instead
     const os = getOfficeState();
@@ -250,6 +254,7 @@ function App() {
             zoom={editor.zoom}
             panRef={editor.panRef}
             onCloseAgent={handleCloseAgent}
+            onSendMessage={handleSendMessage}
             alwaysShowOverlay={alwaysShowOverlay}
           />
         </>

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -74,6 +74,10 @@ function App() {
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    approvalsFromWindow,
+    setApprovalsFromWindow,
+    pendingApprovals,
+    respondApproval,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -255,6 +259,8 @@ function App() {
             panRef={editor.panRef}
             onCloseAgent={handleCloseAgent}
             onSendMessage={handleSendMessage}
+            pendingApprovals={pendingApprovals}
+            onRespondApproval={respondApproval}
             alwaysShowOverlay={alwaysShowOverlay}
           />
         </>
@@ -368,6 +374,12 @@ function App() {
           const newVal = !hooksEnabled;
           setHooksEnabled(newVal);
           transport.send({ type: 'setHooksEnabled', enabled: newVal });
+        }}
+        approvalsFromWindow={approvalsFromWindow}
+        onToggleApprovalsFromWindow={() => {
+          const newVal = !approvalsFromWindow;
+          setApprovalsFromWindow(newVal);
+          transport.send({ type: 'setApprovalsFromWindow', enabled: newVal });
         }}
       />
 

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -19,6 +19,8 @@ interface SettingsModalProps {
   onToggleWatchAllSessions: () => void;
   hooksEnabled: boolean;
   onToggleHooksEnabled: () => void;
+  approvalsFromWindow: boolean;
+  onToggleApprovalsFromWindow: () => void;
 }
 
 export function SettingsModal({
@@ -33,6 +35,8 @@ export function SettingsModal({
   onToggleWatchAllSessions,
   hooksEnabled,
   onToggleHooksEnabled,
+  approvalsFromWindow,
+  onToggleApprovalsFromWindow,
 }: SettingsModalProps) {
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
 
@@ -107,6 +111,11 @@ export function SettingsModal({
         label="Instant Detection (Hooks)"
         checked={hooksEnabled}
         onChange={onToggleHooksEnabled}
+      />
+      <Checkbox
+        label="Approve Tools from Window"
+        checked={approvalsFromWindow}
+        onChange={onToggleApprovalsFromWindow}
       />
       <Checkbox
         label="Always Show Labels"

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -50,6 +50,13 @@ export interface WorkspaceFolder {
   path: string;
 }
 
+/** A tool-use awaiting the user's Allow/Deny decision in the window. */
+export interface ApprovalRequest {
+  approvalId: string;
+  toolName: string;
+  status: string;
+}
+
 interface ExtensionMessageState {
   agents: number[];
   selectedAgent: number | null;
@@ -70,6 +77,10 @@ interface ExtensionMessageState {
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
+  approvalsFromWindow: boolean;
+  setApprovalsFromWindow: (v: boolean) => void;
+  pendingApprovals: Record<number, ApprovalRequest>;
+  respondApproval: (agentId: number, approvalId: string, decision: 'allow' | 'deny') => void;
 }
 
 function saveAgentSeats(os: OfficeState): void {
@@ -107,6 +118,8 @@ export function useExtensionMessages(
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
+  const [approvalsFromWindow, setApprovalsFromWindow] = useState(false);
+  const [pendingApprovals, setPendingApprovals] = useState<Record<number, ApprovalRequest>>({});
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -473,6 +486,9 @@ export function useExtensionMessages(
         if (typeof msg.hooksInfoShown === 'boolean') {
           setHooksInfoShown(msg.hooksInfoShown as boolean);
         }
+        if (typeof msg.approvalsFromWindow === 'boolean') {
+          setApprovalsFromWindow(msg.approvalsFromWindow as boolean);
+        }
         if (Array.isArray(msg.externalAssetDirectories)) {
           setExternalAssetDirectories(msg.externalAssetDirectories as string[]);
         }
@@ -510,6 +526,25 @@ export function useExtensionMessages(
       } else if (msg.type === 'agentTokenUsage') {
         const id = msg.id as number;
         os.setAgentTokens(id, msg.inputTokens as number, msg.outputTokens as number);
+      } else if (msg.type === 'agentApprovalRequest') {
+        const id = msg.id as number;
+        setPendingApprovals((prev) => ({
+          ...prev,
+          [id]: {
+            approvalId: msg.approvalId as string,
+            toolName: msg.toolName as string,
+            status: msg.status as string,
+          },
+        }));
+      } else if (msg.type === 'agentApprovalResolved') {
+        const id = msg.id as number;
+        const approvalId = msg.approvalId as string;
+        setPendingApprovals((prev) => {
+          if (prev[id]?.approvalId !== approvalId) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
       }
     };
     const unsubscribe = transport.onMessage(handler);
@@ -538,5 +573,17 @@ export function useExtensionMessages(
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    approvalsFromWindow,
+    setApprovalsFromWindow,
+    pendingApprovals,
+    respondApproval: (agentId: number, approvalId: string, decision: 'allow' | 'deny') => {
+      transport.send({ type: 'respondApproval', approvalId, decision });
+      setPendingApprovals((prev) => {
+        if (prev[agentId]?.approvalId !== approvalId) return prev;
+        const next = { ...prev };
+        delete next[agentId];
+        return next;
+      });
+    },
   };
 }

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -18,7 +18,7 @@ import {
   TOKEN_WARN_THRESHOLD,
   TOOL_OVERLAY_VERTICAL_OFFSET,
 } from '../../constants.js';
-import type { SubagentCharacter } from '../../hooks/useExtensionMessages.js';
+import type { ApprovalRequest, SubagentCharacter } from '../../hooks/useExtensionMessages.js';
 import type { OfficeState } from '../engine/officeState.js';
 import type { ToolActivity } from '../types.js';
 import { CharacterState, TILE_SIZE } from '../types.js';
@@ -33,6 +33,8 @@ interface ToolOverlayProps {
   panRef: React.RefObject<{ x: number; y: number }>;
   onCloseAgent: (id: number) => void;
   onSendMessage: (id: number, text: string) => void;
+  pendingApprovals: Record<number, ApprovalRequest>;
+  onRespondApproval: (agentId: number, approvalId: string, decision: 'allow' | 'deny') => void;
   alwaysShowOverlay: boolean;
 }
 
@@ -134,6 +136,8 @@ export function ToolOverlay({
   panRef,
   onCloseAgent,
   onSendMessage,
+  pendingApprovals,
+  onRespondApproval,
   alwaysShowOverlay,
 }: ToolOverlayProps) {
   const [, setTick] = useState(0);
@@ -174,9 +178,11 @@ export function ToolOverlay({
         const isSelected = selectedId === id;
         const isHovered = hoveredId === id;
         const isSub = ch.isSubagent;
+        const approval = isSub ? undefined : pendingApprovals[id];
 
-        // Only show for hovered or selected agents (unless always-show is on)
-        if (!alwaysShowOverlay && !isSelected && !isHovered) return null;
+        // Show for hovered/selected agents (unless always-show is on), and always
+        // when an approval is pending so the user can act on it without hovering.
+        if (!alwaysShowOverlay && !isSelected && !isHovered && !approval) return null;
 
         // Position above character
         const sittingOffset = ch.state === CharacterState.TYPE ? CHARACTER_SITTING_OFFSET_PX : 0;
@@ -225,9 +231,14 @@ export function ToolOverlay({
             style={{
               left: screenX,
               top: screenY - (hasExtraLines ? 34 : 28),
-              pointerEvents: isSelected ? 'auto' : 'none',
-              opacity: alwaysShowOverlay && !isSelected && !isHovered ? (isSub ? 0.5 : 0.75) : 1,
-              zIndex: isSelected ? 42 : 41,
+              pointerEvents: isSelected || approval ? 'auto' : 'none',
+              opacity:
+                alwaysShowOverlay && !isSelected && !isHovered && !approval
+                  ? isSub
+                    ? 0.5
+                    : 0.75
+                  : 1,
+              zIndex: isSelected || approval ? 42 : 41,
             }}
           >
             <div className="flex items-center border-border px-8 pt-2 pb-4 gap-5 pixel-panel whitespace-nowrap max-w-2xs">
@@ -280,6 +291,44 @@ export function ToolOverlay({
                 </Button>
               )}
             </div>
+            {approval && (
+              <div
+                className="flex flex-col items-stretch gap-2 mt-2 px-6 py-3 pixel-panel"
+                style={{ pointerEvents: 'auto' }}
+                onClick={(e) => e.stopPropagation()}
+                onMouseDown={(e) => e.stopPropagation()}
+              >
+                <span className="leading-none" style={{ fontSize: '18px' }}>
+                  Approve {approval.toolName}?
+                </span>
+                <div className="flex items-center gap-3">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRespondApproval(id, approval.approvalId, 'allow');
+                    }}
+                    title={`Allow ${approval.status}`}
+                    className="leading-none"
+                  >
+                    ✓ Allow
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRespondApproval(id, approval.approvalId, 'deny');
+                    }}
+                    title={`Deny ${approval.status}`}
+                    className="leading-none"
+                  >
+                    ✗ Deny
+                  </Button>
+                </div>
+              </div>
+            )}
             {isSelected && !isSub && <AgentMessageBar agentId={id} onSendMessage={onSendMessage} />}
             {isTeamAgent && totalTokens > 0 && (
               <div

--- a/webview-ui/src/office/components/ToolOverlay.tsx
+++ b/webview-ui/src/office/components/ToolOverlay.tsx
@@ -32,7 +32,65 @@ interface ToolOverlayProps {
   zoom: number;
   panRef: React.RefObject<{ x: number; y: number }>;
   onCloseAgent: (id: number) => void;
+  onSendMessage: (id: number, text: string) => void;
   alwaysShowOverlay: boolean;
+}
+
+/**
+ * Text input shown under the selected agent's overlay. Sends a message/prompt
+ * to the agent's terminal (VS Code mode). Kept as its own component so its
+ * input state survives the parent's rAF re-renders.
+ */
+function AgentMessageBar({
+  agentId,
+  onSendMessage,
+}: {
+  agentId: number;
+  onSendMessage: (id: number, text: string) => void;
+}) {
+  const [text, setText] = useState('');
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onSendMessage(agentId, trimmed);
+    setText('');
+  };
+  return (
+    <div
+      className="flex items-center gap-3 mt-2 px-6 py-3 pixel-panel"
+      style={{ pointerEvents: 'auto' }}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="Message agent…"
+        className="bg-transparent outline-none text-white placeholder:opacity-50"
+        style={{ fontSize: '20px', width: 170 }}
+        autoFocus
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={(e) => {
+          e.stopPropagation();
+          submit();
+        }}
+        title="Send message"
+        className="shrink-0 leading-none"
+      >
+        ➤
+      </Button>
+    </div>
+  );
 }
 
 /** Derive a short human-readable activity string from tools/status */
@@ -75,6 +133,7 @@ export function ToolOverlay({
   zoom,
   panRef,
   onCloseAgent,
+  onSendMessage,
   alwaysShowOverlay,
 }: ToolOverlayProps) {
   const [, setTick] = useState(0);
@@ -221,6 +280,7 @@ export function ToolOverlay({
                 </Button>
               )}
             </div>
+            {isSelected && !isSub && <AgentMessageBar agentId={id} onSendMessage={onSendMessage} />}
             {isTeamAgent && totalTokens > 0 && (
               <div
                 style={{


### PR DESCRIPTION
## Summary

Two Windows portability fixes (the build was broken on Windows) plus two opt-in features for **interacting with agents from the office window** instead of only observing them.

### Fixes
- **`generate-messages` quote() cross-platform** — `quote()` wrapped the path in single quotes, which `cmd.exe` (used by `execSync` on Windows) does not strip, so the spawned prettier/eslint never found the file and `process.exit(1)` aborted the whole build. Now uses double quotes (works in POSIX shells and cmd.exe).
- **`copyHookScript` path in standalone CLI** — `cli.ts` passed `distRoot` (the `dist/` dir) to `copyHookScript()`, which appends `dist/hooks` itself, yielding `dist/dist/hooks`. The hook script was never copied to `~/.pixel-agents/hooks/`, leaving the global `settings.json` hooks pointing at a missing file. Now passes the package root.

### Features
- **Send messages/prompts to an agent from the window** — a text input under the selected agent's overlay writes to that agent's terminal (`terminal.sendText`) as if typed and submits it. VS Code mode only (the extension owns the terminal); no-op for external/standalone agents.
- **Approve tool use from the window (opt-in)** — new `Approve Tools from Window` setting. When enabled, a `PreToolUse` for a non-exempt tool blocks until the user clicks **Allow/Deny** on the agent's character; the decision is returned to Claude via the hook's `permissionDecision`. The server holds the hook response and resolves it on the window's decision (or times out after 9 min, under Claude's 10-min hook cap). Works in both standalone and VS Code modes.
  - Protocol additions: `AgentApprovalRequest`/`AgentApprovalResolved` (server→client), `RespondApproval`/`SetApprovalsFromWindow` (client→server), `approvalsFromWindow` in `SettingsLoaded`.

## Testing
- `npm run build` passes end-to-end on Windows.
- Server test suite: 200 pass (the 9 pre-existing failures in `fileStateAdapter`/`migrateVsCodeState` are unrelated — they mock `HOME`, which `os.homedir()` ignores on Windows in favour of `USERPROFILE`; identical on `main`).
- Approval flow verified end-to-end: the server held a `PreToolUse` until **Allow** was clicked in the real webview, then returned `{"decision":"allow"}` to the hook.

## Notes
- The approval mode is intentionally opt-in: `PreToolUse` fires for every tool, so when on, every non-exempt tool asks for approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
