### PR TITLE
fix: keep workspace JSONL discovery active with hooks

### DIFF
--- a/server/__tests__/fileWatcherDismissal.test.ts
+++ b/server/__tests__/fileWatcherDismissal.test.ts
@@ -15,9 +15,19 @@ vi.mock('vscode', () => ({
 }));
 
 import { AgentStateStore } from '../src/agentStateStore.js';
-import { DISMISSED_COOLDOWN_MS, EXTERNAL_ACTIVE_THRESHOLD_MS } from '../src/constants.js';
+import {
+  DISMISSED_COOLDOWN_MS,
+  EXTERNAL_ACTIVE_THRESHOLD_MS,
+  EXTERNAL_SCAN_INTERVAL_MS,
+} from '../src/constants.js';
 import { DismissalTracker } from '../src/dismissalTracker.js';
-import { scanExternalDir, scanForNewJsonlFiles, setDismissalTracker } from '../src/fileWatcher.js';
+import {
+  ensureProjectScan,
+  scanExternalDir,
+  scanForNewJsonlFiles,
+  setDismissalTracker,
+  startExternalSessionScanning,
+} from '../src/fileWatcher.js';
 
 /**
  * Tests for the DismissalTracker integration with fileWatcher's scanner functions.
@@ -273,6 +283,58 @@ describe('fileWatcher dismissal state', () => {
       // No active-terminal agent is present, so adoption shouldn't fire regardless.
       // Primarily: dismissal entry should NOT get erased by this pass.
       expect(tracker.isDismissed(file)).toBe(true);
+    });
+  });
+
+  describe('startExternalSessionScanning: hooks mode workspace discovery', () => {
+    it('adopts workspace JSONL sessions when hooks and Watch All Sessions are both enabled', () => {
+      vi.useFakeTimers();
+      const projectScanTimerRef: { current: ReturnType<typeof setInterval> | null } = {
+        current: null,
+      };
+
+      ensureProjectScan(
+        projectDir,
+        knownJsonlFiles,
+        projectScanTimerRef,
+        { current: null },
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        () => {},
+        undefined,
+        { current: true },
+      );
+      writeJsonlFile('workspace-session.jsonl', '{"type":"assistant"}\n');
+
+      const externalScanTimer = startExternalSessionScanning(
+        projectDir,
+        knownJsonlFiles,
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        new Map(),
+        () => {},
+        { current: true },
+        { current: true },
+      );
+
+      vi.advanceTimersByTime(EXTERNAL_SCAN_INTERVAL_MS);
+
+      clearInterval(externalScanTimer);
+      if (projectScanTimerRef.current) clearInterval(projectScanTimerRef.current);
+      vi.useRealTimers();
+
+      expect(agents.size).toBe(1);
+      const adopted = [...agents.values()][0];
+      expect(adopted.jsonlFile).toBe(path.join(projectDir, 'workspace-session.jsonl'));
+      expect(adopted.isExternal).toBe(true);
     });
   });
 

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -3,16 +3,19 @@
  *
  * HOOKS MODE (preferred): Claude Code Hooks API delivers instant, reliable events
  * for session lifecycle (SessionStart, SessionEnd, Stop, PermissionRequest, etc.).
- * When hooks work, heuristic scanners and timers are suppressed. The hookDelivered
- * flag per agent and hooksEnabledRef globally control the switch.
+ * When hooks work, per-agent heuristic timers and terminal adoption scans are
+ * suppressed. The hookDelivered flag per agent and hooksEnabledRef globally
+ * control the switch.
  *
  * HEURISTIC MODE (fallback): For environments without hooks (other providers,
  * hooks disabled, older Claude versions). Uses:
  * - Per-agent 500ms JSONL polling for tool activity and /clear detection
  * - 1s main scanner for terminal adoption
- * - 3s external scanner for external session detection
  * - 30s stale check for orphaned external agents
  * - Multiple dismissal systems to prevent re-adoption races
+ *
+ * EXTERNAL SESSION DISCOVERY: The 3s external scanner runs in both hooks and
+ * heuristic modes because not every JSONL producer emits Claude Code hooks.
  *
  * JSONL POLLING (always active): readNewLines + processTranscriptLine run in both
  * modes. They provide tool content (status text, animations) that hooks don't carry.
@@ -999,27 +1002,24 @@ export function startExternalSessionScanning(
 
   persistAgents: () => void,
   watchAllSessionsRef?: { current: boolean },
-  hooksEnabledRef?: { current: boolean },
+  _hooksEnabledRef?: { current: boolean },
 ): ReturnType<typeof setInterval> {
   return setInterval(() => {
-    // When hooks are active, SessionStart handles workspace session detection.
-    // Only skip workspace scanning; global scanning (Watch All) still needed
-    // because hooks can't detect already-running sessions from other projects.
-    if (!hooksEnabledRef?.current) {
-      // Scan all tracked project dirs (heuristic fallback)
-      for (const dir of trackedProjectDirs) {
-        scanExternalDir(
-          dir,
-          knownJsonlFiles,
-          nextAgentIdRef,
-          agents,
-          fileWatchers,
-          pollingTimers,
-          waitingTimers,
-          permissionTimers,
-          persistAgents,
-        );
-      }
+    // Scan all tracked project dirs in both hooks and heuristic modes. Hooks are
+    // a fast path for producers that emit hook events; polling remains the
+    // discovery path for workspace JSONL sessions created without hooks.
+    for (const dir of trackedProjectDirs) {
+      scanExternalDir(
+        dir,
+        knownJsonlFiles,
+        nextAgentIdRef,
+        agents,
+        fileWatchers,
+        pollingTimers,
+        waitingTimers,
+        permissionTimers,
+        persistAgents,
+      );
     }
     // If "Watch All Sessions" is ON, also scan all global project dirs
     if (watchAllSessionsRef?.current) {


### PR DESCRIPTION
## Summary
- Keep tracked workspace external-session scanning active when hooks are enabled, so workspace JSONL sessions from non-hook producers are still discovered.
- Preserve Watch All global scanning and existing known/tracked-file guards.
- Add a regression test for hooks-enabled + Watch All Sessions workspace JSONL adoption.

Fixes #252.

## Testing
- `gitleaks protect --staged --verbose` via pre-commit
- `npm run test:server -- fileWatcherDismissal.test.ts`
- `npm run check-types`
- `npx prettier --check server/src/fileWatcher.ts server/__tests__/fileWatcherDismissal.test.ts`
- `npx eslint server/src/fileWatcher.ts server/__tests__/fileWatcherDismissal.test.ts`
- `git diff --check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:server -- hookEventHandler.test.ts`
- `npm run test:server -- --fileParallelism=false`
- `npm run asyncapi:validate`
- `npm run e2e:inventory`
- `npm run format:check`
- `npm run e2e`