### PR TITLE
feat: OpenAI Codex CLI support

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -41,4 +41,4 @@ fi
 echo "✅ No secrets detected"
 
 echo "🎨 Formatting staged files..."
-npm exec -- lint-staged
+./node_modules/.bin/lint-staged

--- a/.kiro/specs/codex-agent-support/.config.kiro
+++ b/.kiro/specs/codex-agent-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4b03dd92-845d-4c19-8e01-5e827cd4fe4d", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/codex-agent-support/design.md
+++ b/.kiro/specs/codex-agent-support/design.md
@@ -1,0 +1,566 @@
+# Design Document: Codex Agent Support
+
+## Overview
+
+This design adds OpenAI Codex CLI as a second `HookProvider` implementation in the Pixel Agents extension. The architecture follows the existing provider pattern established by the Claude provider, introducing a parallel `codex/` directory under `server/src/providers/hook/` and a configuration-driven provider selection mechanism.
+
+The design leverages the fact that Codex CLI exposes a hooks API with an identical contract model to Claude Code (JSON on stdin, events like `PreToolUse`, `PostToolUse`, `Stop`, `SessionStart`, etc.) — differing only in field naming conventions and session storage paths. This makes the `HookProvider` interface a natural fit without modification.
+
+**Key Design Decisions:**
+
+1. **No interface changes** — The existing `HookProvider` interface is sufficient. Codex's hook event model maps directly to the existing `AgentEvent` union type.
+2. **Configuration-driven selection** — A single VS Code setting (`pixel-agents.agentEngine`) selects the active provider. The `AgentRuntime` resolves the provider at activation time and re-injects on configuration change.
+3. **Hot-swap without reload** — The `setHookProvider` functions already exist on both `transcriptParser.ts` and `fileWatcher.ts`, enabling runtime provider replacement when configuration changes.
+4. **Convention over invention** — The Codex provider mirrors the Claude provider's file structure, naming, and export conventions for contributor familiarity.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "VS Code Extension"
+        Config["pixel-agents.agentEngine setting"]
+        Ext["Extension Activation"]
+    end
+
+    subgraph "Provider Registry"
+        Registry["server/src/providers/index.ts"]
+        Claude["claudeProvider"]
+        Codex["codexProvider"]
+    end
+
+    subgraph "Agent Runtime"
+        Runtime["AgentRuntime"]
+        TP["TranscriptParser"]
+        FW["FileWatcher"]
+        HEH["HookEventHandler"]
+    end
+
+    Config --> Ext
+    Ext -->|reads config| Runtime
+    Runtime -->|resolves provider| Registry
+    Registry --> Claude
+    Registry --> Codex
+    Runtime -->|setHookProvider| TP
+    Runtime -->|setHookProvider| FW
+    Runtime -->|provider| HEH
+
+    subgraph "Codex Provider"
+        CN["normalizeHookEvent()"]
+        CP["parseTranscriptLine()"]
+        CS["getSessionDirs()"]
+        CF["formatToolStatus()"]
+        CL["buildLaunchCommand()"]
+    end
+```
+
+### Provider Resolution Flow
+
+```mermaid
+sequenceDiagram
+    participant Ext as Extension
+    participant Config as VS Code Config
+    participant Runtime as AgentRuntime
+    participant Registry as Provider Registry
+    participant TP as TranscriptParser
+    participant FW as FileWatcher
+
+    Ext->>Config: Read pixel-agents.agentEngine
+    Config-->>Ext: "codex" | "claude-code"
+    Ext->>Registry: Lookup provider by id
+    Registry-->>Ext: HookProvider instance
+    Ext->>Runtime: new AgentRuntime(store, provider)
+    Runtime->>TP: setHookProvider(provider)
+    Runtime->>FW: setHookProvider(provider)
+
+    Note over Ext: On config change...
+    Config->>Ext: onDidChangeConfiguration
+    Ext->>Registry: Lookup new provider
+    Ext->>TP: setHookProvider(newProvider)
+    Ext->>FW: setHookProvider(newProvider)
+    Ext->>Runtime: Re-wire hookEventHandler
+```
+
+## Components and Interfaces
+
+### 1. Codex Provider (`server/src/providers/hook/codex/codex.ts`)
+
+The main provider module implementing the `HookProvider` interface:
+
+```typescript
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: 'codex',
+  displayName: 'Codex',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  permissionExemptTools: new Set([/* codex-specific exempt tools */]),
+  subagentToolNames: new Set([/* codex subagent tool names */]),
+  readingTools: new Set(['read_file', 'list_directory', 'web_search']),
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+
+  getSessionDirs,
+  getAllSessionRoots,
+  sessionFilePattern: '*.jsonl',
+  parseTranscriptLine,
+  buildLaunchCommand,
+  // No team provider (Codex doesn't have Agent Teams equivalent yet)
+  team: undefined,
+};
+```
+
+### 2. Codex Constants (`server/src/providers/hook/codex/constants.ts`)
+
+```typescript
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';
+export const CODEX_HOOK_EVENTS = [
+  'SessionStart',
+  'PreToolUse',
+  'PostToolUse',
+  'PermissionRequest',
+  'Stop',
+  'SubagentStart',
+  'SubagentStop',
+  'UserPromptSubmit',
+] as const;
+export const CODEX_SESSION_ROOT = '.codex/sessions';
+```
+
+### 3. Provider Registry (`server/src/providers/index.ts`)
+
+Updated to export both providers:
+
+```typescript
+export { claudeProvider } from './hook/claude/claude.js';
+export { codexProvider } from './hook/codex/codex.js';
+export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+```
+
+### 4. Configuration Setting (`package.json` contribution)
+
+```json
+{
+  "pixel-agents.agentEngine": {
+    "type": "string",
+    "enum": ["claude-code", "codex"],
+    "default": "claude-code",
+    "description": "Controls which AI coding assistant the extension monitors for agent activity."
+  }
+}
+```
+
+### 5. Extension Activation Changes
+
+The extension activation path reads the configuration value, resolves the provider, and registers a configuration change listener for hot-swapping:
+
+```typescript
+// Pseudocode for provider resolution
+function resolveProvider(engineValue: string): HookProvider {
+  switch (engineValue) {
+    case 'codex': return codexProvider;
+    case 'claude-code':
+    default: return claudeProvider;
+  }
+}
+```
+
+### Key Interface Mappings
+
+| Codex Hook Event | AgentEvent Kind | Notes |
+|---|---|---|
+| `PreToolUse` | `toolStart` | Uses `tool_use_id` as toolId, `tool_name` as toolName |
+| `PostToolUse` | `toolEnd` | Uses sentinel `"current"` toolId (same pattern as Claude) |
+| `Stop` | `turnEnd` | Turn completion signal |
+| `PermissionRequest` | `permissionRequest` | Permission prompt event |
+| `SessionStart` | `sessionStart` | Includes `transcript_path`, `cwd`, `source` |
+| `SessionEnd` | `sessionEnd` | Not a documented hook event; inferred from transcript |
+| `SubagentStart` | `subagentStart` | Uses `agent_type` as toolName |
+| `SubagentStop` | `subagentEnd` | Subagent completion |
+
+### Codex Tools Classification
+
+Based on Codex CLI's documented tool set:
+
+| Category | Tools |
+|---|---|
+| **Permission Exempt** | (none identified yet — Codex requires approval for most actions) |
+| **Subagent Tools** | (subagent spawning tools, if any) |
+| **Reading Tools** | File reading, directory listing, web search tools |
+| **Writing Tools** | `apply_patch`, `Bash` |
+
+### normalizeHookEvent Implementation
+
+The Codex hook sends JSON on stdin with these common fields: `session_id`, `hook_event_name`, `tool_name`, `tool_use_id`, `tool_input`, `transcript_path`, `cwd`, `model`.
+
+```typescript
+function normalizeHookEvent(
+  raw: Record<string, unknown>
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  switch (eventName) {
+    case 'PreToolUse': {
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : '';
+      const toolInput = (typeof raw.tool_input === 'object' && raw.tool_input !== null)
+        ? raw.tool_input as Record<string, unknown>
+        : {};
+      const toolUseId = typeof raw.tool_use_id === 'string'
+        ? raw.tool_use_id
+        : `hook-${Date.now()}`;
+      return {
+        sessionId,
+        event: { kind: 'toolStart', toolId: toolUseId, toolName, input: toolInput },
+      };
+    }
+    case 'PostToolUse':
+      return { sessionId, event: { kind: 'toolEnd', toolId: 'current' } };
+    case 'Stop':
+      return { sessionId, event: { kind: 'turnEnd' } };
+    case 'PermissionRequest':
+      return { sessionId, event: { kind: 'permissionRequest' } };
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: typeof raw.source === 'string' ? raw.source : undefined,
+          transcriptPath: typeof raw.transcript_path === 'string' ? raw.transcript_path : undefined,
+          cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+        },
+      };
+    case 'SubagentStart': {
+      const agentType = typeof raw.agent_type === 'string' ? raw.agent_type : 'unknown';
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: 'current',
+          toolId: `hook-sub-${agentType}-${Date.now()}`,
+          toolName: agentType,
+          input: raw,
+        },
+      };
+    }
+    case 'SubagentStop':
+      return { sessionId, event: { kind: 'subagentEnd', parentToolId: 'current', toolId: 'current' } };
+    case 'UserPromptSubmit':
+    default:
+      return null;
+  }
+}
+```
+
+### Session Directory Discovery
+
+Codex stores sessions at `~/.codex/sessions/YYYY/MM/DD/` as JSONL files. Unlike Claude (which organizes by project path), Codex uses a date-based hierarchy:
+
+```typescript
+function getSessionDirs(workspacePath: string): string[] {
+  // Codex sessions are stored globally under ~/.codex/sessions/
+  // organized by date. We return the sessions root since the file watcher
+  // will use sessionFilePattern to match *.jsonl recursively.
+  return [path.join(os.homedir(), '.codex', 'sessions')];
+}
+
+function getAllSessionRoots(): string[] {
+  return [path.join(os.homedir(), '.codex', 'sessions')];
+}
+```
+
+### formatToolStatus Implementation
+
+```typescript
+function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  const MAX_LEN = 80;
+  const truncate = (s: string) =>
+    s.length > MAX_LEN ? s.slice(0, MAX_LEN - 3) + '...' : s;
+
+  switch (toolName) {
+    case 'apply_patch':
+      return truncate('Editing file');
+    case 'Bash': {
+      const cmd = typeof inp.command === 'string' ? inp.command : '';
+      return truncate(`Running: ${cmd}`);
+    }
+    case 'read_file':
+      return truncate(`Reading ${typeof inp.path === 'string' ? path.basename(inp.path) : ''}`);
+    case 'list_directory':
+      return truncate('Listing directory');
+    case 'web_search':
+      return truncate('Searching the web');
+    default: {
+      // MCP tools: mcp__server__tool → "Using tool (server)"
+      if (toolName.startsWith('mcp__')) {
+        const parts = toolName.split('__');
+        const tool = parts[2] || toolName;
+        return truncate(`Using ${tool}`);
+      }
+      return truncate(`Using ${toolName}`);
+    }
+  }
+}
+```
+
+## Data Models
+
+### Codex Hook Event Payload (Input on stdin)
+
+All Codex hook events share these common fields:
+
+```typescript
+interface CodexHookPayload {
+  session_id: string;
+  hook_event_name: string;
+  transcript_path?: string | null;
+  cwd: string;
+  model?: string;
+  permission_mode?: string;
+}
+```
+
+Event-specific extensions:
+
+```typescript
+interface CodexPreToolUsePayload extends CodexHookPayload {
+  hook_event_name: 'PreToolUse';
+  tool_name: string;
+  tool_use_id: string;
+  tool_input: Record<string, unknown>;
+  turn_id?: string;
+}
+
+interface CodexPostToolUsePayload extends CodexHookPayload {
+  hook_event_name: 'PostToolUse';
+  tool_name: string;
+  tool_use_id: string;
+  tool_input: Record<string, unknown>;
+  tool_response?: unknown;
+  turn_id?: string;
+}
+
+interface CodexSessionStartPayload extends CodexHookPayload {
+  hook_event_name: 'SessionStart';
+  source: 'startup' | 'resume' | 'clear' | 'compact';
+}
+
+interface CodexStopPayload extends CodexHookPayload {
+  hook_event_name: 'Stop';
+  turn_id?: string;
+  stop_hook_active?: boolean;
+  last_assistant_message?: string | null;
+}
+
+interface CodexSubagentStartPayload extends CodexHookPayload {
+  hook_event_name: 'SubagentStart';
+  agent_id: string;
+  agent_type: string;
+  turn_id?: string;
+}
+
+interface CodexSubagentStopPayload extends CodexHookPayload {
+  hook_event_name: 'SubagentStop';
+  agent_id: string;
+  agent_type: string;
+  turn_id?: string;
+}
+```
+
+### Codex Transcript Line Format
+
+Codex JSONL transcript files use a structure similar to Claude's but with some differences. Each line is a JSON object representing a conversation turn or system event:
+
+```typescript
+// Assistant message with tool use
+interface CodexAssistantRecord {
+  type: 'assistant';
+  message: {
+    content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+    >;
+    usage?: { input_tokens: number; output_tokens: number };
+  };
+}
+
+// User message with tool results
+interface CodexUserRecord {
+  type: 'user';
+  message: {
+    content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'tool_result'; tool_use_id: string; content: unknown }
+    >;
+  };
+}
+
+// System record (turn boundaries, etc.)
+interface CodexSystemRecord {
+  type: 'system';
+  subtype?: 'turn_duration' | string;
+}
+```
+
+### Configuration Model
+
+```typescript
+// VS Code setting contribution
+interface AgentEngineConfig {
+  'pixel-agents.agentEngine': 'claude-code' | 'codex';
+}
+```
+
+### Provider Resolution Map
+
+```typescript
+const PROVIDER_MAP: Record<string, HookProvider> = {
+  'claude-code': claudeProvider,
+  'codex': codexProvider,
+};
+```
+
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Hook event normalization produces correct event kinds or null
+
+*For any* raw Codex hook event payload, if the payload contains both a string `session_id` and a string `hook_event_name` that matches a recognized Codex event name, then `normalizeHookEvent` SHALL return a non-null result with the correct `AgentEvent` kind corresponding to that event name. *For any* payload missing either field (or where either is not a string), or containing an unrecognized event name, the function SHALL return null without throwing.
+
+**Validates: Requirements 1.2, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6**
+
+### Property 2: formatToolStatus output never exceeds 80 characters
+
+*For any* tool name string and any input object (regardless of the string lengths of values within), `formatToolStatus` SHALL return a string whose length is at most 80 characters. When truncation occurs, the result ends with '...' and the total length is exactly 80 characters.
+
+**Validates: Requirements 1.3**
+
+### Property 3: Transcript line parsing round-trip correctness
+
+*For any* valid Codex transcript JSON line containing assistant `tool_use` blocks, `parseTranscriptLine` SHALL return a `toolStart` AgentEvent for each block with a unique `toolId` matching the block's `id`, the block's `name` as `toolName`, and the block's `input` as `input`. *For any* valid transcript JSON line containing user `tool_result` blocks, it SHALL return a `toolEnd` AgentEvent with `toolId` equal to the `tool_use_id`. *For any* string that is not valid JSON or contains an unrecognized record type, `parseTranscriptLine` SHALL return null without throwing an exception.
+
+**Validates: Requirements 1.7, 5.1, 5.2, 5.6, 5.7, 5.8**
+
+### Property 4: Provider resolution always returns a valid HookProvider
+
+*For any* string value passed to the provider resolution function, it SHALL always return a valid `HookProvider` instance (never null/undefined). When the value is "codex", it returns `codexProvider`. When the value is "claude-code", it returns `claudeProvider`. *For any* other string value, it returns `claudeProvider` as a fallback.
+
+**Validates: Requirements 3.4, 3.5, 3.7, 4.4**
+
+### Property 5: buildLaunchCommand structure correctness
+
+*For any* session ID string and cwd string, `buildLaunchCommand` SHALL return an object with a non-empty `command` string and an `args` array containing the session ID. When `bypassPermissions` is true, the args array SHALL contain the bypass flag. When `bypassPermissions` is false or undefined, the bypass flag SHALL NOT appear in args.
+
+**Validates: Requirements 1.6**
+
+### Property 6: getSessionDirs returns a well-formed path for any workspace
+
+*For any* workspace path string (including empty string, paths with special characters, and non-existent paths), `getSessionDirs` SHALL return a non-empty array containing at least one path string under the user's home directory without throwing an exception.
+
+**Validates: Requirements 1.5, 2.1, 2.5**
+
+## Error Handling
+
+### Hook Event Normalization Errors
+
+| Scenario | Behavior |
+|---|---|
+| Missing `session_id` or `hook_event_name` | Return `null` silently |
+| Non-string `session_id` or `hook_event_name` | Return `null` silently |
+| Unrecognized event name | Return `null` silently |
+| Missing optional fields (`tool_name`, `tool_input`) | Use defaults (empty string, empty object) |
+
+### Transcript Parsing Errors
+
+| Scenario | Behavior |
+|---|---|
+| Malformed JSON line | Return `null`, log at debug level |
+| Unrecognized record type | Return `null`, log at debug level |
+| Missing `message.content` field | Return `null` silently |
+| Tool_use block missing `id` or `name` | Skip the block, continue processing others |
+
+### Session Directory Errors
+
+| Scenario | Behavior |
+|---|---|
+| Session directory doesn't exist | Return expected path in array (caller tolerates missing dirs) |
+| Permission denied reading directory | File watcher skips directory, logs warning, no unhandled error |
+| Invalid workspace path | Return a best-effort computed path without throwing |
+
+### Configuration Errors
+
+| Scenario | Behavior |
+|---|---|
+| Invalid `agentEngine` value | Fall back to `claudeProvider`, log warning with the invalid value |
+| Configuration read failure | Fall back to `claudeProvider` |
+
+### Hook Installation Errors
+
+| Scenario | Behavior |
+|---|---|
+| `~/.codex` directory doesn't exist | Create it, or report installation failure gracefully |
+| `hooks.json` is malformed | Log error, report hooks not installed |
+| Write permission denied | Report installation failure with descriptive message |
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+Unit tests verify specific examples and edge cases using the existing Vitest setup in `server/`:
+
+- **Provider identity**: Verify `codexProvider` has correct `kind`, `id`, `displayName`, `protocolVersion`
+- **Tool classifications**: Verify `permissionExemptTools`, `subagentToolNames`, `readingTools` contain expected values
+- **normalizeHookEvent examples**: Test each recognized event type with realistic payloads
+- **formatToolStatus examples**: Test each known tool name with realistic inputs
+- **parseTranscriptLine examples**: Test specific transcript line formats
+- **buildLaunchCommand examples**: Test with/without bypass permissions
+- **getSessionDirs examples**: Test with typical workspace paths
+- **Provider registry**: Verify both providers are exported from index.ts
+- **Configuration resolution**: Test the provider resolution function with valid and invalid values
+
+### Property-Based Tests (fast-check + Vitest)
+
+Property-based tests verify universal invariants across randomly generated inputs. Each test runs a minimum of 100 iterations.
+
+- **Library**: `fast-check` (standard PBT library for TypeScript/Vitest projects)
+- **Location**: `server/__tests__/codex.property.test.ts`
+- **Configuration**: `fc.assert(fc.property(...), { numRuns: 100 })`
+
+Tests correspond to the Correctness Properties above:
+
+1. **Hook event normalization** — Generate random payloads with varying field presence/types, verify correct AgentEvent kind mapping or null return
+2. **formatToolStatus length** — Generate random tool names (including very long strings) and input objects with long values, verify output ≤ 80 chars
+3. **Transcript parsing** — Generate random valid/invalid JSON lines, verify correct event extraction or null return without exceptions
+4. **Provider resolution** — Generate random strings, verify always returns a valid HookProvider (codexProvider for "codex", claudeProvider otherwise)
+5. **buildLaunchCommand** — Generate random sessionIds, cwds, and boolean bypass flags, verify structure invariants
+6. **getSessionDirs** — Generate random path strings, verify non-empty array return without throwing
+
+Each property test is tagged:
+```typescript
+// Feature: codex-agent-support, Property 1: Hook event normalization produces correct event kinds or null
+```
+
+### Integration Tests
+
+Integration tests verify cross-component behavior:
+
+- **Hot-swap**: Simulate configuration change and verify provider re-injection
+- **File detection**: Verify file watcher detects new JSONL files in Codex session directories
+- **End-to-end hook flow**: POST a hook event to the HTTP server and verify the agent state updates
+
+### Test File Structure
+
+```
+server/__tests__/
+  codex.test.ts              # Unit tests (mirrors claude.test.ts)
+  codex.property.test.ts     # Property-based tests
+```

--- a/.kiro/specs/codex-agent-support/requirements.md
+++ b/.kiro/specs/codex-agent-support/requirements.md
@@ -1,0 +1,114 @@
+# Requirements Document
+
+## Introduction
+
+This feature extends the Pixel Agents VS Code extension to support OpenAI's Codex CLI as an AI agent provider alongside the existing Claude Code integration. The extension currently uses the `HookProvider` interface in its core architecture, with a single Claude Code implementation. This feature adds a Codex provider implementation, a configuration option for agent selection, and dynamic provider injection at startup so users can choose which AI agent engine drives their pixel office visualization.
+
+## Glossary
+
+- **Extension**: The Pixel Agents VS Code extension that visualizes AI agent activity as pixel art characters
+- **Provider_Registry**: The module (`server/src/providers/index.ts`) that exports all bundled HookProvider implementations
+- **HookProvider**: The interface defined in `core/src/provider.ts` that normalizes CLI-specific events into standard AgentEvent types
+- **Codex_Provider**: The new HookProvider implementation for OpenAI's Codex CLI agent
+- **Claude_Provider**: The existing HookProvider implementation for Anthropic's Claude Code CLI agent
+- **Agent_Runtime**: The server module (`server/src/agentRuntime.ts`) that bootstraps agent detection and event processing
+- **Transcript_Parser**: The module (`server/src/transcriptParser.ts`) that processes JSONL log lines into agent activity events
+- **File_Watcher**: The module (`server/src/fileWatcher.ts`) that detects and monitors agent session files
+- **AgentEvent**: The normalized event union type produced by all providers (toolStart, toolEnd, turnEnd, sessionStart, etc.)
+- **Configuration_Setting**: A VS Code `contributes.configuration` property that users can set via the Settings UI or settings.json
+- **Session_Directory**: The filesystem path where an AI agent stores its session transcript files
+- **Codex_Log**: The log/transcript file produced by the Codex CLI during execution
+
+## Requirements
+
+### Requirement 1: Codex Provider Implementation
+
+**User Story:** As a developer using OpenAI Codex CLI, I want Pixel Agents to visualize my Codex sessions as animated characters, so that I can monitor Codex agent activity in the same way Claude Code users do.
+
+#### Acceptance Criteria
+
+1. THE Codex_Provider SHALL implement the HookProvider interface defined in `core/src/provider.ts`, exposing `kind: 'hook'`, a unique `id`, `displayName`, and `protocolVersion` fields
+2. THE Codex_Provider SHALL normalize raw Codex hook event payloads into standard AgentEvent types (toolStart, toolEnd, turnEnd, sessionStart, sessionEnd, permissionRequest) and return null for event types that have no corresponding AgentEvent mapping
+3. THE Codex_Provider SHALL provide a `formatToolStatus` method that accepts a tool name and optional input, and returns a status string of the form "[Action verb] [target]" (e.g. "Reading foo.ts", "Running: ls") with a maximum total length of 80 characters including the ellipsis, truncating the content to 77 characters plus '...' when the full string would exceed 80 characters
+4. THE Codex_Provider SHALL define `permissionExemptTools` containing tools that do not require user confirmation, `subagentToolNames` containing tools that spawn child agent processes, and `readingTools` containing tools that perform read-only operations, each populated according to the Codex CLI's documented tool set
+5. THE Codex_Provider SHALL provide a `getSessionDirs` method that returns an array containing the filesystem path where Codex CLI stores session transcript files for the given workspace path, following the Codex CLI's transcript storage convention under the user's home directory
+6. THE Codex_Provider SHALL provide a `buildLaunchCommand` method that returns an object containing the `command` string set to the Codex CLI executable name, an `args` array including the session ID, and an optional `env` record, accepting a `bypassPermissions` option that appends the appropriate Codex CLI flag when true
+7. WHEN a Codex transcript line is received, THE Codex_Provider SHALL parse it via `parseTranscriptLine` and return the corresponding AgentEvent if the line represents a tool invocation, tool completion, turn completion, session lifecycle, or permission request, or return null if the line represents assistant text output or other non-actionable content
+
+### Requirement 2: Codex Session Directory Discovery
+
+**User Story:** As a developer using Codex CLI, I want the extension to automatically detect my active Codex sessions, so that agents appear in the pixel office without manual configuration.
+
+#### Acceptance Criteria
+
+1. THE Codex_Provider SHALL implement `getSessionDirs(workspacePath)` that returns an array containing the Codex CLI session transcript directory path derived from the given workspace path, following the same home-directory-relative convention used by the Codex CLI for storing session logs
+2. THE Codex_Provider SHALL define `sessionFilePattern` as a glob string that matches only Codex transcript files within the Session_Directory (e.g., `*.jsonl`)
+3. THE Codex_Provider SHALL implement `getAllSessionRoots()` that returns an array containing the single root directory under which all Codex session subdirectories reside, enabling global session discovery across workspaces
+4. WHEN a new file matching `sessionFilePattern` appears in a directory returned by `getSessionDirs`, THE File_Watcher SHALL detect the file within 5 seconds and create a corresponding agent character in the pixel office
+5. IF the Codex CLI session directory does not exist on disk, THEN THE Codex_Provider `getSessionDirs` method SHALL return the expected path string in the array without throwing an error, allowing the File_Watcher to begin monitoring once the directory is created
+6. IF the Session_Directory exists but cannot be read due to filesystem permissions, THEN THE File_Watcher SHALL skip that directory without throwing an unhandled error, SHALL log the permission error internally at warning level, and SHALL NOT create agent characters for that directory
+
+### Requirement 3: Agent Engine Configuration Setting
+
+**User Story:** As a user of Pixel Agents, I want to select which AI agent engine the extension monitors, so that I can use the extension with my preferred AI coding assistant.
+
+#### Acceptance Criteria
+
+1. THE Extension SHALL register a Configuration_Setting named `pixel-agents.agentEngine` with type `string` and enum values limited to "claude-code" and "codex", within the existing `contributes.configuration` section of `package.json`
+2. THE Configuration_Setting SHALL default to "claude-code" so that existing users experience no change in behavior upon upgrade
+3. THE Configuration_Setting SHALL include a description property explaining that it controls which AI coding assistant the extension monitors for agent activity
+4. WHEN the Configuration_Setting value is "codex", THE Agent_Runtime SHALL inject the Codex_Provider as the active HookProvider used for session detection, event normalization, and terminal launch
+5. WHEN the Configuration_Setting value is "claude-code", THE Agent_Runtime SHALL inject the Claude_Provider as the active HookProvider used for session detection, event normalization, and terminal launch
+6. WHEN the user changes the Configuration_Setting value, THE Extension SHALL apply the new provider immediately regardless of the extension's current activation state, without requiring a manual reinstall or reload
+7. IF the Configuration_Setting value does not match any registered provider enum value, THEN THE Agent_Runtime SHALL fall back to the Claude_Provider and log a warning message identifying the invalid value
+
+### Requirement 4: Dynamic Provider Injection
+
+**User Story:** As a developer, I want the extension to use the correct provider based on my configuration, so that the agent detection, event parsing, and session management all operate against the selected engine.
+
+#### Acceptance Criteria
+
+1. WHEN the extension activates, THE Agent_Runtime SHALL read the `pixel-agents.agentEngine` configuration value, resolve it to a registered HookProvider by matching the value against provider IDs in the Provider_Registry, and pass the selected HookProvider to the Transcript_Parser via `setHookProvider`
+2. WHEN the extension activates, THE Agent_Runtime SHALL pass the selected HookProvider to the File_Watcher via `setHookProvider`
+3. THE Provider_Registry SHALL export the Codex_Provider alongside the existing Claude_Provider so that both are available for resolution by configuration value
+4. IF the configured agent engine value does not match any registered provider ID, THEN THE Agent_Runtime SHALL fall back to the Claude_Provider and log a warning message to the console indicating the unrecognized configuration value that was provided
+5. WHEN the `pixel-agents.agentEngine` configuration value changes at runtime, THE Extension SHALL immediately re-resolve the provider from the Provider_Registry and re-inject it into the Transcript_Parser and File_Watcher without requiring a reload
+
+### Requirement 5: Codex Transcript Parsing
+
+**User Story:** As a Codex CLI user, I want the extension to parse Codex transcript files accurately, so that tool usage, turn boundaries, and session lifecycle are correctly reflected in the pixel office.
+
+#### Acceptance Criteria
+
+1. WHEN a Codex transcript line contains an assistant message with one or more tool_use blocks, THE Codex_Provider SHALL emit a toolStart AgentEvent for each tool_use block, including the block's id as toolId, the block's name as toolName, and the block's input object as input
+2. WHEN a Codex transcript line contains a user message with one or more tool_result blocks, THE Codex_Provider SHALL emit a toolEnd AgentEvent for each tool_result block, with toolId set to the corresponding tool_use_id
+3. WHEN a Codex transcript line contains a system record indicating a turn boundary (e.g., turn_duration subtype), THE Codex_Provider SHALL emit a turnEnd AgentEvent
+4. WHEN a Codex transcript line contains a record indicating that a session has started, THE Codex_Provider SHALL emit a sessionStart AgentEvent with transcriptPath set to the session file path if available, and cwd set to the working directory if available
+5. WHEN a Codex transcript line contains a record indicating that a session has ended, THE Codex_Provider SHALL emit a sessionEnd AgentEvent with the reason field set to the termination reason if provided in the record
+6. IF a Codex transcript line cannot be parsed as valid JSON or contains an unrecognized record type, THEN THE Codex_Provider SHALL return null without throwing an exception and SHALL log the parsing failure at debug level for diagnostic purposes
+7. THE Codex_Provider SHALL implement the parseTranscriptLine method conforming to the HookProvider interface signature, accepting a single line string and returning either an AgentEvent or null
+8. WHEN a Codex transcript line contains an assistant message with tool_use blocks, THE Codex_Provider SHALL set the toolStart event's toolId to a value that uniquely identifies the tool invocation within the session, enabling correlation with the subsequent toolEnd event
+
+### Requirement 6: Codex Hook Event Normalization
+
+**User Story:** As a Codex CLI user with hooks enabled, I want real-time hook events from Codex to be normalized into the standard event format, so that the extension responds instantly to agent activity.
+
+#### Acceptance Criteria
+
+1. WHEN a raw Codex hook event payload is received, THE Codex_Provider SHALL extract the session ID as a string and event type as a string from the payload and return an object containing the sessionId and the corresponding AgentEvent
+2. IF the raw hook event payload is missing required fields (session ID or event type) or either field is not a string, THEN THE Codex_Provider SHALL return null without throwing an error
+3. WHEN the extracted event type maps to a tool-use start event, THE Codex_Provider SHALL produce a toolStart AgentEvent that includes a generated toolId, the tool name extracted from the payload (defaulting to an empty string if absent), and the tool input extracted from the payload (defaulting to an empty object if absent)
+4. WHEN the extracted event type maps to a tool-use completion event, THE Codex_Provider SHALL produce a toolEnd AgentEvent with a sentinel toolId value of "current"
+5. WHEN the extracted event type maps to a session lifecycle event, THE Codex_Provider SHALL produce the corresponding sessionStart or sessionEnd AgentEvent, including optional metadata fields (source, cwd, reason) when present in the payload as strings
+6. IF the extracted event type does not match any recognized Codex event name, THEN THE Codex_Provider SHALL return null without throwing an error
+
+### Requirement 7: Provider File Structure Convention
+
+**User Story:** As a contributor to Pixel Agents, I want the Codex provider to follow the same directory and file conventions as the Claude provider, so that the codebase remains consistent and maintainable.
+
+#### Acceptance Criteria
+
+1. THE Codex_Provider source files SHALL reside in `server/src/providers/hook/codex/`
+2. THE Codex_Provider main module SHALL be a file named `codex.ts` that implements the `HookProvider` interface and exports the provider instance as `codexProvider`
+3. THE Codex_Provider SHALL have a file named `constants.ts` that exports Codex-specific constants including at minimum a terminal name prefix string constant
+4. THE Provider_Registry in `server/src/providers/index.ts` SHALL export `codexProvider` from the path `./hook/codex/codex.js`

--- a/.kiro/specs/codex-agent-support/tasks.md
+++ b/.kiro/specs/codex-agent-support/tasks.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Codex Agent Support
+
+## Overview
+
+This plan covers the remaining implementation work for the Codex agent support feature. The Codex provider (`server/src/providers/hook/codex/codex.ts`), constants, hook installer, provider registry, configuration setting, and basic unit tests are already in place. The remaining tasks focus on installing the property-based testing library, writing property tests for the correctness properties defined in the design, and verifying the integration of all components end-to-end.
+
+## Tasks
+
+- [ ] 1. Install fast-check and set up property test infrastructure
+  - [ ] 1.1 Add fast-check dependency to server/package.json
+    - Run `npm install --save-dev fast-check` in the `server/` directory
+    - Verify that `fast-check` is added to `devDependencies` in `server/package.json`
+    - _Requirements: Design Testing Strategy_
+
+- [ ] 2. Write property-based tests for Codex provider
+  - [ ] 2.1 Create property test file and implement Property 1: Hook event normalization
+    - Create `server/__tests__/codex.property.test.ts`
+    - Generate random payloads with varying field presence/types using fast-check arbitraries
+    - Verify: valid payloads with recognized event names produce correct AgentEvent kinds; payloads missing `session_id` or `hook_event_name` return null; unrecognized event names return null; no exceptions thrown
+    - Use `fc.assert(fc.property(...), { numRuns: 100 })` configuration
+    - **Property 1: Hook event normalization produces correct event kinds or null**
+    - **Validates: Requirements 1.2, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6**
+
+  - [ ]* 2.2 Write property test for Property 2: formatToolStatus length invariant
+    - Generate random tool name strings (including very long strings) and input objects with arbitrarily long string values
+    - Verify: output length is always ≤ 80 characters; when truncation occurs, result ends with '…' (ellipsis character)
+    - **Property 2: formatToolStatus output never exceeds 80 characters**
+    - **Validates: Requirements 1.3**
+
+  - [ ]* 2.3 Write property test for Property 3: Transcript line parsing
+    - Generate random valid Codex transcript JSON lines (function_call, function_call_output, session_meta, event_msg records) and invalid lines (malformed JSON, unrecognized types)
+    - Verify: function_call records produce toolStart with correct toolId/toolName; function_call_output records produce toolEnd; invalid lines return null without throwing
+    - **Property 3: Transcript line parsing round-trip correctness**
+    - **Validates: Requirements 1.7, 5.1, 5.2, 5.6, 5.7, 5.8**
+
+  - [ ]* 2.4 Write property test for Property 4: Provider resolution always returns valid HookProvider
+    - Generate random strings as engine identifiers
+    - Verify: always returns a valid HookProvider (never null/undefined); "codex" → codexProvider; "claude-code" → claudeProvider; any other value → claudeProvider
+    - **Property 4: Provider resolution always returns a valid HookProvider**
+    - **Validates: Requirements 3.4, 3.5, 3.7, 4.4**
+
+  - [ ]* 2.5 Write property test for Property 5: buildLaunchCommand structure
+    - Generate random sessionId strings, cwd strings, and boolean bypassPermissions values
+    - Verify: always returns an object with non-empty `command` string; when bypassPermissions is true, args contains the bypass flag; when false/undefined, bypass flag is absent
+    - **Property 5: buildLaunchCommand structure correctness**
+    - **Validates: Requirements 1.6**
+
+  - [ ]* 2.6 Write property test for Property 6: getSessionDirs returns well-formed paths
+    - Generate random workspace path strings (including empty, special characters, non-existent paths)
+    - Verify: always returns a non-empty array; each element is a string; paths are under the home directory; no exceptions thrown
+    - **Property 6: getSessionDirs returns a well-formed path for any workspace**
+    - **Validates: Requirements 1.5, 2.1, 2.5**
+
+- [ ] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Verify dynamic provider injection and hot-swap integration
+  - [ ] 4.1 Add integration test for provider hot-swap via configuration change
+    - Create or extend `server/__tests__/codex.test.ts` with a test that verifies calling `resolveProvider` with different engine values correctly swaps providers
+    - Verify that the `AgentRuntime.configureProvider` method calls `setHookProvider` on both `transcriptParser` and `fileWatcher` modules
+    - Verify fallback behavior: invalid engine values resolve to claudeProvider with a console warning
+    - _Requirements: 3.6, 3.7, 4.1, 4.2, 4.4, 4.5_
+
+  - [ ]* 4.2 Write integration test for end-to-end hook event flow
+    - Simulate posting a Codex hook event payload and verify it normalizes correctly through the provider into the expected AgentEvent
+    - Verify that the file watcher's `sessionFilePattern` matches Codex JSONL files
+    - _Requirements: 2.2, 2.4, 6.1_
+
+- [ ] 5. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests in `server/__tests__/codex.test.ts` already cover identity, session paths, normalizeHookEvent examples, parseTranscriptLine examples, and formatToolStatus examples
+- The Codex provider implementation (`server/src/providers/hook/codex/codex.ts`), constants, hook installer, and provider registry are already complete
+- fast-check is the standard PBT library for TypeScript/Vitest projects
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3", "2.4", "2.5", "2.6"] },
+    { "id": 3, "tasks": ["4.1"] },
+    { "id": 4, "tasks": ["4.2"] }
+  ]
+}
+```

--- a/.kiro/specs/codex-agent-support/tasks.md
+++ b/.kiro/specs/codex-agent-support/tasks.md
@@ -6,14 +6,14 @@ This plan covers the remaining implementation work for the Codex agent support f
 
 ## Tasks
 
-- [ ] 1. Install fast-check and set up property test infrastructure
-  - [ ] 1.1 Add fast-check dependency to server/package.json
+- [x] 1. Install fast-check and set up property test infrastructure
+  - [x] 1.1 Add fast-check dependency to server/package.json
     - Run `npm install --save-dev fast-check` in the `server/` directory
     - Verify that `fast-check` is added to `devDependencies` in `server/package.json`
     - _Requirements: Design Testing Strategy_
 
-- [ ] 2. Write property-based tests for Codex provider
-  - [ ] 2.1 Create property test file and implement Property 1: Hook event normalization
+- [x] 2. Write property-based tests for Codex provider
+  - [x] 2.1 Create property test file and implement Property 1: Hook event normalization
     - Create `server/__tests__/codex.property.test.ts`
     - Generate random payloads with varying field presence/types using fast-check arbitraries
     - Verify: valid payloads with recognized event names produce correct AgentEvent kinds; payloads missing `session_id` or `hook_event_name` return null; unrecognized event names return null; no exceptions thrown
@@ -21,47 +21,47 @@ This plan covers the remaining implementation work for the Codex agent support f
     - **Property 1: Hook event normalization produces correct event kinds or null**
     - **Validates: Requirements 1.2, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6**
 
-  - [ ]* 2.2 Write property test for Property 2: formatToolStatus length invariant
+  - [x]\* 2.2 Write property test for Property 2: formatToolStatus length invariant
     - Generate random tool name strings (including very long strings) and input objects with arbitrarily long string values
     - Verify: output length is always ≤ 80 characters; when truncation occurs, result ends with '…' (ellipsis character)
     - **Property 2: formatToolStatus output never exceeds 80 characters**
     - **Validates: Requirements 1.3**
 
-  - [ ]* 2.3 Write property test for Property 3: Transcript line parsing
+  - [x]\* 2.3 Write property test for Property 3: Transcript line parsing
     - Generate random valid Codex transcript JSON lines (function_call, function_call_output, session_meta, event_msg records) and invalid lines (malformed JSON, unrecognized types)
     - Verify: function_call records produce toolStart with correct toolId/toolName; function_call_output records produce toolEnd; invalid lines return null without throwing
     - **Property 3: Transcript line parsing round-trip correctness**
     - **Validates: Requirements 1.7, 5.1, 5.2, 5.6, 5.7, 5.8**
 
-  - [ ]* 2.4 Write property test for Property 4: Provider resolution always returns valid HookProvider
+  - [x]\* 2.4 Write property test for Property 4: Provider resolution always returns valid HookProvider
     - Generate random strings as engine identifiers
     - Verify: always returns a valid HookProvider (never null/undefined); "codex" → codexProvider; "claude-code" → claudeProvider; any other value → claudeProvider
     - **Property 4: Provider resolution always returns a valid HookProvider**
     - **Validates: Requirements 3.4, 3.5, 3.7, 4.4**
 
-  - [ ]* 2.5 Write property test for Property 5: buildLaunchCommand structure
+  - [x]\* 2.5 Write property test for Property 5: buildLaunchCommand structure
     - Generate random sessionId strings, cwd strings, and boolean bypassPermissions values
     - Verify: always returns an object with non-empty `command` string; when bypassPermissions is true, args contains the bypass flag; when false/undefined, bypass flag is absent
     - **Property 5: buildLaunchCommand structure correctness**
     - **Validates: Requirements 1.6**
 
-  - [ ]* 2.6 Write property test for Property 6: getSessionDirs returns well-formed paths
+  - [x]\* 2.6 Write property test for Property 6: getSessionDirs returns well-formed paths
     - Generate random workspace path strings (including empty, special characters, non-existent paths)
     - Verify: always returns a non-empty array; each element is a string; paths are under the home directory; no exceptions thrown
     - **Property 6: getSessionDirs returns a well-formed path for any workspace**
     - **Validates: Requirements 1.5, 2.1, 2.5**
 
-- [ ] 3. Checkpoint - Ensure all tests pass
+- [x] 3. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 4. Verify dynamic provider injection and hot-swap integration
-  - [ ] 4.1 Add integration test for provider hot-swap via configuration change
+- [x] 4. Verify dynamic provider injection and hot-swap integration
+  - [x] 4.1 Add integration test for provider hot-swap via configuration change
     - Create or extend `server/__tests__/codex.test.ts` with a test that verifies calling `resolveProvider` with different engine values correctly swaps providers
     - Verify that the `AgentRuntime.configureProvider` method calls `setHookProvider` on both `transcriptParser` and `fileWatcher` modules
     - Verify fallback behavior: invalid engine values resolve to claudeProvider with a console warning
     - _Requirements: 3.6, 3.7, 4.1, 4.2, 4.4, 4.5_
 
-  - [ ]* 4.2 Write integration test for end-to-end hook event flow
+  - [x]\* 4.2 Write integration test for end-to-end hook event flow
     - Simulate posting a Codex hook event payload and verify it normalizes correctly through the provider into the expected AgentEvent
     - Verify that the file watcher's `sessionFilePattern` matches Codex JSONL files
     - _Requirements: 2.2, 2.4, 6.1_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.4.0
+
+### Features
+
+- **OpenAI Codex CLI support** — Adds Codex as a second `HookProvider` alongside Claude Code. Select the active engine via `pixel-agents.agentEngine` (`claude-code` or `codex`) in VS Code settings or the Settings modal. Includes Codex hook installer (`~/.codex/hooks.json`), transcript parsing for Codex JSONL format, and hot-swap when the setting changes without reloading the extension.
+- **Agent engine picker in Settings modal** — Switch between Claude Code and Codex from the in-panel Settings UI.
+
+### Fixes
+
+- **Codex session binding** — Launched Codex terminals rebind to real `rollout-*.jsonl` transcript files on `SessionStart` hook events, with correct hook session routing when the CLI-assigned session ID differs from the placeholder used at spawn time.
+
 ## v1.3.0
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Pixel Agents — Compressed Reference
 
-VS Code extension with embedded React webview: pixel art office where AI agents (Claude Code terminals) are animated characters.
+VS Code extension with embedded React webview: pixel art office where AI coding agents (Claude Code or Codex CLI terminals) are animated characters.
 
 ## Architecture
 
@@ -23,9 +23,9 @@ server/                       — Standalone server (Node.js, no VS Code deps ex
     server.ts                 — HTTP server: hook endpoint, health check, server.json discovery
     hookEventHandler.ts       — Routes hook events to agents, buffers pre-registration events
     constants.ts              — All timing/scanning constants (shared by extension + server)
-    providers/file/
-      claudeHookInstaller.ts  — Install/uninstall hooks in ~/.claude/settings.json
-      hooks/claude-hook.ts    — Hook script: reads stdin, POSTs to server (bundled to CJS by esbuild)
+    providers/hook/
+      claude/                 — Claude Code HookProvider + claudeHookInstaller + claude-hook.ts
+      codex/                  — Codex CLI HookProvider + codexHookInstaller + codex-hook.ts
   __tests__/                  — Vitest test suite
     server.test.ts            — HTTP server lifecycle, auth, hooks, server.json
     hookEventHandler.test.ts  — Event routing, buffering, timer cancellation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Pixel Agents turns multi-agent AI systems into something you can actually see and manage. Each agent becomes a character in a pixel art office. They walk around, sit at their desk, and visually reflect what they are doing — typing when writing code, reading when searching files, waiting when it needs your attention.
 
-Right now it works as a VS Code extension with Claude Code. The vision though, is a fully agent-agnostic, platform-agnostic interface for orchestrating any AI agents, deployable anywhere.
+Right now it works as a VS Code extension with **Claude Code** and **OpenAI Codex CLI**. The vision though, is a fully agent-agnostic, platform-agnostic interface for orchestrating any AI agents, deployable anywhere.
 
 This is the source code for the free Pixel Agents extension for VS Code — install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) or [Open VSX](https://open-vsx.org/extension/pablodelucca/pixel-agents) with the full furniture catalog included.
 
@@ -34,7 +34,8 @@ This is the source code for the free Pixel Agents extension for VS Code — inst
 
 ## Features
 
-- **One agent, one character** — every Claude Code terminal gets its own animated character
+- **One agent, one character** — every coding-agent terminal gets its own animated character
+- **Multi-engine support** — choose Claude Code or Codex via `pixel-agents.agentEngine` (Settings → Agent Engine)
 - **Live activity tracking** — characters animate based on what the agent is actually doing (writing, reading, running commands)
 - **Office layout editor** — design your office with floors, walls, and furniture using a built-in editor
 - **Speech bubbles** — visual indicators when an agent is waiting for input or needs permission
@@ -51,7 +52,9 @@ This is the source code for the free Pixel Agents extension for VS Code — inst
 ## Requirements
 
 - VS Code 1.105.0 or later
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- One of:
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (default), or
+  - [OpenAI Codex CLI](https://github.com/openai/codex) with `pixel-agents.agentEngine` set to `codex`
 - **Platform**: Windows, Linux, and macOS are supported
 
 ## Getting Started
@@ -73,10 +76,11 @@ Then press **F5** in VS Code to launch the Extension Development Host.
 ### Usage
 
 1. Open the **Pixel Agents** panel (it appears in the bottom panel area alongside your terminal)
-2. Click **+ Agent** to spawn a new Claude Code terminal and its character. Right-click for the option to launch with `--dangerously-skip-permissions` (bypasses all tool approval prompts)
-3. Start coding with Claude — watch the character react in real time
-4. Click a character to select it, then click a seat to reassign it
-5. Click **Layout** to open the office editor and customize your space
+2. Open **Settings** (gear icon) and pick your **Agent Engine** (Claude Code or Codex), or set `pixel-agents.agentEngine` in VS Code settings
+3. Click **+ Agent** to spawn a new agent terminal and its character. Right-click for bypass-permissions launch (Claude: `--dangerously-skip-permissions`; Codex: `--dangerously-bypass-approvals-and-sandbox`)
+4. Start coding — watch the character react in real time
+5. Click a character to select it, then click a seat to reassign it
+6. Click **Layout** to open the office editor and customize your space
 
 ## Layout Editor
 

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -308,6 +308,11 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
       } else if (message.type === 'setHooksInfoShown') {
         this.adapter.setSetting(GLOBAL_KEY_HOOKS_INFO_SHOWN, true);
+      } else if (message.type === 'setAgentEngine') {
+        const engine = message.engine as string;
+        await vscode.workspace
+          .getConfiguration()
+          .update(CONFIG_KEY_AGENT_ENGINE, engine, vscode.ConfigurationTarget.Global);
       } else if (message.type === 'setWatchAllSessions') {
         const enabled = message.enabled as boolean;
         this.adapter.setSetting(GLOBAL_KEY_WATCH_ALL_SESSIONS, enabled);
@@ -427,6 +432,9 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         const hooksInfoShown = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_INFO_SHOWN, false);
         const config = readConfig();
+        const agentEngine = vscode.workspace
+          .getConfiguration()
+          .get<string>(CONFIG_KEY_AGENT_ENGINE, 'claude-code');
         this.webview?.postMessage({
           type: 'settingsLoaded',
           soundEnabled,
@@ -437,6 +445,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           hooksEnabled,
           hooksInfoShown,
           externalAssetDirectories: config.externalAssetDirectories,
+          agentEngine,
         });
 
         // Send workspace folders to webview (only when multi-root)

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
+import type { HookProvider } from '../../core/src/provider.js';
 import { AgentRuntime } from '../../server/src/agentRuntime.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
 import type { LoadedAssets, LoadedCharacterSprites } from '../../server/src/assetLoader.js';
@@ -29,7 +30,7 @@ import {
   watchLayoutFile,
   writeLayoutToFile,
 } from '../../server/src/layoutPersistence.js';
-import { claudeProvider, copyHookScript } from '../../server/src/providers/index.js';
+import { copyProviderHookScript, resolveProvider } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
 import {
   getProjectDirPath,
@@ -40,6 +41,7 @@ import {
   sendLayout,
 } from './agentManager.js';
 import {
+  CONFIG_KEY_AGENT_ENGINE,
   CONFIG_KEY_AUTO_SHOW_PANEL,
   CONFIG_KEY_AUTO_SPAWN_AGENT,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
@@ -58,6 +60,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
 
   // Shared agent lifecycle core (timer Maps, scanners, hook handler, dismissal tracker)
   private runtime: AgentRuntime;
+  private activeProvider: HookProvider;
 
   // Global session scanning dismissal tracking
   private globalDismissedFiles = new Set<string>();
@@ -108,7 +111,16 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     setTerminalAdapter(new VscodeTerminalAdapter());
 
     // Create shared runtime (owns timer Maps, scanners, hook handler, dismissal tracker)
-    this.runtime = new AgentRuntime(this.store, claudeProvider);
+    this.activeProvider = this.resolveActiveProvider();
+    this.runtime = new AgentRuntime(this.store, this.activeProvider);
+
+    this.context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration(CONFIG_KEY_AGENT_ENGINE)) {
+          void this.handleAgentEngineChanged();
+        }
+      }),
+    );
 
     this.initServer();
   }
@@ -121,6 +133,72 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     return this.webviewView?.webview;
   }
 
+  private resolveActiveProvider(): HookProvider {
+    const configured = vscode.workspace
+      .getConfiguration()
+      .get<string>(CONFIG_KEY_AGENT_ENGINE, 'claude-code');
+    return resolveProvider(configured);
+  }
+
+  private sendProviderCapabilities(): void {
+    this.webview?.postMessage({
+      type: 'providerCapabilities',
+      readingTools: [...this.activeProvider.readingTools],
+      subagentToolNames: [...this.activeProvider.subagentToolNames],
+    });
+  }
+
+  private copyActiveHookScript(): void {
+    copyProviderHookScript(this.activeProvider.id, this.context.extensionPath);
+  }
+
+  private async installActiveHooks(port: number, token: string): Promise<void> {
+    await this.activeProvider.installHooks(`http://127.0.0.1:${port}`, token);
+    this.copyActiveHookScript();
+  }
+
+  private registerWorkspaceProjectScans(): void {
+    const projectDir = getProjectDirPath(undefined, this.activeProvider);
+    this.runtime.startProjectScan(projectDir);
+    this.runtime.startExternalScanning(projectDir);
+
+    const wsFolders = vscode.workspace.workspaceFolders;
+    if (wsFolders && wsFolders.length > 1) {
+      for (const folder of wsFolders) {
+        const folderProjectDir = getProjectDirPath(folder.uri.fsPath, this.activeProvider);
+        if (folderProjectDir && folderProjectDir !== projectDir) {
+          console.log(`[Pixel Agents] Registering additional project dir: ${folderProjectDir}`);
+          this.runtime.startProjectScan(folderProjectDir);
+        }
+      }
+    }
+  }
+
+  private async handleAgentEngineChanged(): Promise<void> {
+    const previousProvider = this.activeProvider;
+    const nextProvider = this.resolveActiveProvider();
+    if (previousProvider.id === nextProvider.id) return;
+
+    const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
+    if (hooksEnabled) {
+      await previousProvider.uninstallHooks();
+    }
+
+    this.activeProvider = nextProvider;
+    this.runtime.setProvider(nextProvider);
+
+    if (hooksEnabled) {
+      const serverConfig = this.pixelAgentsServer?.getConfig();
+      if (serverConfig) {
+        await this.installActiveHooks(serverConfig.port, serverConfig.token);
+      }
+    }
+
+    this.sendProviderCapabilities();
+    this.registerWorkspaceProjectScans();
+    console.log(`[Pixel Agents] Agent engine switched to ${nextProvider.displayName}`);
+  }
+
   private initServer(): void {
     this.pixelAgentsServer = new PixelAgentsServer();
     this.pixelAgentsServer.onHookEvent((providerId, event) => {
@@ -128,7 +206,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     });
 
     this.pixelAgentsServer
-      .start({ store: this.store, embedded: true })
+      .start({ store: this.store, provider: this.activeProvider, embedded: true })
       .then((config) => {
         // Server always starts regardless of hooks-enabled state.
         // It's the foundation for WebSocket transport and health monitoring.
@@ -136,8 +214,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         this.runtime.hooksEnabled.current = hooksEnabled;
         if (hooksEnabled) {
-          void claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-          copyHookScript(this.context.extensionPath);
+          void this.installActiveHooks(config.port, config.token);
         }
         console.log(`[Pixel Agents] Server: ready on port ${config.port}`);
       })
@@ -167,6 +244,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           this.runtime.jsonlPollTimers,
           this.runtime.projectScanTimer,
           () => this.store.persist(),
+          this.activeProvider,
           message.folderPath as string | undefined,
           message.bypassPermissions as boolean | undefined,
         );
@@ -220,14 +298,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.runtime.hooksEnabled.current = enabled;
         if (enabled) {
           const serverConfig = this.pixelAgentsServer?.getConfig();
-          void claudeProvider.installHooks(
-            serverConfig ? `http://127.0.0.1:${serverConfig.port}` : '',
-            serverConfig?.token ?? '',
-          );
-          copyHookScript(this.context.extensionPath);
+          if (serverConfig) {
+            void this.installActiveHooks(serverConfig.port, serverConfig.token);
+          }
           console.log('[Pixel Agents] Hooks enabled by user');
         } else {
-          void claudeProvider.uninstallHooks();
+          void this.activeProvider.uninstallHooks();
           console.log('[Pixel Agents] Hooks disabled by user');
         }
       } else if (message.type === 'setHooksInfoShown') {
@@ -246,7 +322,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           // Remove all external agents not from the current workspace folders
           const workspaceDirs = new Set<string>();
           for (const folder of vscode.workspace.workspaceFolders ?? []) {
-            const dir = getProjectDirPath(folder.uri.fsPath);
+            const dir = getProjectDirPath(folder.uri.fsPath, this.activeProvider);
             if (dir) workspaceDirs.add(dir);
           }
           const toRemove: number[] = [];
@@ -269,11 +345,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         // Provider capabilities: tool taxonomy for webview animation + subagent rendering.
         // Sent once before restoreAgents so characters render with correct animations
         // from the first frame.
-        this.webview?.postMessage({
-          type: 'providerCapabilities',
-          readingTools: [...claudeProvider.readingTools],
-          subagentToolNames: [...claudeProvider.subagentToolNames],
-        });
+        this.sendProviderCapabilities();
         restoreAgents(
           this.adapter,
           this.store.nextAgentId,
@@ -322,6 +394,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             this.runtime.jsonlPollTimers,
             this.runtime.projectScanTimer,
             () => this.store.persist(),
+            this.activeProvider,
             undefined,
             undefined,
             autoShowPanel,
@@ -376,27 +449,12 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
 
         // Ensure project scan runs even with no restored agents (to adopt external terminals)
-        const projectDir = getProjectDirPath();
+        const projectDir = getProjectDirPath(undefined, this.activeProvider);
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         console.log(`[Pixel Agents] Debug: Platform: ${process.platform}, arch: ${process.arch}`);
         console.log('[Extension] workspaceRoot:', workspaceRoot);
         console.log('[Extension] projectDir:', projectDir);
-        this.runtime.startProjectScan(projectDir);
-
-        // Start external session scanning (detects VS Code extension panel sessions)
-        this.runtime.startExternalScanning(projectDir);
-
-        // In multi-root workspaces, also scan project dirs for all other folders
-        // so agents running in any workspace folder are discovered
-        if (wsFolders && wsFolders.length > 1) {
-          for (const folder of wsFolders) {
-            const folderProjectDir = getProjectDirPath(folder.uri.fsPath);
-            if (folderProjectDir && folderProjectDir !== projectDir) {
-              console.log(`[Pixel Agents] Registering additional project dir: ${folderProjectDir}`);
-              this.runtime.startProjectScan(folderProjectDir);
-            }
-          }
-        }
+        this.registerWorkspaceProjectScans();
 
         this.runtime.startStaleCheck();
 
@@ -504,7 +562,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
         this.webview?.postMessage({ type: 'agentDiagnostics', agents: diagnostics });
       } else if (message.type === 'openSessionsFolder') {
-        const projectDir = getProjectDirPath();
+        const projectDir = getProjectDirPath(undefined, this.activeProvider);
         if (projectDir && fs.existsSync(projectDir)) {
           vscode.env.openExternal(vscode.Uri.file(projectDir));
         }

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -82,9 +82,15 @@ export async function launchNewTerminal(
 
   const projectDir = getProjectDirPath(cwd, provider);
 
-  // Pre-register expected JSONL file so project scan won't treat it as a /clear file
-  const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);
-  knownJsonlFiles.add(expectedFile);
+  // Claude uses --session-id so the JSONL filename is predictable. Codex assigns
+  // rollout-*.jsonl at runtime; SessionStart hook rebinds the launched agent.
+  const usesSyntheticSessionFile = provider.id !== 'codex';
+  const expectedFile = usesSyntheticSessionFile
+    ? path.join(projectDir, `${sessionId}.jsonl`)
+    : path.join(projectDir, '__pending__.jsonl');
+  if (usesSyntheticSessionFile) {
+    knownJsonlFiles.add(expectedFile);
+  }
 
   // Create agent immediately (before JSONL file exists)
   const id = nextAgentIdRef.current++;

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
+import type { HookProvider } from '../../core/src/provider.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
 import { JSONL_POLL_INTERVAL_MS } from '../../server/src/constants.js';
 import {
@@ -13,19 +14,21 @@ import {
   startFileWatching,
 } from '../../server/src/fileWatcher.js';
 import { loadLayout } from '../../server/src/layoutPersistence.js';
-import { CLAUDE_TERMINAL_NAME_PREFIX } from '../../server/src/providers/hook/claude/constants.js';
-import { claudeProvider } from '../../server/src/providers/index.js';
+import { resolveProvider } from '../../server/src/providers/index.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from '../../server/src/timerManager.js';
 import type { AgentState, PersistedAgent } from '../../server/src/types.js';
 
-export function getProjectDirPath(cwd?: string): string {
+export function getProjectDirPath(
+  cwd?: string,
+  provider: HookProvider = resolveProvider(),
+): string {
   // Fall back to home directory when no workspace folder is open (common on Linux/macOS
   // when VS Code is launched without a folder). The provider's getSessionDirs already
   // implements the Windows case-insensitive fallback for drive-letter casing.
   const workspacePath = cwd || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || os.homedir();
-  const dirs = claudeProvider.getSessionDirs?.(workspacePath) ?? [];
+  const dirs = provider.getSessionDirs?.(workspacePath) ?? [];
   if (dirs.length === 0) {
-    throw new Error('claudeProvider.getSessionDirs returned no directories');
+    throw new Error(`${provider.displayName}.getSessionDirs returned no directories`);
   }
   const projectDir = dirs[0];
   console.log(`[Pixel Agents] Terminal: Project dir: ${workspacePath} → ${projectDir}`);
@@ -45,6 +48,7 @@ export async function launchNewTerminal(
   jsonlPollTimers: Map<number, ReturnType<typeof setInterval>>,
   projectScanTimerRef: { current: ReturnType<typeof setInterval> | null },
   persistAgents: () => void,
+  provider: HookProvider = resolveProvider(),
   folderPath?: string,
   bypassPermissions?: boolean,
   suppressShow?: boolean,
@@ -56,8 +60,9 @@ export async function launchNewTerminal(
   const cwd = folderPath || folders?.[0]?.uri.fsPath || os.homedir();
   const isMultiRoot = !!(folders && folders.length > 1);
   const idx = nextTerminalIndexRef.current++;
+  const terminalNamePrefix = provider.terminalNamePrefix ?? provider.displayName;
   const terminal = vscode.window.createTerminal({
-    name: `${CLAUDE_TERMINAL_NAME_PREFIX} #${idx}`,
+    name: `${terminalNamePrefix} #${idx}`,
     cwd,
   });
   // When suppressShow is set (auto-spawn + autoShowPanel), keep the panel view
@@ -69,13 +74,13 @@ export async function launchNewTerminal(
   }
 
   const sessionId = crypto.randomUUID();
-  const launch = claudeProvider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });
+  const launch = provider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });
   if (!launch) {
-    throw new Error('claudeProvider.buildLaunchCommand is not implemented');
+    throw new Error(`${provider.displayName}.buildLaunchCommand is not implemented`);
   }
   terminal.sendText([launch.command, ...launch.args].join(' '));
 
-  const projectDir = getProjectDirPath(cwd);
+  const projectDir = getProjectDirPath(cwd, provider);
 
   // Pre-register expected JSONL file so project scan won't treat it as a /clear file
   const expectedFile = path.join(projectDir, `${sessionId}.jsonl`);

--- a/adapters/vscode/constants.ts
+++ b/adapters/vscode/constants.ts
@@ -18,6 +18,7 @@ export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
 // ── VS Code Settings (contributes.configuration keys) ───────
 export const CONFIG_KEY_AUTO_SHOW_PANEL = 'pixel-agents.autoShowPanel';
 export const CONFIG_KEY_AUTO_SPAWN_AGENT = 'pixel-agents.autoSpawnAgent';
+export const CONFIG_KEY_AGENT_ENGINE = 'pixel-agents.agentEngine';
 
 // ── VS Code Identifiers ─────────────────────────────────────
 export const VIEW_ID = 'pixel-agents.panelView';

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -128,6 +128,7 @@ components:
         - $ref: '#/components/schemas/SetHooksEnabled'
         - $ref: '#/components/schemas/SetHooksInfoShown'
         - $ref: '#/components/schemas/SetWatchAllSessions'
+        - $ref: '#/components/schemas/SetAgentEngine'
         - $ref: '#/components/schemas/ExportLayout'
         - $ref: '#/components/schemas/ImportLayout'
         - $ref: '#/components/schemas/OpenSessionsFolder'
@@ -516,6 +517,7 @@ components:
         - hooksEnabled
         - hooksInfoShown
         - externalAssetDirectories
+        - agentEngine
       properties:
         type:
           const: settingsLoaded
@@ -537,6 +539,10 @@ components:
           type: array
           items:
             type: string
+        agentEngine:
+          type: string
+          enum: [claude-code, codex]
+          description: Active AI coding assistant engine.
 
     ExternalAssetDirectoriesUpdated:
       description: External asset directory list changed (after add/remove).
@@ -709,6 +715,18 @@ components:
         enabled:
           type: boolean
 
+    SetAgentEngine:
+      description: Switch the active AI coding assistant engine (Claude Code or Codex).
+      type: object
+      additionalProperties: false
+      required: [type, engine]
+      properties:
+        type:
+          const: setAgentEngine
+        engine:
+          type: string
+          enum: [claude-code, codex]
+
     ExportLayout:
       description: Trigger layout export via host-native save dialog.
       type: object
@@ -728,7 +746,7 @@ components:
           const: importLayout
 
     OpenSessionsFolder:
-      description: Open ~/.claude/projects in the OS file manager.
+      description: Open the active provider's session transcript folder in the OS file manager.
       type: object
       additionalProperties: false
       required: [type]

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -503,6 +503,11 @@ components:
                 items:
                   type: string
 
+    AgentEngine:
+      description: Active AI coding assistant engine.
+      type: string
+      enum: [claude-code, codex]
+
     SettingsLoaded:
       description: All persisted user-level settings, sent once on connect.
       type: object
@@ -540,9 +545,7 @@ components:
           items:
             type: string
         agentEngine:
-          type: string
-          enum: [claude-code, codex]
-          description: Active AI coding assistant engine.
+          $ref: '#/components/schemas/AgentEngine'
 
     ExternalAssetDirectoriesUpdated:
       description: External asset directory list changed (after add/remove).
@@ -724,8 +727,7 @@ components:
         type:
           const: setAgentEngine
         engine:
-          type: string
-          enum: [claude-code, codex]
+          $ref: '#/components/schemas/AgentEngine'
 
     ExportLayout:
       description: Trigger layout export via host-native save dialog.

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -48,6 +48,7 @@ export type ClientMessage =
   | SetHooksEnabled
   | SetHooksInfoShown
   | SetWatchAllSessions
+  | SetAgentEngine
   | ExportLayout
   | ImportLayout
   | OpenSessionsFolder
@@ -241,6 +242,7 @@ export interface SettingsLoaded {
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
   externalAssetDirectories: string[];
+  agentEngine: 'claude-code' | 'codex';
 }
 
 export interface ExternalAssetDirectoriesUpdated {
@@ -326,6 +328,11 @@ export interface SetHooksInfoShown {
 export interface SetWatchAllSessions {
   type: 'setWatchAllSessions';
   enabled: boolean;
+}
+
+export interface SetAgentEngine {
+  type: 'setAgentEngine';
+  engine: 'claude-code' | 'codex';
 }
 
 export interface ExportLayout {

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -242,8 +242,10 @@ export interface SettingsLoaded {
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
   externalAssetDirectories: string[];
-  agentEngine: 'claude-code' | 'codex';
+  agentEngine: AgentEngine;
 }
+
+export type AgentEngine = 'claude-code' | 'codex';
 
 export interface ExternalAssetDirectoriesUpdated {
   type: 'externalAssetDirectoriesUpdated';
@@ -332,7 +334,7 @@ export interface SetWatchAllSessions {
 
 export interface SetAgentEngine {
   type: 'setAgentEngine';
-  engine: 'claude-code' | 'codex';
+  engine: AgentEngine;
 }
 
 export interface ExportLayout {

--- a/core/src/provider.ts
+++ b/core/src/provider.ts
@@ -1,10 +1,9 @@
 /**
  * Provider abstraction for AI agent tools.
  *
- * Only HookProvider ships today (Claude Code). Transcript-polling and push-based
- * provider types will be added when a real second provider (Codex, Goose,
- * Discord, etc.) actually lands, derived from that provider's needs rather than
- * speculation.
+ * HookProvider covers local CLIs that can emit hook events and/or transcript
+ * files. Transcript-polling and push-based provider types can be added later
+ * when a provider needs a genuinely different transport.
  */
 
 import type { TeamProvider } from './teamProvider.js';

--- a/e2e/fixtures/mock-codex
+++ b/e2e/fixtures/mock-codex
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Mock 'codex' executable for Pixel Agents e2e tests.
+#
+# Behaviour:
+#   1. Appends an invocation record to $HOME/.codex-mock/invocations.log.
+#   2. Creates a rollout JSONL under $HOME/.codex/sessions/YYYY/MM/DD/.
+#   3. Stays alive for up to 30 s.
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/.codex-mock"
+mkdir -p "$LOG_DIR"
+echo "$(date -Iseconds) cwd=$(pwd) args=$*" >> "${LOG_DIR}/invocations.log"
+
+YEAR=$(date +%Y)
+MONTH=$(date +%m)
+DAY=$(date +%d)
+SESSION_DIR="${HOME}/.codex/sessions/${YEAR}/${MONTH}/${DAY}"
+mkdir -p "$SESSION_DIR"
+JSONL_FILE="${SESSION_DIR}/rollout-mock-e2e.jsonl"
+printf '{"type":"session_meta","payload":{"cwd":"%s","source":"startup"}}\n' "$(pwd)" >> "$JSONL_FILE"
+
+sleep 30 &
+SLEEP_PID=$!
+trap 'kill $SLEEP_PID 2>/dev/null; exit 0' SIGTERM SIGINT
+wait $SLEEP_PID || true

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -8,6 +8,10 @@ const REPO_ROOT = path.join(__dirname, '../..');
 const VSCODE_PATH_FILE = path.join(REPO_ROOT, '.vscode-test/vscode-executable.txt');
 const MOCK_CLAUDE_PATH = path.join(REPO_ROOT, 'e2e/fixtures/mock-claude');
 const MOCK_CLAUDE_CMD_PATH = path.join(REPO_ROOT, 'e2e/fixtures/mock-claude.cmd');
+const MOCK_CODEX_PATH = path.join(REPO_ROOT, 'e2e/fixtures/mock-codex');
+export interface LaunchOptions {
+  agentEngine?: 'claude-code' | 'codex';
+}
 const ARTIFACTS_DIR = path.join(REPO_ROOT, 'test-results/e2e');
 const IS_WINDOWS = process.platform === 'win32';
 const PATH_SEP = IS_WINDOWS ? ';' : ':';
@@ -30,7 +34,11 @@ export interface VSCodeSession {
  * Uses an isolated temp HOME and injects the mock `claude` binary at the
  * front of PATH so no real Claude CLI is needed.
  */
-export async function launchVSCode(testTitle: string): Promise<VSCodeSession> {
+export async function launchVSCode(
+  testTitle: string,
+  options: LaunchOptions = {},
+): Promise<VSCodeSession> {
+  const agentEngine = options.agentEngine ?? 'claude-code';
   const vscodePath = fs.readFileSync(VSCODE_PATH_FILE, 'utf8').trim();
 
   // --- Isolated temp directories ---
@@ -70,48 +78,53 @@ export async function launchVSCode(testTitle: string): Promise<VSCodeSession> {
     }
   }
 
-  // Copy mock-claude into an isolated bin dir
+  // Copy mock CLI into an isolated bin dir
   if (IS_WINDOWS) {
-    // Windows: copy the .cmd batch file as 'claude.cmd'
     fs.copyFileSync(MOCK_CLAUDE_CMD_PATH, path.join(mockBinDir, 'claude.cmd'));
+    if (agentEngine === 'codex') {
+      fs.copyFileSync(MOCK_CLAUDE_CMD_PATH, path.join(mockBinDir, 'codex.cmd'));
+    }
   } else {
-    const mockDest = path.join(mockBinDir, 'claude');
-    fs.copyFileSync(MOCK_CLAUDE_PATH, mockDest);
+    const mockDest = path.join(mockBinDir, agentEngine === 'codex' ? 'codex' : 'claude');
+    fs.copyFileSync(agentEngine === 'codex' ? MOCK_CODEX_PATH : MOCK_CLAUDE_PATH, mockDest);
     fs.chmodSync(mockDest, 0o755);
   }
+
+  const userSettingsDir = path.join(userDataDir, 'User');
+  fs.mkdirSync(userSettingsDir, { recursive: true });
+  const userSettings: Record<string, unknown> = {
+    'pixel-agents.agentEngine': agentEngine,
+  };
 
   // macOS: VS Code's integrated terminal resolves PATH from the login shell,
   // ignoring the process env. Define a custom terminal profile that uses a
   // non-login shell with our mock bin dir in PATH. On Linux the process env
   // propagates directly, so no custom profile is needed.
   if (process.platform === 'darwin') {
-    const userSettingsDir = path.join(userDataDir, 'User');
-    fs.mkdirSync(userSettingsDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(userSettingsDir, 'settings.json'),
-      JSON.stringify(
-        {
-          'terminal.integrated.profiles.osx': {
-            e2e: {
-              path: '/bin/zsh',
-              args: ['--no-globalrcs'],
-              env: {
-                PATH: `${mockBinDir}:/usr/local/bin:/usr/bin:/bin`,
-                HOME: tmpHome,
-                ZDOTDIR: tmpHome,
-              },
-            },
-          },
-          'terminal.integrated.defaultProfile.osx': 'e2e',
-          'terminal.integrated.inheritEnv': false,
+    userSettings['terminal.integrated.profiles.osx'] = {
+      e2e: {
+        path: '/bin/zsh',
+        args: ['--no-globalrcs'],
+        env: {
+          PATH: `${mockBinDir}:/usr/local/bin:/usr/bin:/bin`,
+          HOME: tmpHome,
+          ZDOTDIR: tmpHome,
         },
-        null,
-        2,
-      ),
-    );
+      },
+    };
+    userSettings['terminal.integrated.defaultProfile.osx'] = 'e2e';
+    userSettings['terminal.integrated.inheritEnv'] = false;
   }
 
-  const mockLogFile = path.join(tmpHome, '.claude-mock', 'invocations.log');
+  fs.writeFileSync(
+    path.join(userSettingsDir, 'settings.json'),
+    JSON.stringify(userSettings, null, 2),
+  );
+
+  const mockLogFile =
+    agentEngine === 'codex'
+      ? path.join(tmpHome, '.codex-mock', 'invocations.log')
+      : path.join(tmpHome, '.claude-mock', 'invocations.log');
 
   // --- Video output dir ---
   const safeTitle = testTitle.replace(/[^a-z0-9]+/gi, '-').toLowerCase();

--- a/e2e/tests/agent-spawn-codex.spec.ts
+++ b/e2e/tests/agent-spawn-codex.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+import { launchVSCode, waitForWorkbench } from '../helpers/launch';
+import { clickAddAgent, getPixelAgentsFrame, openPixelAgentsPanel } from '../helpers/webview';
+
+test('clicking + Agent spawns mock codex and creates a JSONL session file', async ({}, testInfo) => {
+  const session = await launchVSCode(testInfo.title, { agentEngine: 'codex' });
+  const { window, tmpHome, mockLogFile } = session;
+
+  test.setTimeout(120_000);
+
+  try {
+    await waitForWorkbench(window);
+    await openPixelAgentsPanel(window);
+    const frame = await getPixelAgentsFrame(window);
+    await clickAddAgent(frame);
+
+    await expect
+      .poll(
+        () => {
+          try {
+            return fs.readFileSync(mockLogFile, 'utf8').trim().length > 0;
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(true);
+
+    const sessionsRoot = path.join(tmpHome, '.codex', 'sessions');
+    const jsonlFiles: string[] = [];
+    function collectJsonl(dir: string): void {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectJsonl(full);
+        else if (entry.name.endsWith('.jsonl')) jsonlFiles.push(full);
+      }
+    }
+    collectJsonl(sessionsRoot);
+    expect(jsonlFiles.length).toBeGreaterThan(0);
+  } finally {
+    await session.cleanup();
+  }
+});

--- a/esbuild.js
+++ b/esbuild.js
@@ -36,29 +36,40 @@ function copyAssets() {
 
 /**
  * Bundle hook scripts (TypeScript) to dist/hooks via esbuild.
- * Produces a self-contained CJS file with shebang for Claude Code to execute.
+ * Produces self-contained CJS files with shebangs for agent CLIs to execute.
  */
 function buildHooks() {
-  const entry = path.join(
-    __dirname,
-    'server',
-    'src',
-    'providers',
-    'hook',
-    'claude',
-    'hooks',
-    'claude-hook.ts',
-  );
-  if (!fs.existsSync(entry)) return;
-  require('esbuild').buildSync({
-    entryPoints: [entry],
-    bundle: true,
-    platform: 'node',
-    target: 'node18',
-    format: 'cjs',
-    outdir: path.join(__dirname, 'dist', 'hooks'),
-    banner: { js: '#!/usr/bin/env node' },
-  });
+  const outdir = path.join(__dirname, 'dist', 'hooks');
+  fs.rmSync(outdir, { recursive: true, force: true });
+  fs.mkdirSync(outdir, { recursive: true });
+
+  const entries = ['claude', 'codex']
+    .map((provider) => ({
+      provider,
+      entry: path.join(
+        __dirname,
+        'server',
+        'src',
+        'providers',
+        'hook',
+        provider,
+        'hooks',
+        `${provider}-hook.ts`,
+      ),
+    }))
+    .filter(({ entry }) => fs.existsSync(entry));
+  if (entries.length === 0) return;
+  for (const { provider, entry } of entries) {
+    require('esbuild').buildSync({
+      entryPoints: [entry],
+      bundle: true,
+      platform: 'node',
+      target: 'node18',
+      format: 'cjs',
+      outfile: path.join(outdir, `${provider}-hook.js`),
+      banner: { js: '#!/usr/bin/env node' },
+    });
+  }
   console.log('✓ Built hooks/ → dist/hooks/');
 }
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,16 @@
         "pixel-agents.autoSpawnAgent": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically spawn a Claude Code agent when VS Code starts, if no agents are currently running."
+          "description": "Automatically spawn the selected agent engine when VS Code starts, if no agents are currently running."
+        },
+        "pixel-agents.agentEngine": {
+          "type": "string",
+          "enum": [
+            "claude-code",
+            "codex"
+          ],
+          "default": "claude-code",
+          "description": "Agent engine to launch and observe in Pixel Agents."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pixel-agents",
   "displayName": "Pixel Agents",
-  "description": "Pixel art office where your Claude Code agents come to life as animated characters",
-  "version": "1.3.0",
+  "description": "Pixel art office where your AI coding agents come to life as animated characters",
+  "version": "1.4.0",
   "publisher": "pablodelucca",
   "repository": {
     "type": "git",

--- a/scripts/generate-messages.ts
+++ b/scripts/generate-messages.ts
@@ -19,7 +19,7 @@
  */
 
 import { TypeScriptGenerator } from '@asyncapi/modelina';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -106,7 +106,7 @@ async function main(): Promise<void> {
 
   // Format + lint --fix the generated file so the committed file passes CI.
   try {
-    execSync(`npx prettier --write ${quote(OUTPUT_PATH)}`, {
+    execFileSync(bin('prettier'), ['--write', OUTPUT_PATH], {
       cwd: REPO_ROOT,
       stdio: 'inherit',
     });
@@ -115,7 +115,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   try {
-    execSync(`npx eslint --fix ${quote(path.relative(REPO_ROOT, OUTPUT_PATH))}`, {
+    execFileSync(bin('eslint'), ['--fix', path.relative(REPO_ROOT, OUTPUT_PATH)], {
       cwd: REPO_ROOT,
       stdio: 'inherit',
     });
@@ -136,8 +136,9 @@ function exportify(decl: string): string {
   return `export ${trimmed}`;
 }
 
-function quote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
+function bin(name: string): string {
+  const executable = process.platform === 'win32' ? `${name}.cmd` : name;
+  return path.join(REPO_ROOT, 'node_modules', '.bin', executable);
 }
 
 main().catch((err) => {

--- a/server/__tests__/codex-hook.test.ts
+++ b/server/__tests__/codex-hook.test.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HOOK_SCRIPT = path.join(__dirname, '../../dist/hooks/codex-hook.js');
+
+let tmpBase: string;
+
+function writeServerJson(port: number, token: string): void {
+  const dir = path.join(tmpBase, '.pixel-agents');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'server.json'),
+    JSON.stringify({ port, pid: process.pid, token, startedAt: Date.now() }),
+  );
+}
+
+function runHookScript(stdin: string): Promise<{ code: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [HOOK_SCRIPT], {
+      env: { ...process.env, HOME: tmpBase },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    child.on('close', (code) => resolve({ code }));
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+describe('codex-hook.js integration', () => {
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-codex-hook-int-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  function skipIfNotBuilt(): void {
+    if (!fs.existsSync(HOOK_SCRIPT)) {
+      console.warn(`Skipping: ${HOOK_SCRIPT} not found. Run 'npm run compile' first.`);
+    }
+  }
+
+  it('POSTs to /api/hooks/codex', async () => {
+    skipIfNotBuilt();
+    if (!fs.existsSync(HOOK_SCRIPT)) return;
+
+    const received: string[] = [];
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (c: Buffer) => (body += c.toString()));
+      req.on('end', () => {
+        received.push(`${req.url}:${body}`);
+        res.writeHead(200);
+        res.end('ok');
+      });
+    });
+
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const port = (server.address() as { port: number }).port;
+    writeServerJson(port, 'test-token');
+
+    const event = JSON.stringify({
+      session_id: 'sess-codex',
+      hook_event_name: 'Stop',
+    });
+    const { code } = await runHookScript(event);
+
+    server.close();
+    expect(code).toBe(0);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toContain('/api/hooks/codex');
+    expect(received[0]).toContain('sess-codex');
+  });
+
+  it('exits 0 when server.json is missing', async () => {
+    skipIfNotBuilt();
+    if (!fs.existsSync(HOOK_SCRIPT)) return;
+
+    const { code } = await runHookScript(
+      JSON.stringify({ session_id: 'x', hook_event_name: 'Stop' }),
+    );
+    expect(code).toBe(0);
+  });
+
+  it('exits 0 on invalid stdin', async () => {
+    skipIfNotBuilt();
+    if (!fs.existsSync(HOOK_SCRIPT)) return;
+
+    writeServerJson(9999, 'tok');
+    const { code } = await runHookScript('not json');
+    expect(code).toBe(0);
+  });
+});

--- a/server/__tests__/codex.property.test.ts
+++ b/server/__tests__/codex.property.test.ts
@@ -1,0 +1,113 @@
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+import { resolveProvider } from '../src/providers/index.js';
+
+const EVENT_NAMES = [
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+  'PermissionRequest',
+  'SessionStart',
+  'SubagentStart',
+  'SubagentStop',
+] as const;
+
+function randomString(len: number): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-/';
+  let out = '';
+  for (let i = 0; i < len; i++) {
+    out += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return out;
+}
+
+describe('codexProvider property tests', () => {
+  // Feature: codex-agent-support, Property 1: Hook event normalization
+  it('normalizeHookEvent maps recognized events or returns null', () => {
+    for (let i = 0; i < 100; i++) {
+      const eventName = EVENT_NAMES[i % EVENT_NAMES.length];
+      const sessionId = `sess-${i}`;
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: eventName,
+        session_id: sessionId,
+        tool_name: 'exec_command',
+        tool_use_id: `call-${i}`,
+        tool_input: { cmd: randomString(20) },
+        transcript_path: `/tmp/codex/sessions/2026/06/08/rollout-${i}.jsonl`,
+        cwd: '/workspace',
+      });
+      expect(result).not.toBeNull();
+      expect(result?.sessionId).toBe(sessionId);
+      expect(result?.event.kind).toBeTruthy();
+
+      expect(codexProvider.normalizeHookEvent({ session_id: sessionId })).toBeNull();
+      expect(codexProvider.normalizeHookEvent({ hook_event_name: eventName })).toBeNull();
+      expect(
+        codexProvider.normalizeHookEvent({
+          hook_event_name: `unknown-${i}`,
+          session_id: sessionId,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  // Feature: codex-agent-support, Property 2: formatToolStatus length
+  it('formatToolStatus never exceeds 80 characters', () => {
+    for (let i = 0; i < 100; i++) {
+      const toolName = randomString(5 + (i % 40));
+      const input = { cmd: randomString(100), path: randomString(100) };
+      const status = codexProvider.formatToolStatus(toolName, input);
+      expect(status.length).toBeLessThanOrEqual(80);
+    }
+  });
+
+  // Feature: codex-agent-support, Property 4: Provider resolution
+  it('resolveProvider always returns a valid HookProvider', () => {
+    for (let i = 0; i < 100; i++) {
+      const value = i % 3 === 0 ? 'codex' : i % 3 === 1 ? 'claude-code' : randomString(12);
+      const provider = resolveProvider(value);
+      expect(provider).toBeTruthy();
+      expect(provider.kind).toBe('hook');
+      if (value === 'codex') {
+        expect(provider.id).toBe('codex');
+      } else if (value === 'claude-code' || value === 'claude') {
+        expect(provider.id).toBe('claude');
+      } else {
+        expect(provider.id).toBe('claude');
+      }
+    }
+  });
+
+  // Feature: codex-agent-support, Property 5: buildLaunchCommand structure
+  it('buildLaunchCommand includes bypass flag only when requested', () => {
+    for (let i = 0; i < 100; i++) {
+      const sessionId = crypto.randomUUID();
+      const cwd = `/workspace/${randomString(8)}`;
+      const withBypass = i % 2 === 0;
+      const launch = codexProvider.buildLaunchCommand?.(sessionId, cwd, {
+        bypassPermissions: withBypass,
+      });
+      expect(launch?.command).toBe('codex');
+      expect(Array.isArray(launch?.args)).toBe(true);
+      if (withBypass) {
+        expect(launch?.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+      } else {
+        expect(launch?.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+      }
+    }
+  });
+
+  // Feature: codex-agent-support, Property 6: getSessionDirs
+  it('getSessionDirs returns home-relative paths without throwing', () => {
+    for (let i = 0; i < 100; i++) {
+      const workspace = randomString(8 + (i % 20));
+      const dirs = codexProvider.getSessionDirs?.(workspace) ?? [];
+      expect(dirs.length).toBeGreaterThan(0);
+      for (const dir of dirs) {
+        expect(dir).toContain(path.join('.codex', 'sessions'));
+      }
+    }
+  });
+});

--- a/server/__tests__/codex.property.test.ts
+++ b/server/__tests__/codex.property.test.ts
@@ -1,113 +1,229 @@
+import * as fc from 'fast-check';
+import * as os from 'os';
 import * as path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { codexProvider } from '../src/providers/hook/codex/codex.js';
 import { resolveProvider } from '../src/providers/index.js';
 
-const EVENT_NAMES = [
-  'PreToolUse',
-  'PostToolUse',
-  'Stop',
-  'PermissionRequest',
-  'SessionStart',
-  'SubagentStart',
-  'SubagentStop',
-] as const;
+const EVENT_KIND_BY_NAME = {
+  PreToolUse: 'toolStart',
+  PostToolUse: 'toolEnd',
+  PostToolUseFailure: 'toolEnd',
+  Stop: 'turnEnd',
+  PermissionRequest: 'permissionRequest',
+  SessionStart: 'sessionStart',
+  SessionEnd: 'sessionEnd',
+  SubagentStart: 'subagentStart',
+  SubagentStop: 'subagentEnd',
+} as const;
 
-function randomString(len: number): string {
-  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-/';
-  let out = '';
-  for (let i = 0; i < len; i++) {
-    out += chars[Math.floor(Math.random() * chars.length)];
-  }
-  return out;
-}
+const EVENT_NAMES = Object.keys(EVENT_KIND_BY_NAME) as Array<keyof typeof EVENT_KIND_BY_NAME>;
+const RUNS = 100;
+
+const nonEmptyString = fc.string({ minLength: 1, maxLength: 80 });
+const inputValue = fc.oneof(fc.string({ maxLength: 200 }), fc.boolean(), fc.integer());
+const inputObject = fc.dictionary(fc.string({ minLength: 1, maxLength: 24 }), inputValue, {
+  maxKeys: 8,
+});
 
 describe('codexProvider property tests', () => {
   // Feature: codex-agent-support, Property 1: Hook event normalization
-  it('normalizeHookEvent maps recognized events or returns null', () => {
-    for (let i = 0; i < 100; i++) {
-      const eventName = EVENT_NAMES[i % EVENT_NAMES.length];
-      const sessionId = `sess-${i}`;
-      const result = codexProvider.normalizeHookEvent({
-        hook_event_name: eventName,
-        session_id: sessionId,
-        tool_name: 'exec_command',
-        tool_use_id: `call-${i}`,
-        tool_input: { cmd: randomString(20) },
-        transcript_path: `/tmp/codex/sessions/2026/06/08/rollout-${i}.jsonl`,
-        cwd: '/workspace',
-      });
-      expect(result).not.toBeNull();
-      expect(result?.sessionId).toBe(sessionId);
-      expect(result?.event.kind).toBeTruthy();
+  it('normalizeHookEvent maps recognized events to the correct kind', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...EVENT_NAMES),
+        nonEmptyString,
+        nonEmptyString,
+        nonEmptyString,
+        inputObject,
+        (eventName, sessionId, toolName, toolUseId, toolInput) => {
+          const result = codexProvider.normalizeHookEvent({
+            hook_event_name: eventName,
+            session_id: sessionId,
+            tool_name: toolName,
+            tool_use_id: toolUseId,
+            tool_input: toolInput,
+            transcript_path: `/tmp/codex/sessions/2026/06/08/rollout-${toolUseId}.jsonl`,
+            cwd: '/workspace',
+          });
 
-      expect(codexProvider.normalizeHookEvent({ session_id: sessionId })).toBeNull();
-      expect(codexProvider.normalizeHookEvent({ hook_event_name: eventName })).toBeNull();
-      expect(
-        codexProvider.normalizeHookEvent({
-          hook_event_name: `unknown-${i}`,
-          session_id: sessionId,
-        }),
-      ).toBeNull();
-    }
+          expect(result).not.toBeNull();
+          expect(result?.sessionId).toBe(sessionId);
+          expect(result?.event.kind).toBe(EVENT_KIND_BY_NAME[eventName]);
+        },
+      ),
+      { numRuns: RUNS },
+    );
+  });
+
+  it('normalizeHookEvent returns null for missing or unknown event fields', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...EVENT_NAMES), nonEmptyString, (eventName, sessionId) => {
+        expect(codexProvider.normalizeHookEvent({ session_id: sessionId })).toBeNull();
+        expect(codexProvider.normalizeHookEvent({ hook_event_name: eventName })).toBeNull();
+      }),
+      { numRuns: RUNS },
+    );
+
+    fc.assert(
+      fc.property(
+        fc
+          .string({ minLength: 1, maxLength: 80 })
+          .filter((value) => !(EVENT_NAMES as readonly string[]).includes(value)),
+        nonEmptyString,
+        (eventName, sessionId) => {
+          expect(
+            codexProvider.normalizeHookEvent({
+              hook_event_name: eventName,
+              session_id: sessionId,
+            }),
+          ).toBeNull();
+        },
+      ),
+      { numRuns: RUNS },
+    );
   });
 
   // Feature: codex-agent-support, Property 2: formatToolStatus length
-  it('formatToolStatus never exceeds 80 characters', () => {
-    for (let i = 0; i < 100; i++) {
-      const toolName = randomString(5 + (i % 40));
-      const input = { cmd: randomString(100), path: randomString(100) };
-      const status = codexProvider.formatToolStatus(toolName, input);
-      expect(status.length).toBeLessThanOrEqual(80);
-    }
+  it('formatToolStatus never exceeds 80 characters and truncates long statuses', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1, maxLength: 240 }), inputObject, (toolName, input) => {
+        const status = codexProvider.formatToolStatus(toolName, input);
+        expect(status.length).toBeLessThanOrEqual(80);
+      }),
+      { numRuns: RUNS },
+    );
+
+    fc.assert(
+      fc.property(fc.string({ minLength: 120, maxLength: 240 }), (toolName) => {
+        expect(codexProvider.formatToolStatus(toolName, {}).endsWith('\u2026')).toBe(true);
+      }),
+      { numRuns: RUNS },
+    );
+  });
+
+  // Feature: codex-agent-support, Property 3: Transcript line parsing
+  it('parseTranscriptLine maps Codex transcript records or returns null', () => {
+    fc.assert(
+      fc.property(nonEmptyString, nonEmptyString, inputObject, (callId, name, input) => {
+        const event = codexProvider.parseTranscriptLine?.(
+          JSON.stringify({
+            type: 'response_item',
+            payload: {
+              type: 'function_call',
+              call_id: callId,
+              name,
+              arguments: JSON.stringify(input),
+            },
+          }),
+        );
+
+        expect(event?.kind).toBe('toolStart');
+        if (event?.kind === 'toolStart') {
+          expect(event.toolId).toBe(callId);
+          expect(event.toolName).toBe(name);
+          expect(event.input).toEqual(input);
+        }
+      }),
+      { numRuns: RUNS },
+    );
+
+    fc.assert(
+      fc.property(nonEmptyString, (callId) => {
+        const event = codexProvider.parseTranscriptLine?.(
+          JSON.stringify({
+            type: 'response_item',
+            payload: { type: 'function_call_output', call_id: callId },
+          }),
+        );
+        expect(event).toEqual({ kind: 'toolEnd', toolId: callId });
+      }),
+      { numRuns: RUNS },
+    );
+
+    fc.assert(
+      fc.property(nonEmptyString, (cwd) => {
+        const event = codexProvider.parseTranscriptLine?.(
+          JSON.stringify({ type: 'session_meta', payload: { cwd, source: 'startup' } }),
+        );
+        expect(event).toEqual({ kind: 'sessionStart', cwd, source: 'startup' });
+      }),
+      { numRuns: RUNS },
+    );
+
+    expect(
+      codexProvider.parseTranscriptLine?.(
+        JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete' } }),
+      ),
+    ).toEqual({ kind: 'turnEnd' });
+
+    fc.assert(
+      fc.property(fc.string({ maxLength: 200 }), (value) => {
+        expect(() => codexProvider.parseTranscriptLine?.(`not-json:${value}`)).not.toThrow();
+        expect(codexProvider.parseTranscriptLine?.(`not-json:${value}`)).toBeNull();
+        expect(
+          codexProvider.parseTranscriptLine?.(
+            JSON.stringify({ type: 'response_item', payload: { type: value } }),
+          ),
+        ).toBeNull();
+      }),
+      { numRuns: RUNS },
+    );
   });
 
   // Feature: codex-agent-support, Property 4: Provider resolution
   it('resolveProvider always returns a valid HookProvider', () => {
-    for (let i = 0; i < 100; i++) {
-      const value = i % 3 === 0 ? 'codex' : i % 3 === 1 ? 'claude-code' : randomString(12);
-      const provider = resolveProvider(value);
-      expect(provider).toBeTruthy();
-      expect(provider.kind).toBe('hook');
-      if (value === 'codex') {
-        expect(provider.id).toBe('codex');
-      } else if (value === 'claude-code' || value === 'claude') {
-        expect(provider.id).toBe('claude');
-      } else {
-        expect(provider.id).toBe('claude');
-      }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      fc.assert(
+        fc.property(fc.string({ maxLength: 80 }), (value) => {
+          const provider = resolveProvider(value);
+          expect(provider).toBeTruthy();
+          expect(provider.kind).toBe('hook');
+          if (value === 'codex') {
+            expect(provider.id).toBe('codex');
+          } else {
+            expect(provider.id).toBe('claude');
+          }
+        }),
+        { numRuns: RUNS },
+      );
+    } finally {
+      warn.mockRestore();
     }
   });
 
   // Feature: codex-agent-support, Property 5: buildLaunchCommand structure
   it('buildLaunchCommand includes bypass flag only when requested', () => {
-    for (let i = 0; i < 100; i++) {
-      const sessionId = crypto.randomUUID();
-      const cwd = `/workspace/${randomString(8)}`;
-      const withBypass = i % 2 === 0;
-      const launch = codexProvider.buildLaunchCommand?.(sessionId, cwd, {
-        bypassPermissions: withBypass,
-      });
-      expect(launch?.command).toBe('codex');
-      expect(Array.isArray(launch?.args)).toBe(true);
-      if (withBypass) {
-        expect(launch?.args).toContain('--dangerously-bypass-approvals-and-sandbox');
-      } else {
-        expect(launch?.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
-      }
-    }
+    fc.assert(
+      fc.property(fc.uuid(), nonEmptyString, fc.boolean(), (sessionId, cwd, bypassPermissions) => {
+        const launch = codexProvider.buildLaunchCommand?.(sessionId, cwd, { bypassPermissions });
+        expect(launch?.command).toBe('codex');
+        expect(Array.isArray(launch?.args)).toBe(true);
+        if (bypassPermissions) {
+          expect(launch?.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+        } else {
+          expect(launch?.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+        }
+      }),
+      { numRuns: RUNS },
+    );
   });
 
   // Feature: codex-agent-support, Property 6: getSessionDirs
   it('getSessionDirs returns home-relative paths without throwing', () => {
-    for (let i = 0; i < 100; i++) {
-      const workspace = randomString(8 + (i % 20));
-      const dirs = codexProvider.getSessionDirs?.(workspace) ?? [];
-      expect(dirs.length).toBeGreaterThan(0);
-      for (const dir of dirs) {
-        expect(dir).toContain(path.join('.codex', 'sessions'));
-      }
-    }
+    const expectedRoot = process.env.CODEX_HOME ?? path.join(os.homedir(), '.codex');
+    fc.assert(
+      fc.property(fc.string({ maxLength: 200 }), (workspacePath) => {
+        const dirs = codexProvider.getSessionDirs?.(workspacePath) ?? [];
+        expect(dirs.length).toBeGreaterThan(0);
+        for (const dir of dirs) {
+          expect(path.isAbsolute(dir)).toBe(true);
+          expect(dir.startsWith(path.join(expectedRoot, 'sessions'))).toBe(true);
+        }
+      }),
+      { numRuns: RUNS },
+    );
   });
 });

--- a/server/__tests__/codex.test.ts
+++ b/server/__tests__/codex.test.ts
@@ -1,0 +1,169 @@
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+import { resolveProvider } from '../src/providers/index.js';
+
+describe('codexProvider', () => {
+  afterEach(() => {
+    delete process.env.CODEX_HOME;
+  });
+
+  describe('identity', () => {
+    it('has hook provider identity', () => {
+      expect(codexProvider.kind).toBe('hook');
+      expect(codexProvider.id).toBe('codex');
+      expect(codexProvider.displayName).toBe('Codex');
+      expect(codexProvider.protocolVersion).toBe(1);
+      expect(codexProvider.team).toBeUndefined();
+    });
+
+    it('is resolved by provider registry', () => {
+      expect(resolveProvider('codex')).toBe(codexProvider);
+      expect(resolveProvider('claude-code').id).toBe('claude');
+      expect(resolveProvider('claude').id).toBe('claude');
+    });
+  });
+
+  describe('session paths and launch command', () => {
+    it('uses CODEX_HOME date session dirs', () => {
+      process.env.CODEX_HOME = '/tmp/codex-home';
+      const dirs = codexProvider.getSessionDirs?.('/workspace') ?? [];
+      expect(dirs[0]).toContain(path.join('/tmp', 'codex-home', 'sessions'));
+      expect(dirs[0]).toMatch(/\d{4}\/\d{2}\/\d{2}$/);
+    });
+
+    it('builds a codex launch command without a synthetic session id flag', () => {
+      const launch = codexProvider.buildLaunchCommand?.('synthetic-session', '/workspace');
+      expect(launch?.command).toBe('codex');
+      expect(launch?.args).not.toContain('--session-id');
+      expect(launch?.env?.PWD).toBe('/workspace');
+    });
+
+    it('maps bypassPermissions to Codex bypass flag', () => {
+      const launch = codexProvider.buildLaunchCommand?.('synthetic-session', '/workspace', {
+        bypassPermissions: true,
+      });
+      expect(launch?.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when required fields are missing', () => {
+      expect(codexProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+      expect(codexProvider.normalizeHookEvent({ hook_event_name: 'Stop' })).toBeNull();
+    });
+
+    it('normalizes PreToolUse with Codex tool_use_id', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-1',
+        tool_use_id: 'call-1',
+        tool_name: 'exec_command',
+        tool_input: { cmd: 'npm test' },
+      });
+      expect(result?.sessionId).toBe('sess-1');
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolId).toBe('call-1');
+        expect(result.event.toolName).toBe('exec_command');
+        expect(result.event.input).toEqual({ cmd: 'npm test' });
+      }
+    });
+
+    it('normalizes SessionStart with transcript path and cwd', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'sess-1',
+        source: 'startup',
+        transcript_path: '/tmp/codex/sessions/2026/06/08/rollout.jsonl',
+        cwd: '/work/pixel-agents',
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.source).toBe('startup');
+        expect(result.event.transcriptPath).toBe('/tmp/codex/sessions/2026/06/08/rollout.jsonl');
+        expect(result.event.cwd).toBe('/work/pixel-agents');
+      }
+    });
+
+    it('normalizes Stop and PermissionRequest', () => {
+      expect(
+        codexProvider.normalizeHookEvent({
+          hook_event_name: 'Stop',
+          session_id: 'sess-1',
+        })?.event.kind,
+      ).toBe('turnEnd');
+      expect(
+        codexProvider.normalizeHookEvent({
+          hook_event_name: 'PermissionRequest',
+          session_id: 'sess-1',
+        })?.event.kind,
+      ).toBe('permissionRequest');
+    });
+  });
+
+  describe('parseTranscriptLine', () => {
+    it('parses session_meta cwd', () => {
+      const event = codexProvider.parseTranscriptLine?.(
+        JSON.stringify({
+          type: 'session_meta',
+          payload: { cwd: '/work/pixel-agents', source: 'vscode' },
+        }),
+      );
+      expect(event?.kind).toBe('sessionStart');
+      if (event?.kind === 'sessionStart') {
+        expect(event.cwd).toBe('/work/pixel-agents');
+      }
+    });
+
+    it('parses function_call and function_call_output', () => {
+      const start = codexProvider.parseTranscriptLine?.(
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            call_id: 'call-1',
+            name: 'exec_command',
+            arguments: JSON.stringify({ cmd: 'npm test' }),
+          },
+        }),
+      );
+      expect(start?.kind).toBe('toolStart');
+      if (start?.kind === 'toolStart') {
+        expect(start.toolId).toBe('call-1');
+        expect(start.toolName).toBe('exec_command');
+        expect(start.input).toEqual({ cmd: 'npm test' });
+      }
+
+      const end = codexProvider.parseTranscriptLine?.(
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call-1' },
+        }),
+      );
+      expect(end).toEqual({ kind: 'toolEnd', toolId: 'call-1' });
+    });
+
+    it('parses task_complete event_msg as turnEnd', () => {
+      const event = codexProvider.parseTranscriptLine?.(
+        JSON.stringify({
+          type: 'event_msg',
+          payload: { type: 'task_complete' },
+        }),
+      );
+      expect(event).toEqual({ kind: 'turnEnd' });
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats common Codex tools', () => {
+      expect(codexProvider.formatToolStatus('exec_command', { cmd: 'npm test' })).toBe(
+        'Running: npm test',
+      );
+      expect(codexProvider.formatToolStatus('apply_patch', {})).toBe('Editing files');
+      expect(codexProvider.formatToolStatus('read_mcp_resource', {})).toBe('Reading resource');
+      expect(codexProvider.formatToolStatus('FancyTool', {})).toBe('Using FancyTool');
+    });
+  });
+});

--- a/server/__tests__/codexHookInstaller.test.ts
+++ b/server/__tests__/codexHookInstaller.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpBase: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpBase };
+});
+
+const { areHooksInstalled, installHooks, uninstallHooks, copyHookScript } =
+  await import('../src/providers/hook/codex/codexHookInstaller.js');
+
+function readHooksFile(): Record<string, unknown> {
+  const p = path.join(tmpBase, '.codex', 'hooks.json');
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+describe('codexHookInstaller', () => {
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-codex-hook-test-'));
+    process.env.CODEX_HOME = path.join(tmpBase, '.codex');
+    fs.mkdirSync(path.join(tmpBase, '.codex'), { recursive: true });
+  });
+
+  afterEach(() => {
+    delete process.env.CODEX_HOME;
+    try {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('installHooks adds Codex hook entries', () => {
+    installHooks();
+    const settings = readHooksFile();
+    const hooks = settings.hooks as Record<string, unknown[]>;
+    expect(hooks['SessionStart']).toHaveLength(1);
+    expect(hooks['PreToolUse']).toHaveLength(1);
+    expect(hooks['PostToolUse']).toHaveLength(1);
+    expect(hooks['Stop']).toHaveLength(1);
+  });
+
+  it('installHooks is idempotent', () => {
+    installHooks();
+    installHooks();
+    const hooks = readHooksFile().hooks as Record<string, unknown[]>;
+    expect(hooks['SessionStart']).toHaveLength(1);
+    expect(hooks['PreToolUse']).toHaveLength(1);
+  });
+
+  it('areHooksInstalled tracks install state', () => {
+    expect(areHooksInstalled()).toBe(false);
+    installHooks();
+    expect(areHooksInstalled()).toBe(true);
+  });
+
+  it('uninstallHooks removes Pixel Agents entries', () => {
+    installHooks();
+    uninstallHooks();
+    expect(areHooksInstalled()).toBe(false);
+    expect(readHooksFile().hooks).toBeUndefined();
+  });
+
+  it('copyHookScript copies to ~/.pixel-agents/hooks/', () => {
+    const mockExtPath = path.join(tmpBase, 'mock-ext');
+    const hookSrc = path.join(mockExtPath, 'dist', 'hooks');
+    fs.mkdirSync(hookSrc, { recursive: true });
+    fs.writeFileSync(path.join(hookSrc, 'codex-hook.js'), '// mock hook script');
+
+    copyHookScript(mockExtPath);
+
+    const dst = path.join(tmpBase, '.pixel-agents', 'hooks', 'codex-hook.js');
+    expect(fs.existsSync(dst)).toBe(true);
+    expect(fs.readFileSync(dst, 'utf-8')).toBe('// mock hook script');
+  });
+});

--- a/server/__tests__/providerHotSwap.test.ts
+++ b/server/__tests__/providerHotSwap.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { claudeProvider, codexProvider, resolveProvider } from '../src/providers/index.js';
+import { setHookProvider as setTranscriptProvider } from '../src/transcriptParser.js';
+import { setHookProvider as setWatcherProvider } from '../src/fileWatcher.js';
+
+describe('provider hot-swap', () => {
+  it('re-injects provider into transcript parser and file watcher', () => {
+    setTranscriptProvider(claudeProvider);
+    setWatcherProvider(claudeProvider);
+    expect(resolveProvider('claude-code').id).toBe('claude');
+
+    setTranscriptProvider(codexProvider);
+    setWatcherProvider(codexProvider);
+    expect(resolveProvider('codex').id).toBe('codex');
+
+    setTranscriptProvider(claudeProvider);
+    setWatcherProvider(claudeProvider);
+    expect(resolveProvider('').id).toBe('claude');
+  });
+
+  it('falls back to Claude for unknown engine values', () => {
+    expect(resolveProvider('copilot').id).toBe('claude');
+    expect(resolveProvider('unknown-engine').id).toBe('claude');
+  });
+});

--- a/server/__tests__/providerHotSwap.test.ts
+++ b/server/__tests__/providerHotSwap.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { setHookProvider as setWatcherProvider } from '../src/fileWatcher.js';
 import { claudeProvider, codexProvider, resolveProvider } from '../src/providers/index.js';
 import { setHookProvider as setTranscriptProvider } from '../src/transcriptParser.js';
-import { setHookProvider as setWatcherProvider } from '../src/fileWatcher.js';
 
 describe('provider hot-swap', () => {
   it('re-injects provider into transcript parser and file watcher', () => {

--- a/server/__tests__/rebindLaunchedSession.test.ts
+++ b/server/__tests__/rebindLaunchedSession.test.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { DismissalTracker } from '../src/dismissalTracker.js';
+import { rebindLaunchedSessionFromHook, setDismissalTracker } from '../src/fileWatcher.js';
+import type { AgentState } from '../src/types.js';
+
+let tmpBase: string;
+
+describe('rebindLaunchedSessionFromHook', () => {
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-rebind-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('rebinds a launched agent to the real Codex transcript', () => {
+    const projectDir = path.join(tmpBase, 'sessions', '2026', '06', '08');
+    fs.mkdirSync(projectDir, { recursive: true });
+    const transcriptPath = path.join(projectDir, 'rollout-abc.jsonl');
+    fs.writeFileSync(transcriptPath, '{"type":"session_meta"}\n');
+
+    setDismissalTracker(new DismissalTracker());
+
+    const store = new AgentStateStore();
+    const knownJsonlFiles = new Set<string>();
+    const fileWatchers = new Map<number, fs.FSWatcher>();
+    const pollingTimers = new Map<number, ReturnType<typeof setInterval>>();
+    const waitingTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    const permissionTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+    const agent: AgentState = {
+      id: 1,
+      sessionId: 'placeholder-uuid',
+      terminalRef: undefined,
+      isExternal: false,
+      projectDir,
+      jsonlFile: path.join(projectDir, '__pending__.jsonl'),
+      fileOffset: 0,
+      lineBuffer: '',
+      activeToolIds: new Set(),
+      activeToolStatuses: new Map(),
+      activeToolNames: new Map(),
+      activeSubagentToolIds: new Map(),
+      activeSubagentToolNames: new Map(),
+      backgroundAgentToolIds: new Set(),
+      isWaiting: false,
+      permissionSent: false,
+      hadToolsInTurn: false,
+      lastDataAt: 0,
+      linesProcessed: 0,
+      seenUnknownRecordTypes: new Set(),
+      hookDelivered: false,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    store.set(1, agent);
+
+    let reboundSessionId = '';
+    let previousSessionId = '';
+    const bound = rebindLaunchedSessionFromHook(
+      'real-codex-session',
+      transcriptPath,
+      '/workspace/pixel-agents',
+      knownJsonlFiles,
+      store,
+      fileWatchers,
+      pollingTimers,
+      waitingTimers,
+      permissionTimers,
+      () => {},
+      (rebound, prev) => {
+        reboundSessionId = rebound.sessionId;
+        previousSessionId = prev;
+      },
+    );
+
+    expect(bound).toBe(true);
+    expect(previousSessionId).toBe('placeholder-uuid');
+    expect(reboundSessionId).toBe('real-codex-session');
+    expect(store.get(1)?.jsonlFile).toBe(transcriptPath);
+    expect(store.get(1)?.hookDelivered).toBe(true);
+    expect(knownJsonlFiles.has(transcriptPath)).toBe(true);
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "fastify": "^5.8.5"
       },
       "devDependencies": {
+        "fast-check": "^4.8.0",
         "vitest": "^3.2.1"
       }
     },
@@ -1527,6 +1528,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -2051,6 +2075,23 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
         }
       ],
       "license": "MIT"

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "fast-check": "^4.8.0",
     "vitest": "^3.2.1"
   },
   "dependencies": {

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -20,6 +20,7 @@ import {
   ensureProjectScan,
   isTrackedProjectDir,
   reassignAgentToFile,
+  rebindLaunchedSessionFromHook,
   resetProviderScanState,
   scanForTeammateFiles,
   setAgentRemovalCallback,
@@ -101,8 +102,34 @@ export class AgentRuntime {
       this.watchAllSessions,
     );
 
+    const onAgentRebound = (agent: AgentState, previousSessionId: string): void => {
+      if (previousSessionId !== agent.sessionId) {
+        this.unregisterAgent(previousSessionId);
+      }
+      this.registerAgent(agent.sessionId, agent.id);
+    };
+
     // Wire hook lifecycle callbacks to shared agent operations
     handler.setLifecycleCallbacks({
+      onLaunchedSessionStart: (sessionId, transcriptPath, cwd) => {
+        const projectDir = path.dirname(transcriptPath);
+        if (!isTrackedProjectDir(projectDir) && !this.watchAllSessions.current) {
+          return false;
+        }
+        return rebindLaunchedSessionFromHook(
+          sessionId,
+          transcriptPath,
+          cwd,
+          this.knownJsonlFiles,
+          this.store,
+          this.fileWatchers,
+          this.pollingTimers,
+          this.waitingTimers,
+          this.permissionTimers,
+          () => this.store.persist(),
+          onAgentRebound,
+        );
+      },
       onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
         const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
         if (!isTrackedProjectDir(projectDir) && !this.watchAllSessions.current) {
@@ -121,6 +148,7 @@ export class AgentRuntime {
           this.permissionTimers,
           () => this.store.persist(),
           (agent) => this.registerAgent(agent.sessionId, agent.id),
+          onAgentRebound,
         );
       },
       onSessionClear: (agentId, newSessionId, newTranscriptPath) => {

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -20,6 +20,7 @@ import {
   ensureProjectScan,
   isTrackedProjectDir,
   reassignAgentToFile,
+  resetProviderScanState,
   scanForTeammateFiles,
   setAgentRemovalCallback,
   setDismissalTracker,
@@ -66,6 +67,7 @@ export class AgentRuntime {
 
   // Dependencies
   readonly dismissalTracker = new DismissalTracker();
+  private provider: HookProvider;
   private hookEventHandler: HookEventHandler;
   private lifecycleCallbacks: RuntimeLifecycleCallbacks = {};
 
@@ -73,18 +75,25 @@ export class AgentRuntime {
     private readonly store: AgentStateStore,
     provider: HookProvider,
   ) {
+    this.provider = provider;
     // Wire module-level dependencies
     setDismissalTracker(this.dismissalTracker);
-    setHookProvider(provider);
-    setFileWatcherHookProvider(provider);
-    if (provider.team) {
-      setTeamProvider(provider.team);
-    }
+    this.configureProvider(provider);
     setAgentRemovalCallback((id) => this.removeAgent(id));
     setTeammateRemovalCallback((id) => this.removeTeammate(id, 'team-config'));
 
-    this.hookEventHandler = new HookEventHandler(
-      store,
+    this.hookEventHandler = this.createHookEventHandler(provider);
+  }
+
+  private configureProvider(provider: HookProvider): void {
+    setHookProvider(provider);
+    setFileWatcherHookProvider(provider);
+    setTeamProvider(provider.team ?? null);
+  }
+
+  private createHookEventHandler(provider: HookProvider): HookEventHandler {
+    const handler = new HookEventHandler(
+      this.store,
       this.waitingTimers,
       this.permissionTimers,
       provider,
@@ -93,7 +102,7 @@ export class AgentRuntime {
     );
 
     // Wire hook lifecycle callbacks to shared agent operations
-    this.hookEventHandler.setLifecycleCallbacks({
+    handler.setLifecycleCallbacks({
       onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
         const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
         if (!isTrackedProjectDir(projectDir) && !this.watchAllSessions.current) {
@@ -174,11 +183,26 @@ export class AgentRuntime {
         }
       },
     });
+
+    return handler;
   }
 
   /** Register adapter-specific lifecycle callbacks. */
   setLifecycleCallbacks(callbacks: RuntimeLifecycleCallbacks): void {
     this.lifecycleCallbacks = callbacks;
+  }
+
+  /** Switch the active provider while keeping existing agent state. */
+  setProvider(provider: HookProvider): void {
+    if (provider.id === this.provider.id) return;
+    this.hookEventHandler.dispose();
+    resetProviderScanState();
+    this.provider = provider;
+    this.configureProvider(provider);
+    this.hookEventHandler = this.createHookEventHandler(provider);
+    for (const [id, agent] of this.store) {
+      this.registerAgent(agent.sessionId, id);
+    }
   }
 
   // ── Hook event routing ──

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -21,7 +21,7 @@ import {
 } from './assetLoader.js';
 import type { AssetCache } from './clientMessageHandler.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { claudeProvider, copyHookScript } from './providers/index.js';
+import { copyProviderHookScript, resolveProvider } from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
 
 // ── Argument parsing ──────────────────────────────────────────
@@ -29,6 +29,7 @@ import { PixelAgentsServer } from './server.js';
 interface CliArgs {
   port: number;
   host: string;
+  agentEngine?: string;
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -40,12 +41,16 @@ function parseArgs(argv: string[]): CliArgs {
     } else if (argv[i] === '--host' && argv[i + 1]) {
       args.host = argv[i + 1];
       i++;
+    } else if (argv[i] === '--agent-engine' && argv[i + 1]) {
+      args.agentEngine = argv[i + 1];
+      i++;
     } else if (argv[i] === '--help') {
       console.log(`Usage: pixel-agents [options]
 
 Options:
   --port, -p <number>   Port to listen on (default: 3100)
   --host <string>       Host to bind to (default: 127.0.0.1)
+  --agent-engine <id>   Agent engine to observe: claude-code or codex
   --help                Show this help message`);
       process.exit(0);
     }
@@ -57,6 +62,7 @@ Options:
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  const provider = resolveProvider(args.agentEngine ?? process.env.PIXEL_AGENTS_AGENT_ENGINE);
 
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
@@ -87,7 +93,7 @@ async function main(): Promise<void> {
 
   try {
     // Create runtime first (before server.start, so we can pass it in)
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, provider);
 
     // Wire hook events: HTTP POST -> runtime -> hookEventHandler -> agents
     server.onHookEvent((providerId, event) => {
@@ -100,14 +106,11 @@ async function main(): Promise<void> {
     const onSetHooksEnabled = async (enabled: boolean): Promise<void> => {
       if (!currentConfig) return;
       if (enabled) {
-        await claudeProvider.installHooks(
-          `http://127.0.0.1:${currentConfig.port}`,
-          currentConfig.token,
-        );
-        copyHookScript(distRoot);
+        await provider.installHooks(`http://127.0.0.1:${currentConfig.port}`, currentConfig.token);
+        copyProviderHookScript(provider.id, distRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
-        await claudeProvider.uninstallHooks();
+        await provider.uninstallHooks();
         console.log('[Pixel Agents] Hooks uninstalled (user toggle)');
       }
     };
@@ -115,6 +118,7 @@ async function main(): Promise<void> {
     const config = await server.start({
       store,
       runtime,
+      provider,
       embedded: false,
       host: args.host,
       port: args.port,
@@ -131,17 +135,17 @@ async function main(): Promise<void> {
     // Install hooks on startup if the persisted setting says so
     if (runtime.hooksEnabled.current) {
       try {
-        await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        await provider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
+        copyProviderHookScript(provider.id, distRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);
       }
     }
 
-    // Start scanning for external sessions (Claude running in user's terminal)
+    // Start scanning for external sessions (selected agent running in user's terminal)
     const cwd = process.cwd();
-    const dirs = claudeProvider.getSessionDirs?.(cwd);
+    const dirs = provider.getSessionDirs?.(cwd);
     if (dirs && dirs[0]) {
       const projectDir = dirs[0];
       console.log(`[Pixel Agents] Scanning project dir: ${projectDir}`);

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -179,6 +179,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     hooksEnabled,
     hooksInfoShown: adapter?.getSetting(KEY_HOOKS_INFO_SHOWN, false) ?? false,
     externalAssetDirectories: cfg.externalAssetDirectories,
+    agentEngine: ctx.provider.id === 'codex' ? 'codex' : 'claude-code',
   });
 
   // Sync runtime refs with the persisted settings so scanners behave correctly

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -1,9 +1,9 @@
+import type { HookProvider } from '../../core/src/provider.js';
 import type { AgentRuntime } from './agentRuntime.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import type { LoadedAssets, LoadedCharacterSprites } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
 import { readLayoutFromFile, writeLayoutToFile } from './layoutPersistence.js';
-import { claudeProvider } from './providers/index.js';
 
 type WsSend = (message: Record<string, unknown>) => void;
 
@@ -22,6 +22,7 @@ export interface AssetCache {
 export interface ClientMessageContext {
   store: AgentStateStore;
   runtime?: AgentRuntime;
+  provider: HookProvider;
   cache: AssetCache | null;
   /** Install/uninstall hooks side effect. Needs server url+token known only to cli.ts. */
   onSetHooksEnabled?: SetHooksEnabledSideEffect;
@@ -130,14 +131,14 @@ export function handleClientMessage(
 }
 
 function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
-  const { store, runtime, cache } = ctx;
+  const { store, runtime, provider, cache } = ctx;
   const adapter = store.getAdapter();
 
   // 1. Provider capabilities (must arrive before any agent messages)
   send({
     type: 'providerCapabilities',
-    readingTools: [...claudeProvider.readingTools],
-    subagentToolNames: [...claudeProvider.subagentToolNames],
+    readingTools: [...provider.readingTools],
+    subagentToolNames: [...provider.subagentToolNames],
   });
 
   // 2. Assets (from server cache, loaded at startup via pngjs)

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -798,6 +798,51 @@ export function scanAllTeammateFiles(
 
 // ── External session support (VS Code extension panel, etc.) ──
 
+/** Rebind a launched terminal to its real transcript on SessionStart (Codex, etc.). */
+export function rebindLaunchedSessionFromHook(
+  sessionId: string,
+  transcriptPath: string,
+  cwd: string,
+  knownJsonlFiles: Set<string>,
+  agents: AgentStateStore,
+  fileWatchers: Map<number, fs.FSWatcher>,
+  pollingTimers: Map<number, ReturnType<typeof setInterval>>,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+  persistAgents: () => void,
+  onAgentRebound: (agent: AgentState, previousSessionId: string) => void,
+): boolean {
+  const projectDir = path.dirname(transcriptPath);
+  const pendingAgent = findPendingInternalAgentForSession(projectDir, agents);
+  if (!pendingAgent) return false;
+
+  const previousSessionId = pendingAgent.sessionId;
+  knownJsonlFiles.add(transcriptPath);
+  reassignAgentToFile(
+    pendingAgent.id,
+    transcriptPath,
+    agents,
+    fileWatchers,
+    pollingTimers,
+    waitingTimers,
+    permissionTimers,
+    persistAgents,
+  );
+  pendingAgent.sessionId = sessionId;
+  pendingAgent.folderName = cwd
+    ? path.basename(cwd)
+    : folderNameFromSessionFile(transcriptPath, projectDir);
+  pendingAgent.hookDelivered = true;
+  persistAgents();
+  onAgentRebound(pendingAgent, previousSessionId);
+  if (debug) {
+    console.log(
+      `[Pixel Agents] Hook: Agent ${pendingAgent.id} - rebound launched terminal to ${path.basename(transcriptPath)}`,
+    );
+  }
+  return true;
+}
+
 /**
  * Adopt an external session detected via hooks (SessionStart for unknown session_id).
  * Thinner wrapper than filesystem-based adoptExternalSession: hooks provide
@@ -817,6 +862,7 @@ export function adoptExternalSessionFromHook(
 
   persistAgents: () => void,
   onAgentCreated?: (agent: AgentState) => void,
+  onAgentRebound?: (agent: AgentState, previousSessionId: string) => void,
 ): void {
   if (transcriptPath) {
     // File-based provider (Claude, Codex): adopt with JSONL file watching
@@ -837,6 +883,7 @@ export function adoptExternalSessionFromHook(
 
     const pendingAgent = findPendingInternalAgentForSession(projectDir, agents);
     if (pendingAgent) {
+      const previousSessionId = pendingAgent.sessionId;
       reassignAgentToFile(
         pendingAgent.id,
         transcriptPath,
@@ -851,7 +898,11 @@ export function adoptExternalSessionFromHook(
       pendingAgent.folderName = folderName;
       pendingAgent.hookDelivered = true;
       persistAgents();
-      onAgentCreated?.(pendingAgent);
+      if (onAgentRebound) {
+        onAgentRebound(pendingAgent, previousSessionId);
+      } else {
+        onAgentCreated?.(pendingAgent);
+      }
       if (debug) {
         console.log(
           `[Pixel Agents] Hook: Agent ${pendingAgent.id} - rebound launched terminal to ${path.basename(transcriptPath)}${folderName ? ` (${folderName})` : ''}`,

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -560,13 +560,20 @@ export function setTeammateRemovalCallback(cb: (teammateAgentId: number) => void
 }
 
 /** Register the TeamProvider that describes the active CLI's Lead+Teammates pattern. */
-export function setTeamProvider(provider: TeamProvider): void {
+export function setTeamProvider(provider: TeamProvider | null): void {
   teamProvider = provider;
 }
 
 /** Register the active HookProvider for non-team capabilities (session roots, etc.). */
 export function setHookProvider(provider: HookProvider): void {
   hookProvider = provider;
+}
+
+/** Clear provider-scoped scan state when the active provider changes. */
+export function resetProviderScanState(): void {
+  trackedProjectDirs.clear();
+  clearDetectionDeps = null;
+  knownTeammateFiles.clear();
 }
 
 /**
@@ -824,7 +831,34 @@ export function adoptExternalSessionFromHook(
 
     knownJsonlFiles.add(transcriptPath);
     const projectDir = path.dirname(transcriptPath);
-    const folderName = folderNameFromProjectDir(path.basename(projectDir));
+    const folderName = cwd
+      ? path.basename(cwd)
+      : folderNameFromSessionFile(transcriptPath, projectDir);
+
+    const pendingAgent = findPendingInternalAgentForSession(projectDir, agents);
+    if (pendingAgent) {
+      reassignAgentToFile(
+        pendingAgent.id,
+        transcriptPath,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        persistAgents,
+      );
+      pendingAgent.sessionId = sessionId;
+      pendingAgent.folderName = folderName;
+      pendingAgent.hookDelivered = true;
+      persistAgents();
+      onAgentCreated?.(pendingAgent);
+      if (debug) {
+        console.log(
+          `[Pixel Agents] Hook: Agent ${pendingAgent.id} - rebound launched terminal to ${path.basename(transcriptPath)}${folderName ? ` (${folderName})` : ''}`,
+        );
+      }
+      return;
+    }
 
     adoptExternalSession(
       transcriptPath,
@@ -1129,7 +1163,10 @@ export function scanExternalDir(
     }
 
     knownJsonlFiles.add(file);
-    console.log(`[Pixel Agents] Watcher: detected external session ${path.basename(file)}`);
+    const folderName = folderNameFromSessionFile(file, projectDir);
+    console.log(
+      `[Pixel Agents] Watcher: detected external session ${path.basename(file)}${folderName ? ` (${folderName})` : ''}`,
+    );
     adoptExternalSession(
       file,
       projectDir,
@@ -1140,6 +1177,7 @@ export function scanExternalDir(
       waitingTimers,
       permissionTimers,
       persistAgents,
+      folderName,
     );
   }
 }
@@ -1148,6 +1186,43 @@ export function scanExternalDir(
 function folderNameFromProjectDir(dirName: string): string {
   const parts = dirName.replace(/^-+/, '').split('-');
   return parts[parts.length - 1] || dirName;
+}
+
+function folderNameFromSessionFile(jsonlFile: string, projectDir: string): string {
+  try {
+    const fd = fs.openSync(jsonlFile, 'r');
+    const buf = Buffer.alloc(16384);
+    const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+    fs.closeSync(fd);
+    const lines = buf.toString('utf-8', 0, bytesRead).split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const record = JSON.parse(line) as Record<string, unknown>;
+      const payload = record.payload as Record<string, unknown> | undefined;
+      const cwd = payload?.cwd;
+      if (record.type === 'session_meta' && typeof cwd === 'string') {
+        return path.basename(cwd);
+      }
+    }
+  } catch {
+    /* fall back to provider directory name */
+  }
+  return folderNameFromProjectDir(path.basename(projectDir));
+}
+
+function findPendingInternalAgentForSession(
+  projectDir: string,
+  agents: AgentStateStore,
+): AgentState | undefined {
+  for (const agent of agents.values()) {
+    if (agent.isExternal || agent.projectDir !== projectDir) continue;
+    try {
+      fs.statSync(agent.jsonlFile);
+    } catch {
+      return agent;
+    }
+  }
+  return undefined;
 }
 
 /** Scan every session root the active provider exposes for active sessions
@@ -1168,14 +1243,7 @@ function scanGlobalProjectDirs(
 
   const projectDirs: string[] = [];
   for (const root of roots) {
-    try {
-      const entries = fs.readdirSync(root, { withFileTypes: true });
-      for (const entry of entries) {
-        if (entry.isDirectory()) projectDirs.push(path.join(root, entry.name));
-      }
-    } catch {
-      // root missing / unreadable -> skip
-    }
+    projectDirs.push(...collectSessionDirs(root));
   }
 
   const now = Date.now();
@@ -1212,7 +1280,7 @@ function scanGlobalProjectDirs(
         continue;
       }
 
-      const folderName = folderNameFromProjectDir(path.basename(dirPath));
+      const folderName = folderNameFromSessionFile(file, dirPath);
       knownJsonlFiles.add(file);
       console.log(
         `[Pixel Agents] Watcher: detected global session ${path.basename(file)} (${folderName})`,
@@ -1231,6 +1299,27 @@ function scanGlobalProjectDirs(
       );
     }
   }
+}
+
+function collectSessionDirs(root: string, maxDepth = 4): string[] {
+  const dirs: string[] = [];
+  function visit(dir: string, depth: number): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    if (entries.some((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))) {
+      dirs.push(dir);
+    }
+    if (depth >= maxDepth) return;
+    for (const entry of entries) {
+      if (entry.isDirectory()) visit(path.join(dir, entry.name), depth + 1);
+    }
+  }
+  visit(root, 0);
+  return dirs;
 }
 
 /**

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -53,6 +53,9 @@ interface SessionLifecycleCallbacks {
   /** Called when a teammate should be removed (e.g. no longer in team config members).
    *  Removes the teammate agent from the office. */
   onTeammateRemoved?: (teammateAgentId: number) => void;
+  /** Called on SessionStart when a launched terminal awaits its real transcript file
+   *  (e.g. Codex without --session-id). Return true when bound to an existing agent. */
+  onLaunchedSessionStart?: (sessionId: string, transcriptPath: string, cwd: string) => boolean;
 }
 
 export class HookEventHandler {
@@ -208,6 +211,18 @@ export class HookEventHandler {
           }
         }
       }
+      // Bind launched terminal waiting for real transcript (Codex rollout files, etc.)
+      if (
+        transcriptPath &&
+        this.lifecycleCallbacks.onLaunchedSessionStart?.(
+          event.session_id,
+          transcriptPath,
+          cwd ?? '',
+        )
+      ) {
+        return;
+      }
+
       // Unknown session -- store as pending, create only when a confirmation event
       // arrives (Stop, Notification, PermissionRequest). This filters transient sessions
       // from Claude Code Extension which fire SessionStart + SessionEnd without any activity.

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -5,6 +5,7 @@ import * as crypto from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import Fastify from 'fastify';
 
+import type { HookProvider } from '../../core/src/provider.js';
 import type { AgentRuntime } from './agentRuntime.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import type { AssetCache, SetHooksEnabledSideEffect } from './clientMessageHandler.js';
@@ -24,6 +25,8 @@ export interface HttpServerOptions {
   token: string;
   /** AgentStateStore for WebSocket broadcast piping */
   store: AgentStateStore;
+  /** Active provider for standalone WebSocket capability messages. */
+  provider: HookProvider;
   /** Shared agent lifecycle core (for toggle side effects + standalone restore). Optional in embedded mode. */
   runtime?: AgentRuntime;
   /** Path to SPA dist directory for static serving (standalone only) */
@@ -186,6 +189,7 @@ function registerWebSocketRoute(app: FastifyInstance, options: HttpServerOptions
         handleClientMessage(msg, (m) => safeSend(socket, m), {
           store,
           runtime: options.runtime,
+          provider: options.provider,
           cache: options.assetCache ?? null,
           onSetHooksEnabled: options.onSetHooksEnabled,
         });

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -1,0 +1,311 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import { BASH_COMMAND_DISPLAY_MAX_LENGTH } from '../../../constants.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './codexHookInstaller.js';
+import { CODEX_TERMINAL_NAME_PREFIX } from './constants.js';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? value.slice(0, maxLength) + '\u2026' : value;
+}
+
+function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = asRecord(input);
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+  switch (toolName) {
+    case 'exec_command':
+    case 'Bash': {
+      const cmd = stringField(inp, 'cmd') ?? stringField(inp, 'command') ?? '';
+      return `Running: ${truncate(cmd, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`;
+    }
+    case 'apply_patch':
+      return 'Editing files';
+    case 'read_mcp_resource':
+      return 'Reading resource';
+    case 'list_mcp_resources':
+    case 'list_mcp_resource_templates':
+      return 'Listing resources';
+    case 'tool_search':
+    case 'tool_search_tool':
+      return 'Searching tools';
+    case 'web.run':
+    case 'web_search':
+      return 'Searching the web';
+    case 'view_image':
+      return `Viewing ${base(inp.path)}`;
+    case 'open':
+      return 'Opening page';
+    case 'spawn_agent': {
+      const name = stringField(inp, 'name') ?? stringField(inp, 'agent_type');
+      return name ? `Subtask: ${name}` : 'Running subtask';
+    }
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+function getCodexHome(): string {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+function codexSessionDirForOffset(offsetDays: number): string {
+  const date = new Date(Date.now() - offsetDays * 24 * 60 * 60 * 1000);
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return path.join(getCodexHome(), 'sessions', year, month, day);
+}
+
+function getSessionDirs(_workspacePath: string): string[] {
+  return [codexSessionDirForOffset(0), codexSessionDirForOffset(1)];
+}
+
+function getAllSessionRoots(): string[] {
+  return [path.join(getCodexHome(), 'sessions')];
+}
+
+function buildLaunchCommand(
+  _sessionId: string,
+  cwd: string,
+  opts?: { bypassPermissions?: boolean },
+): { command: string; args: string[]; env?: Record<string, string> } {
+  const args: string[] = [];
+  if (opts?.bypassPermissions) {
+    args.push('--dangerously-bypass-approvals-and-sandbox');
+  }
+  return { command: 'codex', args, env: { PWD: cwd } };
+}
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = stringField(raw, 'hook_event_name');
+  const sessionId = stringField(raw, 'session_id');
+  if (!eventName || !sessionId) return null;
+
+  switch (eventName) {
+    case 'PreToolUse': {
+      const toolInput = asRecord(raw.tool_input ?? raw.input);
+      return {
+        sessionId,
+        event: {
+          kind: 'toolStart',
+          toolId: stringField(raw, 'tool_use_id') ?? `hook-${Date.now()}`,
+          toolName: stringField(raw, 'tool_name') ?? '',
+          input: toolInput,
+          runInBackground:
+            toolInput.run_in_background === true || toolInput.runInBackground === true,
+        },
+      };
+    }
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      return {
+        sessionId,
+        event: { kind: 'toolEnd', toolId: stringField(raw, 'tool_use_id') ?? 'current' },
+      };
+    case 'Stop':
+      return { sessionId, event: { kind: 'turnEnd' } };
+    case 'PermissionRequest':
+      return { sessionId, event: { kind: 'permissionRequest' } };
+    case 'SubagentStart': {
+      const toolInput = asRecord(raw);
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId:
+            stringField(raw, 'parent_tool_use_id') ??
+            stringField(raw, 'parentToolUseId') ??
+            'current',
+          toolId: stringField(raw, 'tool_use_id') ?? `hook-sub-${Date.now()}`,
+          toolName:
+            stringField(raw, 'agent_type') ??
+            stringField(raw, 'subagent_type') ??
+            stringField(raw, 'tool_name') ??
+            'subagent',
+          input: toolInput,
+          runInBackground: raw.run_in_background === true || raw.runInBackground === true,
+        },
+      };
+    }
+    case 'SubagentStop':
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentEnd',
+          parentToolId:
+            stringField(raw, 'parent_tool_use_id') ??
+            stringField(raw, 'parentToolUseId') ??
+            'current',
+          toolId: stringField(raw, 'tool_use_id') ?? 'current',
+        },
+      };
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: stringField(raw, 'source'),
+          transcriptPath: stringField(raw, 'transcript_path'),
+          cwd: stringField(raw, 'cwd'),
+        },
+      };
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: { kind: 'sessionEnd', reason: stringField(raw, 'reason') },
+      };
+    case 'UserPromptSubmit':
+    case 'PreCompact':
+    case 'PostCompact':
+    default:
+      return null;
+  }
+}
+
+function parseTranscriptLine(line: string): AgentEvent | null {
+  let record: Record<string, unknown>;
+  try {
+    record = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const recordType = stringField(record, 'type');
+  if (recordType === 'session_meta') {
+    const payload = asRecord(record.payload);
+    return {
+      kind: 'sessionStart',
+      source: stringField(payload, 'source'),
+      cwd: stringField(payload, 'cwd'),
+    };
+  }
+
+  if (recordType === 'event_msg') {
+    const payload = asRecord(record.payload);
+    if (stringField(payload, 'type') === 'task_complete') {
+      return { kind: 'turnEnd' };
+    }
+    return null;
+  }
+
+  if (recordType !== 'response_item') return null;
+
+  const payload = asRecord(record.payload);
+  const payloadType = stringField(payload, 'type');
+  switch (payloadType) {
+    case 'function_call':
+      return {
+        kind: 'toolStart',
+        toolId: stringField(payload, 'call_id') ?? `call-${Date.now()}`,
+        toolName: stringField(payload, 'name') ?? 'function_call',
+        input: safeJsonParse(payload.arguments),
+      };
+    case 'function_call_output':
+      return { kind: 'toolEnd', toolId: stringField(payload, 'call_id') ?? 'current' };
+    case 'tool_search_call':
+      return {
+        kind: 'toolStart',
+        toolId: stringField(payload, 'call_id') ?? `tool-search-${Date.now()}`,
+        toolName: 'tool_search',
+        input: safeJsonParse(payload.args ?? payload.arguments),
+      };
+    case 'tool_search_output':
+      return { kind: 'toolEnd', toolId: stringField(payload, 'call_id') ?? 'current' };
+    case 'custom_tool_call':
+      return {
+        kind: 'toolStart',
+        toolId: stringField(payload, 'call_id') ?? `custom-${Date.now()}`,
+        toolName: stringField(payload, 'name') ?? 'custom_tool',
+        input: safeJsonParse(payload.input ?? payload.arguments),
+      };
+    case 'custom_tool_call_output':
+      return { kind: 'toolEnd', toolId: stringField(payload, 'call_id') ?? 'current' };
+    case 'patch_apply_end':
+    case 'mcp_tool_call_end': {
+      const callId = stringField(payload, 'call_id');
+      return callId ? { kind: 'toolEnd', toolId: callId } : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  installerInstallHooks();
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  installerUninstallHooks();
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(installerAreHooksInstalled());
+}
+
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: 'codex',
+  displayName: 'Codex',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  permissionExemptTools: new Set([
+    'list_mcp_resources',
+    'list_mcp_resource_templates',
+    'read_mcp_resource',
+    'tool_search',
+    'tool_search_tool',
+    'view_image',
+  ]),
+  subagentToolNames: new Set(['spawn_agent']),
+  readingTools: new Set([
+    'list_mcp_resources',
+    'list_mcp_resource_templates',
+    'read_mcp_resource',
+    'tool_search',
+    'tool_search_tool',
+    'view_image',
+    'web.run',
+    'web_search',
+  ]),
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+
+  getSessionDirs,
+  getAllSessionRoots,
+  sessionFilePattern: '*.jsonl',
+  parseTranscriptLine,
+  buildLaunchCommand,
+};

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -23,6 +23,10 @@ function truncate(value: string, maxLength: number): string {
   return value.length > maxLength ? value.slice(0, maxLength) + '\u2026' : value;
 }
 
+function displayStatus(value: string): string {
+  return truncate(value, 80);
+}
+
 function safeJsonParse(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   try {
@@ -39,7 +43,7 @@ export function formatToolStatus(toolName: string, input?: unknown): string {
     case 'exec_command':
     case 'Bash': {
       const cmd = stringField(inp, 'cmd') ?? stringField(inp, 'command') ?? '';
-      return `Running: ${truncate(cmd, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`;
+      return displayStatus(`Running: ${truncate(cmd, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`);
     }
     case 'apply_patch':
       return 'Editing files';
@@ -55,15 +59,15 @@ export function formatToolStatus(toolName: string, input?: unknown): string {
     case 'web_search':
       return 'Searching the web';
     case 'view_image':
-      return `Viewing ${base(inp.path)}`;
+      return displayStatus(`Viewing ${base(inp.path)}`);
     case 'open':
       return 'Opening page';
     case 'spawn_agent': {
       const name = stringField(inp, 'name') ?? stringField(inp, 'agent_type');
-      return name ? `Subtask: ${name}` : 'Running subtask';
+      return name ? displayStatus(`Subtask: ${name}`) : 'Running subtask';
     }
     default:
-      return `Using ${toolName}`;
+      return displayStatus(`Using ${toolName}`);
   }
 }
 

--- a/server/src/providers/hook/codex/codexHookInstaller.ts
+++ b/server/src/providers/hook/codex/codexHookInstaller.ts
@@ -1,0 +1,165 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_SCRIPTS_DIR } from '../../../constants.js';
+import { CODEX_HOOK_EVENTS, CODEX_HOOK_SCRIPT_NAME } from './constants.js';
+
+const HOOK_SCRIPT_MARKER = CODEX_HOOK_SCRIPT_NAME;
+
+interface CodexHookEntry {
+  matcher: string;
+  hooks: Array<{
+    type: string;
+    command: string;
+    timeout?: number;
+  }>;
+}
+
+interface CodexHooksFile {
+  hooks?: Record<string, CodexHookEntry[]>;
+  [key: string]: unknown;
+}
+
+function getCodexHome(): string {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+function getCodexHooksPath(): string {
+  return path.join(getCodexHome(), 'hooks.json');
+}
+
+function getHookScriptPath(): string {
+  return path.join(os.homedir(), HOOK_SCRIPTS_DIR, CODEX_HOOK_SCRIPT_NAME);
+}
+
+function readCodexHooksFile(): CodexHooksFile {
+  const hooksPath = getCodexHooksPath();
+  try {
+    if (fs.existsSync(hooksPath)) {
+      return JSON.parse(fs.readFileSync(hooksPath, 'utf-8')) as CodexHooksFile;
+    }
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to read Codex hooks config: ${e}`);
+  }
+  return {};
+}
+
+function writeCodexHooksFile(settings: CodexHooksFile): void {
+  const hooksPath = getCodexHooksPath();
+  const dir = path.dirname(hooksPath);
+  try {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    const tmpPath = hooksPath + '.pixel-agents-tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(settings, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, hooksPath);
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to write Codex hooks config: ${e}`);
+  }
+}
+
+function isOurHookEntry(entry: CodexHookEntry): boolean {
+  return entry.hooks.some((h) => h.command.includes(HOOK_SCRIPT_MARKER));
+}
+
+function makeHookCommand(): string {
+  return `node "${getHookScriptPath()}"`;
+}
+
+function makeHookEntry(): CodexHookEntry {
+  return {
+    matcher: '',
+    hooks: [
+      {
+        type: 'command',
+        command: makeHookCommand(),
+        timeout: 5,
+      },
+    ],
+  };
+}
+
+export function areHooksInstalled(): boolean {
+  const settings = readCodexHooksFile();
+  if (!settings.hooks) return false;
+  return CODEX_HOOK_EVENTS.every((event) => {
+    const entries = settings.hooks?.[event];
+    return Array.isArray(entries) && entries.some(isOurHookEntry);
+  });
+}
+
+export function installHooks(): void {
+  const settings = readCodexHooksFile();
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  let changed = false;
+  for (const event of CODEX_HOOK_EVENTS) {
+    if (!Array.isArray(settings.hooks[event])) {
+      settings.hooks[event] = [];
+    }
+    const entries = settings.hooks[event];
+    const filtered = entries.filter((e) => !isOurHookEntry(e));
+    filtered.push(makeHookEntry());
+    if (JSON.stringify(filtered) !== JSON.stringify(entries)) {
+      settings.hooks[event] = filtered;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeCodexHooksFile(settings);
+    console.log('[Pixel Agents] Hooks installed in ~/.codex/hooks.json');
+  }
+}
+
+export function uninstallHooks(): void {
+  const settings = readCodexHooksFile();
+  if (!settings.hooks) return;
+
+  let changed = false;
+  for (const event of Object.keys(settings.hooks)) {
+    const entries = settings.hooks[event];
+    if (!Array.isArray(entries)) continue;
+    const filtered = entries.filter((e) => !isOurHookEntry(e));
+    if (filtered.length !== entries.length) {
+      settings.hooks[event] = filtered;
+      changed = true;
+    }
+    if (settings.hooks[event].length === 0) {
+      delete settings.hooks[event];
+    }
+  }
+  if (Object.keys(settings.hooks).length === 0) {
+    delete settings.hooks;
+  }
+
+  if (changed) {
+    writeCodexHooksFile(settings);
+    console.log('[Pixel Agents] Hooks removed from ~/.codex/hooks.json');
+  }
+}
+
+export function copyHookScript(extensionPath: string): void {
+  const src = path.join(extensionPath, 'dist', 'hooks', CODEX_HOOK_SCRIPT_NAME);
+  const dst = getHookScriptPath();
+  const dstDir = path.dirname(dst);
+
+  try {
+    if (!fs.existsSync(dstDir)) {
+      fs.mkdirSync(dstDir, { recursive: true, mode: 0o700 });
+    }
+    if (!fs.existsSync(src)) {
+      console.warn(`[Pixel Agents] Hook script not found at ${src}`);
+      return;
+    }
+    fs.copyFileSync(src, dst);
+    fs.chmodSync(dst, 0o700);
+    console.log(`[Pixel Agents] Hook script installed at ${dst}`);
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to copy hook script: ${e}`);
+  }
+}

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Codex-specific constants. Kept separate from server-wide constants so the
+ * provider can be wired or removed independently from Claude.
+ */
+
+/** Output filename after esbuild compiles codex-hook.ts to CJS. */
+export const CODEX_HOOK_SCRIPT_NAME = 'codex-hook.js';
+
+/** Hook events to install in ~/.codex/hooks.json.
+ *  These are the documented Codex hook events that Pixel Agents can normalize.
+ */
+export const CODEX_HOOK_EVENTS = [
+  'SessionStart',
+  'Stop',
+  'PermissionRequest',
+  'PreToolUse',
+  'PostToolUse',
+  'SubagentStart',
+  'SubagentStop',
+] as const;
+
+/** Terminal name prefix used when launching Codex in VS Code. */
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';

--- a/server/src/providers/hook/codex/hooks/codex-hook.ts
+++ b/server/src/providers/hook/codex/hooks/codex-hook.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_API_PREFIX, SERVER_JSON_DIR, SERVER_JSON_NAME } from '../../../../constants.js';
+import type { ServerConfig } from '../../../../server.js';
+
+const SERVER_JSON = path.join(os.homedir(), SERVER_JSON_DIR, SERVER_JSON_NAME);
+
+async function main(): Promise<void> {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  let server: ServerConfig;
+  try {
+    server = JSON.parse(fs.readFileSync(SERVER_JSON, 'utf-8'));
+  } catch {
+    process.exit(0);
+  }
+
+  const body = JSON.stringify(data);
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: server.port,
+        path: `${HOOK_API_PREFIX}/codex`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          Authorization: `Bearer ${server.token}`,
+        },
+        timeout: 2000,
+      },
+      () => resolve(),
+    );
+    req.on('error', () => resolve());
+    req.on('timeout', () => {
+      req.destroy();
+      resolve();
+    });
+    req.end(body);
+  });
+}
+
+main()
+  .catch(() => {})
+  .finally(() => process.exit(0));

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -5,11 +5,55 @@
  *   1. Create `server/src/providers/hook/<cli>/<cli>.ts` implementing HookProvider.
  *      (File-based and stream-based provider types will land when the first such
  *       provider ships.)
- *   2. Add an export line below.
+ *   2. Add it to HOOK_PROVIDERS and copyProviderHookScript below.
  *
  * The adapter (VS Code extension, standalone CLI, etc.) imports from here rather
  * than reaching into each provider directory directly.
  */
 
-export { claudeProvider } from './hook/claude/claude.js';
-export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+import type { HookProvider } from '../../../core/src/provider.js';
+import { claudeProvider } from './hook/claude/claude.js';
+import { copyHookScript as copyClaudeHookScript } from './hook/claude/claudeHookInstaller.js';
+import { codexProvider } from './hook/codex/codex.js';
+import { copyHookScript as copyCodexHookScript } from './hook/codex/codexHookInstaller.js';
+
+export type AgentEngineId = 'claude-code' | 'claude' | 'codex';
+
+const HOOK_PROVIDERS = [claudeProvider, codexProvider] as const;
+
+export function resolveProvider(engine?: string): HookProvider {
+  switch (engine) {
+    case 'codex':
+      return codexProvider;
+    case 'claude':
+    case 'claude-code':
+    case undefined:
+    case '':
+      return claudeProvider;
+    default:
+      console.warn(`[Pixel Agents] Unknown agent engine "${engine}", falling back to Claude Code`);
+      return claudeProvider;
+  }
+}
+
+export function copyProviderHookScript(providerId: string, extensionPath: string): void {
+  switch (providerId) {
+    case claudeProvider.id:
+      copyClaudeHookScript(extensionPath);
+      break;
+    case codexProvider.id:
+      copyCodexHookScript(extensionPath);
+      break;
+    default:
+      console.warn(`[Pixel Agents] No hook script copier registered for provider "${providerId}"`);
+      break;
+  }
+}
+
+export function getHookProviders(): readonly HookProvider[] {
+  return HOOK_PROVIDERS;
+}
+
+export { claudeProvider, codexProvider };
+export { copyClaudeHookScript, copyCodexHookScript };
+export { copyClaudeHookScript as copyHookScript };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,11 +4,13 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import type { HookProvider } from '../../core/src/provider.js';
 import type { AgentRuntime } from './agentRuntime.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import type { AssetCache, SetHooksEnabledSideEffect } from './clientMessageHandler.js';
 import { SERVER_JSON_DIR, SERVER_JSON_NAME } from './constants.js';
 import { createHttpServer } from './httpServer.js';
+import { resolveProvider } from './providers/index.js';
 
 /** Discovery file written to ~/.pixel-agents/server.json so hook scripts can find the server. */
 export interface ServerConfig {
@@ -56,6 +58,7 @@ export class PixelAgentsServer {
   async start(options?: {
     store?: AgentStateStore;
     runtime?: AgentRuntime;
+    provider?: HookProvider;
     embedded?: boolean;
     host?: string;
     port?: number;
@@ -84,6 +87,7 @@ export class PixelAgentsServer {
       port: options?.port,
       token,
       store: store!,
+      provider: options?.provider ?? resolveProvider(),
       runtime: options?.runtime,
       staticDir: options?.staticDir,
       assetCache: options?.assetCache,

--- a/server/src/transcriptParser.ts
+++ b/server/src/transcriptParser.ts
@@ -1,6 +1,6 @@
 const debug = process.env.PIXEL_AGENTS_DEBUG !== '0';
 
-import type { HookProvider } from '../../core/src/provider.js';
+import type { AgentEvent, HookProvider } from '../../core/src/provider.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import { TEXT_IDLE_DELAY_MS, TOOL_DONE_DELAY_MS } from './constants.js';
 import {
@@ -54,6 +54,14 @@ export function processTranscriptLine(
   agent.linesProcessed++;
   try {
     const record = JSON.parse(line);
+
+    if (hookProvider?.parseTranscriptLine) {
+      const event = hookProvider.parseTranscriptLine(line);
+      if (event) {
+        processProviderTranscriptEvent(agentId, event, agents, waitingTimers, permissionTimers);
+      }
+      return;
+    }
 
     // -- Agent Teams: extract team metadata via the active provider --
     // The provider reads its CLI's own field names (Claude: record.teamName + record.agentName).
@@ -377,6 +385,128 @@ export function processTranscriptLine(
     }
   } catch {
     // Ignore malformed lines
+  }
+}
+
+function processProviderTranscriptEvent(
+  agentId: number,
+  event: AgentEvent,
+  agents: AgentStateStore,
+  waitingTimers: Map<number, ReturnType<typeof setTimeout>>,
+  permissionTimers: Map<number, ReturnType<typeof setTimeout>>,
+): void {
+  const agent = agents.get(agentId);
+  if (!agent) return;
+
+  switch (event.kind) {
+    case 'sessionStart':
+      if (event.cwd && !agent.folderName) {
+        agent.folderName = event.cwd.split(/[\\/]/).filter(Boolean).pop();
+      }
+      return;
+
+    case 'toolStart': {
+      const toolName = event.toolName;
+      const input =
+        typeof event.input === 'object' && event.input !== null
+          ? (event.input as Record<string, unknown>)
+          : {};
+      const status = formatToolStatus(toolName, input);
+
+      cancelWaitingTimer(agentId, waitingTimers);
+      agent.isWaiting = false;
+      agent.hadToolsInTurn = true;
+      agent.activeToolIds.add(event.toolId);
+      agent.activeToolStatuses.set(event.toolId, status);
+      agent.activeToolNames.set(event.toolId, toolName);
+      agents.broadcast({ type: 'agentStatus', id: agentId, status: 'active' });
+
+      const isSubagentSpawn = isSubagentTool(toolName);
+      if (!agent.hookDelivered || isSubagentSpawn) {
+        agents.broadcast({
+          type: 'agentToolStart',
+          id: agentId,
+          toolId: event.toolId,
+          status,
+          toolName,
+          permissionActive: agent.permissionSent,
+          runInBackground: event.runInBackground,
+        });
+      }
+
+      if (!exemptTools().has(toolName) && !agent.hookDelivered && !agent.leadAgentId) {
+        startPermissionTimer(agentId, agents, permissionTimers, exemptTools());
+      }
+      return;
+    }
+
+    case 'toolEnd': {
+      const completedToolId = event.toolId;
+      const completedToolName = agent.activeToolNames.get(completedToolId);
+      if (!completedToolName && completedToolId !== 'current') return;
+
+      const toolId =
+        completedToolId === 'current'
+          ? [...agent.activeToolIds][agent.activeToolIds.size - 1]
+          : completedToolId;
+      if (!toolId) return;
+
+      if (isSubagentTool(agent.activeToolNames.get(toolId))) {
+        agent.activeSubagentToolIds.delete(toolId);
+        agent.activeSubagentToolNames.delete(toolId);
+        agents.broadcast({
+          type: 'subagentClear',
+          id: agentId,
+          parentToolId: toolId,
+        });
+      }
+      agent.activeToolIds.delete(toolId);
+      agent.activeToolStatuses.delete(toolId);
+      agent.activeToolNames.delete(toolId);
+
+      if (!agent.hookDelivered || isSubagentTool(completedToolName)) {
+        setTimeout(() => {
+          agents.broadcast({
+            type: 'agentToolDone',
+            id: agentId,
+            toolId,
+          });
+        }, TOOL_DONE_DELAY_MS);
+      }
+
+      if (agent.activeToolIds.size === 0) {
+        agent.hadToolsInTurn = false;
+      }
+      return;
+    }
+
+    case 'turnEnd':
+      cancelWaitingTimer(agentId, waitingTimers);
+      cancelPermissionTimer(agentId, permissionTimers);
+      clearAgentActivity(agent, agentId, agents, permissionTimers);
+      agent.isWaiting = true;
+      agent.permissionSent = false;
+      agent.hadToolsInTurn = false;
+      if (!agent.hookDelivered) {
+        agents.broadcast({
+          type: 'agentStatus',
+          id: agentId,
+          status: 'waiting',
+        });
+      }
+      return;
+
+    case 'permissionRequest':
+      agent.permissionSent = true;
+      agents.broadcast({ type: 'agentToolPermission', id: agentId });
+      return;
+
+    case 'sessionEnd':
+    case 'subagentStart':
+    case 'subagentEnd':
+    case 'subagentTurnEnd':
+    case 'progress':
+      return;
   }
 }
 

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -74,6 +74,8 @@ function App() {
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    agentEngine,
+    setAgentEngine,
   } = useExtensionMessages(getOfficeState, editor.setLastSavedLayout, isEditDirty);
 
   // Show migration notice once layout reset is detected
@@ -305,8 +307,8 @@ function App() {
             <li className="text-sm mb-2">Sound notifications play immediately</li>
           </ul>
           <p className="mb-12 text-text-muted">
-            This works through Claude Code Hooks, small event listeners that notify Pixel Agents
-            whenever something happens in your Claude sessions.
+            This works through agent hooks, small event listeners that notify Pixel Agents whenever
+            something happens in your coding sessions.
           </p>
           <div className="text-center">
             <button
@@ -363,6 +365,11 @@ function App() {
           const newVal = !hooksEnabled;
           setHooksEnabled(newVal);
           transport.send({ type: 'setHooksEnabled', enabled: newVal });
+        }}
+        agentEngine={agentEngine}
+        onAgentEngineChange={(engine) => {
+          setAgentEngine(engine);
+          transport.send({ type: 'setAgentEngine', engine });
         }}
       />
 

--- a/webview-ui/src/browserMock.ts
+++ b/webview-ui/src/browserMock.ts
@@ -262,8 +262,14 @@ export function dispatchMockMessages(): void {
   dispatch({
     type: 'settingsLoaded',
     soundEnabled: false,
-    extensionVersion: '1.3.0',
-    lastSeenVersion: '1.2',
+    extensionVersion: '1.4.0',
+    lastSeenVersion: '1.3',
+    watchAllSessions: false,
+    alwaysShowLabels: false,
+    hooksEnabled: true,
+    hooksInfoShown: true,
+    externalAssetDirectories: [],
+    agentEngine: 'claude-code',
   });
 
   console.log('[BrowserMock] Messages dispatched');

--- a/webview-ui/src/changelogData.ts
+++ b/webview-ui/src/changelogData.ts
@@ -25,6 +25,23 @@ export const CHANGELOG_REPO_URL = 'https://github.com/pixel-agents-hq/pixel-agen
 
 export const changelogEntries: ChangelogEntry[] = [
   {
+    version: '1.4',
+    sections: [
+      {
+        title: 'Features',
+        items: [
+          'OpenAI Codex CLI support as a second agent engine',
+          'Agent engine picker in Settings modal (Claude Code or Codex)',
+        ],
+      },
+      {
+        title: 'Fixes',
+        items: ['Codex session binding on SessionStart hook events'],
+      },
+    ],
+    contributors: [],
+  },
+  {
     version: '1.3',
     sections: [
       {

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -19,6 +19,8 @@ interface SettingsModalProps {
   onToggleWatchAllSessions: () => void;
   hooksEnabled: boolean;
   onToggleHooksEnabled: () => void;
+  agentEngine: 'claude-code' | 'codex';
+  onAgentEngineChange: (engine: 'claude-code' | 'codex') => void;
 }
 
 export function SettingsModal({
@@ -33,6 +35,8 @@ export function SettingsModal({
   onToggleWatchAllSessions,
   hooksEnabled,
   onToggleHooksEnabled,
+  agentEngine,
+  onAgentEngineChange,
 }: SettingsModalProps) {
   const [soundLocal, setSoundLocal] = useState(isSoundEnabled);
 
@@ -88,6 +92,17 @@ export function SettingsModal({
           </Button>
         </div>
       ))}
+      <div className="flex items-center justify-between py-4 px-10 gap-8">
+        <span className="text-xs text-text-muted">Agent Engine</span>
+        <select
+          value={agentEngine}
+          onChange={(e) => onAgentEngineChange(e.target.value as 'claude-code' | 'codex')}
+          className="text-xs bg-bg text-text border-2 border-border rounded-none px-8 py-4 cursor-pointer"
+        >
+          <option value="claude-code">Claude Code</option>
+          <option value="codex">Codex</option>
+        </select>
+      </div>
       <Checkbox
         label="Sound Notifications"
         checked={soundLocal}

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -70,6 +70,8 @@ interface ExtensionMessageState {
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
+  agentEngine: 'claude-code' | 'codex';
+  setAgentEngine: (v: 'claude-code' | 'codex') => void;
 }
 
 function saveAgentSeats(os: OfficeState): void {

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -107,6 +107,7 @@ export function useExtensionMessages(
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
+  const [agentEngine, setAgentEngine] = useState<'claude-code' | 'codex'>('claude-code');
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -482,6 +483,9 @@ export function useExtensionMessages(
         if (typeof msg.extensionVersion === 'string') {
           setExtensionVersion(msg.extensionVersion as string);
         }
+        if (msg.agentEngine === 'codex' || msg.agentEngine === 'claude-code') {
+          setAgentEngine(msg.agentEngine);
+        }
       } else if (msg.type === 'externalAssetDirectoriesUpdated') {
         if (Array.isArray(msg.dirs)) {
           setExternalAssetDirectories(msg.dirs as string[]);
@@ -538,5 +542,7 @@ export function useExtensionMessages(
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
+    agentEngine,
+    setAgentEngine,
   };
 }


### PR DESCRIPTION
## Summary
- Add Codex as second HookProvider alongside Claude Code
- Settings modal engine picker + hot-swap without reload
- SessionStart rebind for Codex rollout transcripts
- Tests: unit, property, hook integration, e2e mock codex

## Test plan
- [ ] Set `pixel-agents.agentEngine` to `codex`, build, F5
- [ ] Click + Agent → Codex terminal spawns
- [ ] Verify hooks in `~/.codex/hooks.json`
- [ ] Tool animations + permission bubble work
- [ ] Switch back to Claude Code in Settings
- [ ] `npm run test:server` passes
