### PR TITLE
fix: Windows compatibility for build script and standalone CLI hook install

### DIFF
--- a/scripts/generate-messages.ts
+++ b/scripts/generate-messages.ts
@@ -137,7 +137,10 @@ function exportify(decl: string): string {
 }
 
 function quote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
+  // Cross-platform shell quoting: cmd.exe (Windows) doesn't honor POSIX
+  // single-quote escaping, so prettier/eslint receive the literal quotes and
+  // fail to match the path. Use double quotes on Windows, single on POSIX.
+  return process.platform === 'win32' ? `"${s}"` : `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 main().catch((err) => {

--- a/server/src/providers/hook/claude/claudeHookInstaller.ts
+++ b/server/src/providers/hook/claude/claudeHookInstaller.ts
@@ -169,7 +169,14 @@ export function uninstallHooks(): void {
 
 /** Copy the shipped hook script from the extension to ~/.pixel-agents/hooks/ */
 export function copyHookScript(extensionPath: string): void {
-  const src = path.join(extensionPath, 'dist', 'hooks', CLAUDE_HOOK_SCRIPT_NAME);
+  // The VS Code adapter passes the extension root (hook lives at dist/hooks/),
+  // while the standalone CLI passes the dist/ dir itself (hook at hooks/). Try
+  // both so the hook installs correctly in either mode.
+  const candidates = [
+    path.join(extensionPath, 'dist', 'hooks', CLAUDE_HOOK_SCRIPT_NAME),
+    path.join(extensionPath, 'hooks', CLAUDE_HOOK_SCRIPT_NAME),
+  ];
+  const src = candidates.find((p) => fs.existsSync(p)) ?? candidates[0];
   const dst = getHookScriptPath();
   const dstDir = path.dirname(dst);
 


### PR DESCRIPTION
## What

Two Windows-only failures when building and running the project outside VS Code.

### 1. Build fails on Windows (`npm run build`)

`scripts/generate-messages.ts` quotes the generated file path with POSIX single quotes before passing it to `execSync(...)`. On Windows, `cmd.exe` does not strip single quotes, so `prettier`/`eslint` receive the literal quoted string and abort with:

```
[error] No files matching the pattern were found: "'...\core\src\messages.ts'".
[generate-messages] prettier failed: Error: Command failed
```

This breaks `npm run compile` (and therefore `npm run build`) on Windows.

**Fix:** platform-aware quoting — double quotes on `win32`, single quotes elsewhere.

### 2. Standalone CLI never installs its hook on Windows

`copyHookScript()` always resolves the hook script as `<extensionPath>/dist/hooks/<name>`. That is correct for the VS Code adapter (where `extensionPath` is the repo root), but the standalone CLI passes `dist/` itself as `extensionPath`, producing `dist/dist/hooks/<name>` — which doesn't exist:

```
[Pixel Agents] Hook script not found at ...\dist\dist\hooks\claude-hook.js
```

So the hook is never copied and live agent capture silently fails when running via the CLI.

**Fix:** try both `dist/hooks/<name>` and `hooks/<name>`, so it resolves correctly in both the VS Code and standalone-CLI modes.

## Testing

- `npm run build` now completes on Windows (previously failed at the prettier step).
- Running the standalone CLI (`node dist/cli.js`) now copies `claude-hook.js` to `~/.pixel-agents/hooks/` and captures agent events; verified the office renders and agents spawn from hook events.
- No behavior change on macOS/Linux or in the VS Code adapter (the POSIX path and `dist/hooks` resolution are preserved as the defaults).

Both changes are minimal and isolated.
