### PR TITLE
fix: standalone CLI never installs the hook script (dist/dist/ path)

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -62,6 +62,9 @@ async function main(): Promise<void> {
   // dist/ contains both the CLI bundle and the assets/ + webview/ directories
   const distRoot = __dirname;
   const staticDir = path.join(distRoot, 'webview');
+  // copyHookScript expects the package root (it appends dist/hooks/ itself,
+  // matching the VS Code adapter which passes extensionPath)
+  const packageRoot = path.dirname(distRoot);
 
   // ── Load assets on startup (same pipeline as VS Code extension) ──
   console.log('[Pixel Agents] Loading assets...');
@@ -107,7 +110,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(packageRoot);
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -135,7 +138,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(packageRoot);
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);


### PR DESCRIPTION
## Problem

Running the standalone CLI (`node dist/cli.js`) logs:

```
[Pixel Agents] Hook script not found at <root>/dist/dist/hooks/claude-hook.js
[Pixel Agents] Hooks installed
```

`copyHookScript()` appends `dist/hooks/<script>` to the path it receives — matching the VS Code adapter, which passes `context.extensionPath`. The CLI passes `__dirname`, which is already `dist/`, so the source path resolves to `dist/dist/hooks/` and the copy silently fails.

The net effect for standalone CLI users: hooks get registered in `~/.claude/settings.json` pointing at `~/.pixel-agents/hooks/claude-hook.js`, but that script is never installed — so every Claude Code session runs a hook command against a missing file, and no hook events ever reach the server (only the heuristic JSONL fallback works).

## Fix

Pass the package root (parent of `dist/`) to `copyHookScript()` at both call sites in `server/src/cli.ts`.

## Verification

- Before: warning above, `~/.pixel-agents/hooks/` stays empty.
- After: `[Pixel Agents] Hook script installed at ~/.pixel-agents/hooks/claude-hook.js`, file present with `0700` perms, hook events flow to the server.
- `npm run lint` clean, server suite green (13 files, 213 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)