### PR TITLE
feat: add --token/t CLI option for static auth token

### DIFF
--- a/server/__tests__/cli.test.ts
+++ b/server/__tests__/cli.test.ts
@@ -118,6 +118,46 @@ describe('parseArgs', () => {
   it('parses --host', () => {
     expect(parseArgs(['--host', '0.0.0.0']).host).toBe('0.0.0.0');
   });
+
+  // 11. --token defaults to undefined (server generates a random UUID)
+  it('defaults token to undefined when --token is omitted', () => {
+    expect(parseArgs([]).token).toBeUndefined();
+  });
+
+  // 12. Valid --token is accepted
+  it('accepts a valid --token (>= 8 characters)', () => {
+    expect(parseArgs(['--token', 'my-secret-token']).token).toBe('my-secret-token');
+  });
+
+  // 13. -t short form works
+  it('accepts -t as a short form for --token', () => {
+    expect(parseArgs(['-t', 'abcdefgh']).token).toBe('abcdefgh');
+  });
+
+  // 14. Exactly 8 characters is the minimum accepted
+  it('accepts a token of exactly 8 characters', () => {
+    expect(parseArgs(['--token', '12345678']).token).toBe('12345678');
+  });
+
+  // 15. Token shorter than 8 characters is rejected
+  it('rejects --token shorter than 8 characters', () => {
+    expect(() => parseArgs(['--token', 'short'])).toThrow(CliArgsError);
+    expect(() => parseArgs(['--token', 'short'])).toThrow(/at least 8 characters/);
+  });
+
+  // 16. --token without a value is rejected
+  it.each(['--token', '-t'])('rejects %s when its value is missing', (option) => {
+    expect(() => parseArgs([option])).toThrow(CliArgsError);
+    expect(() => parseArgs([option])).toThrow(/Missing value/);
+  });
+
+  // 17. --token combined with other options
+  it('parses --token alongside --port and --host', () => {
+    const args = parseArgs(['--port', '3100', '--host', '0.0.0.0', '--token', 'my-token-123']);
+    expect(args.port).toBe(3100);
+    expect(args.host).toBe('0.0.0.0');
+    expect(args.token).toBe('my-token-123');
+  });
 });
 
 /**

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -341,4 +341,23 @@ describe('PixelAgentsServer', () => {
 
     expect(received).toHaveLength(0);
   });
+
+  // 23. Custom token is used when provided
+  it('uses a custom token when provided via options', async () => {
+    const customToken = 'my-custom-static-token';
+    const config = await server.start({ token: customToken });
+    expect(config.token).toBe(customToken);
+  });
+
+  // 24. Custom token is enforced for Bearer auth
+  it('rejects a random token when a custom token was set', async () => {
+    const customToken = 'my-custom-static-token';
+    const config = await server.start({ token: customToken });
+    const res = await fetch(`http://127.0.0.1:${config.port}/api/hooks/claude`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer not-the-right-token' },
+      body: '{}',
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -32,6 +32,8 @@ export interface CliArgs {
    *  can run at once without a collision. --port picks a fixed one. */
   port?: number;
   host: string;
+  /** Static auth token. If not provided, a random UUID is generated. */
+  token?: string;
 }
 
 /** Thrown by parseArgs on an invalid --port. Kept separate from process.exit so
@@ -60,12 +62,23 @@ export function parseArgs(argv: string[]): CliArgs {
     } else if (argv[i] === '--host' && argv[i + 1]) {
       args.host = argv[i + 1];
       i++;
+    } else if (argv[i] === '--token' || argv[i] === '-t') {
+      const raw = argv[i + 1];
+      if (raw === undefined) {
+        throw new CliArgsError(`Missing value for ${argv[i]}: expected a string token.`);
+      }
+      if (raw.length < 8) {
+        throw new CliArgsError(`Invalid --token: must be at least 8 characters.`);
+      }
+      args.token = raw;
+      i++;
     } else if (argv[i] === '--help') {
       console.log(`Usage: pixel-agents [options]
 
 Options:
   --port, -p <number>   Port to listen on (default: OS-assigned ephemeral port)
   --host <string>       Host to bind to (default: 127.0.0.1)
+  --token, -t <string>  Static auth token (default: random UUID, min 8 chars)
   --help                Show this help message`);
       process.exit(0);
     }
@@ -183,6 +196,7 @@ async function main(): Promise<void> {
       embedded: false,
       host: args.host,
       port: args.port,
+      token: args.token,
       staticDir,
       assetCache,
       onSetHooksEnabled,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -65,6 +65,7 @@ export class PixelAgentsServer {
     embedded?: boolean;
     host?: string;
     port?: number;
+    token?: string;
     staticDir?: string;
     assetCache?: AssetCache;
     onSetHooksEnabled?: SetHooksEnabledSideEffect;
@@ -91,7 +92,7 @@ export class PixelAgentsServer {
     }
 
     // Start our own server
-    const token = crypto.randomUUID();
+    const token = options?.token ?? crypto.randomUUID();
     const store = options?.store;
 
     const { app, port } = await createHttpServer({


### PR DESCRIPTION
## Description

Add a new --token/-t CLI option that allows specifying a static auth token instead of generating a random UUID on each server start.

This is useful for:
  - Persistent API clients that need to survive server restarts
  - Development/testing with known credentials
  - Integration with external tools that store the token

Usage:
  pixel-agents --port 3100 --token my-secret-token
  pixel-agents -p 3100 -t my-secret-token

The token must be at least 8 characters. If omitted, a random UUID is generated as before (default behavior unchanged).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ...

## Test plan

Tested by building the app and running with `--token my-secret-token`, verified the token worked as expected.  I then provided no custom token and the app generated a UUID and stored it in ~/pixel-agents/server.json just like before.

Unit tests have been added to verify normal usage, too-short validation, missing value and that the server actually uses the custom auth token.