### PR TITLE
fix(cli): correct hook script path to prevent dist/dist double-join

### DIFF
--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
           `http://127.0.0.1:${currentConfig.port}`,
           currentConfig.token,
         );
-        copyHookScript(distRoot);
+        copyHookScript(path.dirname(distRoot));
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
@@ -135,7 +135,7 @@ async function main(): Promise<void> {
     if (runtime.hooksEnabled.current) {
       try {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        copyHookScript(distRoot);
+        copyHookScript(path.dirname(distRoot));
         console.log('[Pixel Agents] Hooks installed');
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);


### PR DESCRIPTION
## Summary
- The standalone CLI's `copyHookScript(distRoot)` calls in `server/src/cli.ts` pass `distRoot` (`__dirname` of `cli.js`, already pointing at `dist/`) into `copyHookScript(extensionPath)`, which joins its argument with `'dist', 'hooks', <script>`. This doubles the `dist` segment and looks for the hook script at `dist/dist/hooks/claude-hook.js`, which never exists.
- Effect: every standalone CLI startup (and every hooks on/off toggle) logs `Hook script not found at .../dist/dist/hooks/claude-hook.js` and silently fails to copy the hook script into `~/.pixel-agents/hooks/`. Since `~/.claude/settings.json` hook entries point at `~/.pixel-agents/hooks/claude-hook.js` unconditionally, every Claude Code hook event (across all projects on the machine) then fails to execute — hooks are effectively broken for anyone using the standalone CLI.
- The VS Code adapter is unaffected: `PixelAgentsViewProvider.ts` passes `context.extensionPath` (the extension root, containing `dist/`), which is exactly what `copyHookScript` expects.
- Fix: pass `path.dirname(distRoot)` from the CLI instead of `distRoot`, so the join lands on `dist/hooks/claude-hook.js`, matching the actual esbuild output.

## Test plan
- [x] `npm run build` — types, lint, asyncapi drift check, and webview build all pass
- [x] Confirmed `esbuild.js` outputs the hook script at `dist/hooks/claude-hook.js`, matching the corrected joined path
- [x] Reproduced locally: prior to the fix, standalone CLI startup logged `Hook script not found at .../dist/dist/hooks/claude-hook.js`; traced root cause to the `distRoot` argument
- [x] Confirmed the VS Code call sites (`PixelAgentsViewProvider.ts`) are untouched and still pass `context.extensionPath` correctly