### PR TITLE
fix: render existing agents when layout is already loaded

### DIFF
--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -246,16 +246,24 @@ export function useExtensionMessages(
           { palette?: number; hueShift?: number; seatId?: string }
         >;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
-        // Buffer agents — they'll be added in layoutLoaded after seats are built
+        // If layout (and seats) are already built, add characters immediately —
+        // the standalone server sends layoutLoaded BEFORE existingAgents, so
+        // buffering here would never flush. Otherwise buffer for layoutLoaded.
         for (const id of incoming) {
           const m = meta[id];
-          pendingAgents.push({
-            id,
-            palette: m?.palette,
-            hueShift: m?.hueShift,
-            seatId: m?.seatId,
-            folderName: folderNames[id],
-          });
+          if (layoutReadyRef.current) {
+            if (!os.characters.has(id)) {
+              os.addAgent(id, m?.palette, m?.hueShift, m?.seatId, true, folderNames[id]);
+            }
+          } else {
+            pendingAgents.push({
+              id,
+              palette: m?.palette,
+              hueShift: m?.hueShift,
+              seatId: m?.seatId,
+              folderName: folderNames[id],
+            });
+          }
         }
         setAgents((prev) => {
           const ids = new Set(prev);


### PR DESCRIPTION
## Problem

In standalone mode, restored/external agents show up in the debug view but their characters never appear on the office canvas after a page load or refresh.

## Cause

On webview connect, the standalone server sends `layoutLoaded` **before** `existingAgents` (`server/src/clientMessageHandler.ts`). The `existingAgents` handler in `webview-ui/src/hooks/useExtensionMessages.ts` unconditionally buffers incoming agents into `pendingAgents`, which is only flushed by a *subsequent* `layoutLoaded`. Since that message has already passed, the buffer never flushes: React state (`setAgents`) is updated — hence the debug view shows the agents — but `os.addAgent()` is never called, so no characters are created.

## Fix

In the `existingAgents` handler, if the layout is already ready (`layoutReadyRef.current`), add the characters immediately via `os.addAgent()` (deduped against `os.characters`). The buffering path is kept for the case where `existingAgents` arrives before `layoutLoaded`.

## How to reproduce / verify

1. `npx pixel-agents` with previously persisted external agents (or adopt a couple of running Claude Code sessions with **Watch All Sessions** on).
2. Open/refresh `http://localhost:3100`.
3. Before: office renders with no characters; debug view lists the agents. After: characters render at their seats immediately.