### PR TITLE
fix: send layoutLoaded after existingAgents on webviewReady

### DIFF
--- a/server/__tests__/clientMessageHandler.test.ts
+++ b/server/__tests__/clientMessageHandler.test.ts
@@ -11,6 +11,36 @@ import {
 } from '../src/clientMessageHandler.js';
 import { readConfig } from '../src/configPersistence.js';
 import { FileStateAdapter } from '../src/fileStateAdapter.js';
+import type { AgentState } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: 'sess-1',
+    terminalRef: undefined,
+    isExternal: false,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    inputTokens: 0,
+    outputTokens: 0,
+    ...overrides,
+  } as AgentState;
+}
 
 /**
  * These tests exercise the area-related dispatch branches and the load-order
@@ -142,6 +172,26 @@ describe('clientMessageHandler: areas + carpet wire ordering', () => {
 
       const mappings = sent[iAreaMappings] as { mappings?: Record<string, string[]> };
       expect(mappings.mappings).toEqual({ frontend: ['Engineering'] });
+    });
+
+    it('emits layoutLoaded after existingAgents so buffered agents materialize', () => {
+      // The webview buffers agents from existingAgents and only materializes
+      // them on the next layoutLoaded. If layout arrives first, a client
+      // connecting after agents were created never renders their characters.
+      store.set(1, createTestAgent({ id: 1 }));
+
+      handleClientMessage({ type: 'webviewReady' }, (m) => sent.push(m), ctx);
+
+      const types = sent.map((m) => m.type);
+      const iExistingAgents = types.indexOf('existingAgents');
+      const iLayout = types.indexOf('layoutLoaded');
+
+      expect(iExistingAgents).toBeGreaterThanOrEqual(0);
+      expect(iLayout).toBeGreaterThanOrEqual(0);
+      expect(iExistingAgents).toBeLessThan(iLayout);
+
+      const existing = sent[iExistingAgents] as { agents?: number[] };
+      expect(existing.agents).toEqual([1]);
     });
 
     it('emits carpetTilesLoaded after wallTilesLoaded when both are present in the cache', () => {

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -221,9 +221,11 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     }
   }
 
-  // 3. Layout (saved file, or bundled default)
-  const savedLayout = readLayoutFromFile();
-  send({ type: 'layoutLoaded', layout: savedLayout ?? cache?.defaultLayout ?? null });
+  // 3. Layout is sent AFTER existingAgents — see step 7 below. The webview
+  // buffers agents from existingAgents and only materializes them on the next
+  // layoutLoaded (useExtensionMessages.ts: "Buffer agents — they'll be added
+  // in layoutLoaded"), so layout-first would leave a client that connects
+  // after agent creation with no characters.
 
   // 4. Settings (from adapter, with sensible defaults when adapter is absent)
   const cfg = readConfig();
@@ -281,4 +283,9 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     folderNames,
     externalAgents,
   });
+
+  // 7. Layout last (see step 3): flushes the webview's buffered existingAgents
+  // into characters once seats are rebuilt.
+  const savedLayout = readLayoutFromFile();
+  send({ type: 'layoutLoaded', layout: savedLayout ?? cache?.defaultLayout ?? null });
 }


### PR DESCRIPTION
## Description

In standalone mode, a browser that connects **after** agents already exist renders an empty office — no characters ever appear.

**Root cause:** `handleWebviewReady` (`server/src/clientMessageHandler.ts`) sends `layoutLoaded` *before* `existingAgents`. But the webview buffers agents from `existingAgents` and only materializes them on the **next** `layoutLoaded` (`webview-ui/src/hooks/useExtensionMessages.ts`: *"Buffer agents — they'll be added in layoutLoaded"*). For a client connecting after agent creation, that next `layoutLoaded` never arrives, so the buffered agents are never added to the office.

**Fix:** send `layoutLoaded` last in `handleWebviewReady`, after `existingAgents`. The `layoutLoaded` handler then flushes the buffered agents into characters once the layout and seats are rebuilt. Clients that connect before any agents exist are unaffected (empty buffer), and later `agentCreated` broadcasts behave as before.

### Reproduction (standalone)

1. `npx pixel-agents --port 3100` — do **not** open the browser yet.
2. Create an agent while no client is connected, e.g. POST a `SessionStart` hook event (token from `~/.pixel-agents/server.json`):
   ```bash
   curl -X POST http://127.0.0.1:3100/api/hooks/claude \
     -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
     -d '{"session_id":"repro-1","hook_event_name":"SessionStart","cwd":"'$PWD'"}'
   ```
3. Open `http://localhost:3100`. The office renders, `existingAgents` arrives on the WebSocket with the agent — but no character is drawn. Reloading doesn't help; only creating *another* agent after connecting makes it appear.

With this fix the character renders immediately on connect.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ...

## Related issues

None found.

## Test plan

- [x] Added `emits layoutLoaded after existingAgents so buffered agents materialize` to `server/__tests__/clientMessageHandler.test.ts` (seeds an agent in the store, asserts the `webviewReady` reply ordering). It fails against the old ordering.
- [x] `npm run test:server` — 19 files, 273 tests passed.
- [x] `npm run check-types` and `npm run lint` — clean (one pre-existing warning in `App.tsx`, untouched).
- [x] Bug originally observed against a live standalone server (browser connected after agent creation showed an empty office); this reordering has been running as a local patch in that deployment since.

## E2E coverage

- [ ] If user-visible behavior changed, an e2e test was added or updated
      under `pixel-agents/e2e/tests/`.
- [x] No e2e test added — explanation below.

**What e2e tests cover this change?**

The wire-order invariant is covered deterministically by the new server unit test in `server/__tests__/clientMessageHandler.test.ts`. The existing `standalone/hooks.spec.ts` scenarios connect the browser *before* creating agents, which is why this path was never exercised. Happy to add a late-connect e2e scenario if you'd prefer that coverage as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
