### PR TITLE
fix(webview): render existing agents on reconnect when layout already loaded

### DIFF
--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -224,16 +224,28 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
-        // Buffer agents — they'll be added in layoutLoaded after seats are built
+        // Buffer agents until layout (seats) is built; but if the layout has
+        // ALREADY loaded (e.g. existingAgents arrives AFTER layoutLoaded on a
+        // reconnect/refresh), add them immediately — otherwise they would sit in
+        // pendingAgents forever and never render (empty office on refresh).
         for (const id of incoming) {
           const m = meta[id];
-          pendingAgents.push({
-            id,
-            palette: m?.palette,
-            hueShift: m?.hueShift,
-            seatId: m?.seatId,
-            folderName: folderNames[id],
-          });
+          if (layoutReadyRef.current) {
+            if (!os.characters.has(id)) {
+              os.addAgent(id, m?.palette, m?.hueShift, m?.seatId, true, folderNames[id]);
+            }
+          } else {
+            pendingAgents.push({
+              id,
+              palette: m?.palette,
+              hueShift: m?.hueShift,
+              seatId: m?.seatId,
+              folderName: folderNames[id],
+            });
+          }
+        }
+        if (layoutReadyRef.current && os.characters.size > 0) {
+          saveAgentSeats(os);
         }
         setAgents((prev) => {
           const ids = new Set(prev);


### PR DESCRIPTION
### Problem

In **standalone server mode**, refreshing or reconnecting the browser shows an **empty office** — the furniture renders but no agent characters appear — even though the server sends the full agent snapshot. Live agent detection (`agentCreated`) works fine; only the reconnect/refresh path is broken.

### Root cause

`webview-ui/src/hooks/useExtensionMessages.ts` — the `existingAgents` handler buffers agents into `pendingAgents`, relying on the `layoutLoaded` handler to drain them once seats are built. On reconnect the server sends `layoutLoaded` **before** `existingAgents`, so the drain loop runs against an empty buffer and the later-arriving agents sit in `pendingAgents` forever.

Verified by connecting a raw WebSocket client to a standalone server: it replies with `existingAgents: [1,2,3,4]` (seats + palettes populated), but those agents were never added to `OfficeState`.

### Fix

When `existingAgents` arrives and the layout is **already loaded**, add the agents immediately (mirroring the `layoutLoaded` drain call, with `isExternal = true`); otherwise buffer as before. The immediate add is guarded with `!os.characters.has(id)` so a repeated `existingAgents` message (e.g. a second reconnect) can't double-add a character.

### Test plan

- Standalone server: open the office, let agents appear, then **hard-refresh** the browser → characters now re-render from the snapshot (previously the office was empty).
- Fresh connect before any agent exists → unchanged (buffer path still used, drained by `layoutLoaded`).
