### PR TITLE
fix: attribute /clear transcript to the agent whose activity stopped, not the active terminal

### DIFF
--- a/server/__tests__/pickClearClaimant.test.ts
+++ b/server/__tests__/pickClearClaimant.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// fileWatcher.ts does `import * as vscode from 'vscode'` at module load; the 'vscode'
+// package only resolves inside the extension host. Stub the two APIs fileWatcher
+// touches at runtime so the module loads under vitest.
+vi.mock('vscode', () => ({
+  window: {
+    activeTerminal: undefined,
+    terminals: [],
+  },
+}));
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { CLEAR_IDLE_THRESHOLD_MS } from '../src/constants.js';
+import { pickClearClaimant } from '../src/fileWatcher.js';
+import type { AgentState } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: 'sess-1',
+    terminalRef: { name: 'term' },
+    isExternal: false,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 10,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    inputTokens: 0,
+    outputTokens: 0,
+    ...overrides,
+  } as AgentState;
+}
+
+/**
+ * #251 — with two sessions in the same project dir, the /clear transcript must
+ * be claimed by the agent whose activity stopped at the file's creation time,
+ * not by whichever agent happens to be polling (formerly: the active terminal).
+ */
+describe('pickClearClaimant', () => {
+  let agents: AgentStateStore;
+  const now = 1_000_000_000;
+  const idle = CLEAR_IDLE_THRESHOLD_MS + 5_000;
+
+  beforeEach(() => {
+    agents = new AgentStateStore();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+  });
+
+  it('single agent claims its own /clear file', () => {
+    agents.set(1, createTestAgent({ id: 1, lastDataAt: now - idle }));
+    expect(pickClearClaimant(agents, 1, now - idle)).toBe(1);
+  });
+
+  it('the agent whose data stopped at file creation wins over the polling agent', () => {
+    // Agent 1 (polling, e.g. active terminal) went idle long before the /clear;
+    // agent 2 stopped writing right when the new file appeared.
+    const fileBirth = now - idle;
+    agents.set(1, createTestAgent({ id: 1, sessionId: 'a', lastDataAt: fileBirth - 60_000 }));
+    agents.set(2, createTestAgent({ id: 2, sessionId: 'b', lastDataAt: fileBirth - 100 }));
+    expect(pickClearClaimant(agents, 1, fileBirth)).toBe(2);
+  });
+
+  it('polling agent keeps the file when it is the best match', () => {
+    const fileBirth = now - idle;
+    agents.set(1, createTestAgent({ id: 1, sessionId: 'a', lastDataAt: fileBirth - 100 }));
+    agents.set(2, createTestAgent({ id: 2, sessionId: 'b', lastDataAt: fileBirth - 60_000 }));
+    expect(pickClearClaimant(agents, 1, fileBirth)).toBe(1);
+  });
+
+  it('busy (non-idle) agents are not candidates even if closer to file birth', () => {
+    const fileBirth = now - idle;
+    agents.set(1, createTestAgent({ id: 1, sessionId: 'a', lastDataAt: fileBirth - 60_000 }));
+    // Agent 2 is still streaming data — it cannot be the one that ran /clear.
+    agents.set(2, createTestAgent({ id: 2, sessionId: 'b', lastDataAt: now - 1_000 }));
+    expect(pickClearClaimant(agents, 1, fileBirth)).toBe(1);
+  });
+
+  it('external, hook-driven, and terminal-less agents are not candidates', () => {
+    const fileBirth = now - idle;
+    agents.set(1, createTestAgent({ id: 1, sessionId: 'a', lastDataAt: fileBirth - 60_000 }));
+    agents.set(
+      2,
+      createTestAgent({ id: 2, sessionId: 'b', lastDataAt: fileBirth, isExternal: true }),
+    );
+    agents.set(
+      3,
+      createTestAgent({ id: 3, sessionId: 'c', lastDataAt: fileBirth, hookDelivered: true }),
+    );
+    agents.set(
+      4,
+      createTestAgent({ id: 4, sessionId: 'd', lastDataAt: fileBirth, terminalRef: undefined }),
+    );
+    expect(pickClearClaimant(agents, 1, fileBirth)).toBe(1);
+  });
+});

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -96,6 +96,42 @@ let clearDetectionDeps: {
   persistAgents: () => void;
 } | null = null;
 
+/**
+ * Decide which agent should claim a freshly created /clear transcript when
+ * several sessions share a project dir. The session that ran /clear stopped
+ * writing its old transcript at the moment the new file was created, so among
+ * the eligible (internal, hookless, idle) agents the one whose lastDataAt is
+ * closest to the file's creation time is the claimant (#251). Candidate
+ * `agentId` is the polling agent; it is assumed eligible by its own poll gate.
+ */
+export function pickClearClaimant(
+  agents: AgentStateStore,
+  agentId: number,
+  fileBirth: number,
+): number {
+  const self = agents.get(agentId);
+  let bestDelta = self ? Math.abs(self.lastDataAt - fileBirth) : Number.POSITIVE_INFINITY;
+  let claimant = agentId;
+  for (const [otherId, other] of agents) {
+    if (otherId === agentId) continue;
+    if (
+      other.hookDelivered ||
+      !other.terminalRef ||
+      other.isExternal ||
+      other.linesProcessed <= 0 ||
+      Date.now() - other.lastDataAt <= CLEAR_IDLE_THRESHOLD_MS
+    ) {
+      continue;
+    }
+    const delta = Math.abs(other.lastDataAt - fileBirth);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      claimant = otherId;
+    }
+  }
+  return claimant;
+}
+
 export function startFileWatching(
   agentId: number,
   _filePath: string,
@@ -129,7 +165,6 @@ export function startFileWatching(
       !agent.isExternal &&
       ![...agents.values()].some((a) => a.isExternal) &&
       agent.linesProcessed > 0 &&
-      clearDetectionDeps.activeAgentIdRef.current === agentId &&
       Date.now() - agent.lastDataAt > CLEAR_IDLE_THRESHOLD_MS
     ) {
       const deps = clearDetectionDeps;
@@ -166,6 +201,22 @@ export function startFileWatching(
           } catch {
             continue;
           }
+          // Attribute the /clear file to the right agent when several sessions share
+          // this project dir. The session that ran /clear stopped writing its old
+          // transcript at the moment the new file was created, so the eligible agent
+          // whose lastDataAt is closest to the file's creation time is the claimant —
+          // not necessarily the active terminal: the user may be focusing another,
+          // still-busy session when /clear runs elsewhere (#251).
+          let fileBirth = 0;
+          try {
+            const st = fs.statSync(file);
+            fileBirth = st.birthtimeMs || st.mtimeMs;
+          } catch {
+            continue;
+          }
+          // Another idle agent matches the file's creation time better — let its
+          // own poll claim it.
+          if (pickClearClaimant(agents, agentId, fileBirth) !== agentId) continue;
           // Found a /clear file (has last-prompt) → claim it
           deps.knownJsonlFiles.add(file);
           console.log(


### PR DESCRIPTION
Fixes #251

## Problem

With two Claude Code sessions in the same VS Code window (heuristic mode), running `/clear` in one session can swap the two characters' terminal bindings: clicking the busy-looking character focuses the cleared terminal and vice versa. See #251 for a detailed report and reproduction.

## Cause

The heuristic `/clear` detection in `server/src/fileWatcher.ts` gated the claim of a freshly created `/clear` transcript on `activeAgentIdRef.current === agentId` — i.e. whichever agent owns the **active terminal** claims the new file. If `/clear` runs in a background session while the user is focused on a busy one, the busy agent claims the cleared session's transcript as soon as it goes idle for `CLEAR_IDLE_THRESHOLD_MS` (2 s, e.g. between tools), rebinding itself to the other session. Both agent records end up with correct-looking statuses but crossed `terminalRef`s — exactly the swap described in the issue.

A side effect of the old gate: a `/clear` in a non-active terminal was never detected at all.

## Fix

Replace the active-terminal gate with `pickClearClaimant()`: among the eligible agents (internal, hookless, idle past the threshold), the one whose `lastDataAt` is closest to the new file's creation time (`birthtimeMs`) claims it. The session that ran `/clear` stopped writing its old transcript at exactly the moment the new file was created, so file-creation-time proximity is a far more reliable attribution signal than terminal focus. Each agent's own poll makes the decision, so no new coordination is needed; a poll simply skips the file when another agent is the better match.

The hooks path is unaffected — it already attributes `/clear` correctly via the per-agent `pendingClear` flag on `SessionEnd(reason=clear)`.

## Tests

- New unit suite `server/__tests__/pickClearClaimant.test.ts` (5 cases): single-agent claim, best-match wins over the polling agent, polling agent keeps the file when it is the best match, busy agents excluded, external/hook-driven/terminal-less agents excluded.
- `npm run test:server` — 283 passing.
- `npm run compile` (types + lint + build) clean.