### PR TITLE
feat(office): render headless agents as ghosts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,11 +23,15 @@ An AI coding session tracked by Pixel Agents, whether spawned from the office or
 _Avoid_: bot, terminal (as a synonym), session (as a synonym)
 
 **Headless agent**:
-An agent with no terminal — a non-interactive run adopted from outside the office, for example. A full citizen: it has a seat and can be selected, but there is no terminal to focus. Agents it spawns are sub-agents or teammates like anyone else's.
+An agent with no terminal — a non-interactive run adopted from outside the office, for example. A full citizen: it has a seat and can be selected, but there is no terminal to focus. Agents it spawns are sub-agents or teammates like anyone else's. Optionally drawn as a Ghost.
 
 **Character**:
 The animated pixel-art figure representing an agent in the office. An agent has a status and a session; its character has a position and an animation state.
 _Avoid_: avatar, sprite (a sprite is the image asset, not the figure)
+
+**Ghost**:
+A character drawn translucent because its agent is headless — the visual shorthand for "nothing to focus here". Opt-in: off unless the user turns on "Display Headless as Ghosts", and never used in adapters without terminals, where every agent would qualify and the cue would say nothing. Teammates and sub-agents are never ghosts; clicking one reaches its lead's or parent's terminal.
+_Avoid_: faded, dimmed, transparent, inactive (that's a status)
 
 **Sub-agent**:
 An unnamed piece of delegated work spawned by an agent, visualized with its own character near its parent — around it, not in a seat. Not an Agent (no session of its own) and not a Teammate (no name). It exists only for the duration of its task, which may outlive the parent's turn. Having no name is what makes it a sub-agent.

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -48,6 +48,7 @@ import {
   CONFIG_KEY_AUTO_SHOW_PANEL,
   CONFIG_KEY_AUTO_SPAWN_AGENT,
   GLOBAL_KEY_ALWAYS_SHOW_LABELS,
+  GLOBAL_KEY_GHOST_HEADLESS_AGENTS,
   GLOBAL_KEY_HOOKS_ENABLED,
   GLOBAL_KEY_HOOKS_INFO_SHOWN,
   GLOBAL_KEY_LAST_SEEN_VERSION,
@@ -293,6 +294,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         this.adapter.setSetting(GLOBAL_KEY_LAST_SEEN_VERSION, message.version as string);
       } else if (message.type === 'setAlwaysShowLabels') {
         this.adapter.setSetting(GLOBAL_KEY_ALWAYS_SHOW_LABELS, message.enabled);
+      } else if (message.type === 'setGhostHeadlessAgents') {
+        this.adapter.setSetting(GLOBAL_KEY_GHOST_HEADLESS_AGENTS, message.enabled);
       } else if (message.type === 'setHooksEnabled') {
         const enabled = message.enabled as boolean;
         this.adapter.setSetting(GLOBAL_KEY_HOOKS_ENABLED, enabled);
@@ -395,6 +398,10 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           GLOBAL_KEY_ALWAYS_SHOW_LABELS,
           false,
         );
+        const ghostHeadlessAgents = this.adapter.getSetting<boolean>(
+          GLOBAL_KEY_GHOST_HEADLESS_AGENTS,
+          true,
+        );
         this.runtime.watchAllSessions.current = watchAllSessions;
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);
         const hooksInfoShown = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_INFO_SHOWN, false);
@@ -407,6 +414,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
           extensionVersion,
           watchAllSessions,
           alwaysShowLabels,
+          ghostHeadlessAgents,
           hooksEnabled,
           hooksInfoShown,
           externalAssetDirectories: config.externalAssetDirectories,

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -400,7 +400,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         );
         const ghostHeadlessAgents = this.adapter.getSetting<boolean>(
           GLOBAL_KEY_GHOST_HEADLESS_AGENTS,
-          true,
+          false,
         );
         this.runtime.watchAllSessions.current = watchAllSessions;
         const hooksEnabled = this.adapter.getSetting<boolean>(GLOBAL_KEY_HOOKS_ENABLED, true);

--- a/adapters/vscode/constants.ts
+++ b/adapters/vscode/constants.ts
@@ -18,6 +18,7 @@ export {
 export const GLOBAL_KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 export const GLOBAL_KEY_LAST_SEEN_VERSION = 'pixel-agents.lastSeenVersion';
 export const GLOBAL_KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
+export const GLOBAL_KEY_GHOST_HEADLESS_AGENTS = 'pixel-agents.ghostHeadlessAgents';
 export const GLOBAL_KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 export const GLOBAL_KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 export const GLOBAL_KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -129,6 +129,7 @@ components:
         - $ref: '#/components/schemas/SetSoundEnabled'
         - $ref: '#/components/schemas/SetLastSeenVersion'
         - $ref: '#/components/schemas/SetAlwaysShowLabels'
+        - $ref: '#/components/schemas/SetGhostHeadlessAgents'
         - $ref: '#/components/schemas/SetHooksEnabled'
         - $ref: '#/components/schemas/SetHooksInfoShown'
         - $ref: '#/components/schemas/SetWatchAllSessions'
@@ -629,6 +630,7 @@ components:
         - extensionVersion
         - watchAllSessions
         - alwaysShowLabels
+        - ghostHeadlessAgents
         - hooksEnabled
         - hooksInfoShown
         - externalAssetDirectories
@@ -645,6 +647,8 @@ components:
         watchAllSessions:
           type: boolean
         alwaysShowLabels:
+          type: boolean
+        ghostHeadlessAgents:
           type: boolean
         hooksEnabled:
           type: boolean
@@ -815,6 +819,19 @@ components:
       properties:
         type:
           const: setAlwaysShowLabels
+        enabled:
+          type: boolean
+
+    SetGhostHeadlessAgents:
+      description: >-
+        Toggle translucent rendering for headless agents (adopted sessions with no
+        terminal to focus).
+      type: object
+      additionalProperties: false
+      required: [type, enabled]
+      properties:
+        type:
+          const: setGhostHeadlessAgents
         enabled:
           type: boolean
 

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -48,6 +48,7 @@ export type ClientMessage =
   | SetSoundEnabled
   | SetLastSeenVersion
   | SetAlwaysShowLabels
+  | SetGhostHeadlessAgents
   | SetHooksEnabled
   | SetHooksInfoShown
   | SetWatchAllSessions
@@ -264,6 +265,7 @@ export interface SettingsLoaded {
   extensionVersion: string;
   watchAllSessions: boolean;
   alwaysShowLabels: boolean;
+  ghostHeadlessAgents: boolean;
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
   externalAssetDirectories: string[];
@@ -343,6 +345,11 @@ export interface SetLastSeenVersion {
 
 export interface SetAlwaysShowLabels {
   type: 'setAlwaysShowLabels';
+  enabled: boolean;
+}
+
+export interface SetGhostHeadlessAgents {
+  type: 'setGhostHeadlessAgents';
   enabled: boolean;
 }
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -178,7 +178,7 @@ This section is auto-generated. Do not edit between the markers; CI fails on dri
 ### `@area:spawn` (2 tests)
 
 - `e2e/claude/hooks-on/basic.spec.ts:34` — internal terminal spawns agent and Task subagent appears then despawns (Hooks ON / spawn paths)
-- `e2e/claude/hooks-on/basic.spec.ts:114` — external Claude session adopted via hook confirmation lifecycle (Hooks ON / spawn paths)
+- `e2e/claude/hooks-on/basic.spec.ts:120` — external Claude session adopted via hook confirmation lifecycle (Hooks ON / spawn paths)
 
 ### `@area:lifecycle` (22 tests)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -177,8 +177,8 @@ This section is auto-generated. Do not edit between the markers; CI fails on dri
 
 ### `@area:spawn` (2 tests)
 
-- `e2e/claude/hooks-on/basic.spec.ts:33` — internal terminal spawns agent and Task subagent appears then despawns (Hooks ON / spawn paths)
-- `e2e/claude/hooks-on/basic.spec.ts:108` — external Claude session adopted via hook confirmation lifecycle (Hooks ON / spawn paths)
+- `e2e/claude/hooks-on/basic.spec.ts:34` — internal terminal spawns agent and Task subagent appears then despawns (Hooks ON / spawn paths)
+- `e2e/claude/hooks-on/basic.spec.ts:114` — external Claude session adopted via hook confirmation lifecycle (Hooks ON / spawn paths)
 
 ### `@area:lifecycle` (22 tests)
 
@@ -218,8 +218,8 @@ This section is auto-generated. Do not edit between the markers; CI fails on dri
 - `e2e/claude/hooks-on/lifecycle.spec.ts:1447` — hook install and uninstall round-trip via the Settings toggle (Hooks ON / lifecycle)
 - `e2e/claude/hooks-on/lifecycle.spec.ts:1501` — permission bubble auto-clears when a fresh PreToolUse arrives (Hooks ON / lifecycle)
 - `e2e/claude/hooks-on/lifecycle.spec.ts:1575` — settings toggles persist across a webview reload (Hooks ON / lifecycle)
-- `e2e/claude/hooks-on/lifecycle.spec.ts:1617` — layout editor enter paint save persist and exit round-trip (Hooks ON / lifecycle)
-- `e2e/claude/hooks-on/lifecycle.spec.ts:1698` — hook uninstall preserves a pre-existing third-party hook entry (Hooks ON / lifecycle)
+- `e2e/claude/hooks-on/lifecycle.spec.ts:1623` — layout editor enter paint save persist and exit round-trip (Hooks ON / lifecycle)
+- `e2e/claude/hooks-on/lifecycle.spec.ts:1704` — hook uninstall preserves a pre-existing third-party hook entry (Hooks ON / lifecycle)
 
 ### `@area:teams` (7 tests)
 

--- a/e2e/helpers/office.ts
+++ b/e2e/helpers/office.ts
@@ -176,6 +176,39 @@ export async function expectSingleAgentOverlay(frame: OverlaySurface): Promise<n
 }
 
 /**
+ * Assert whether the office's single character is drawn as a ghost — the
+ * translucent rendering a headless agent gets (adopted from outside, so there
+ * is no terminal to focus) while "Display Headless as Ghosts" is on.
+ *
+ * Both inputs to that decision are canvas-only: the per-character flag and the
+ * renderer's setting. So this reads them through the test hooks and combines
+ * them the same way the renderer does — same rationale as getCharacters/getPets.
+ */
+export async function expectCharacterGhosted(
+  frame: OverlaySurface,
+  ghosted: boolean,
+): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        await frame.evaluate(() => {
+          interface GhostHooks {
+            getCharacters?: () => Array<{ id: number; isHeadless?: boolean }>;
+            getGhostHeadlessAgents?: () => boolean;
+          }
+          const hooks = (window as { __pixelAgentsTestHooks?: GhostHooks }).__pixelAgentsTestHooks;
+          const characters = hooks?.getCharacters?.() ?? [];
+          if (characters.length !== 1) return `expected 1 character, got ${characters.length}`;
+          const setting = hooks?.getGhostHeadlessAgents?.() ?? false;
+          return characters[0]!.isHeadless === true && setting;
+        }),
+      { timeout: OVERLAY_TIMEOUT_MS },
+    )
+    .toBe(ghosted);
+  narrate.check(`character is drawn ${ghosted ? 'as a ghost (translucent)' : 'fully opaque'}`);
+}
+
+/**
  * Assert the named teammate character occupies the free seat closest to its
  * lead. Seats and characters render only on the canvas (no DOM), so this reads
  * through the test hooks — the same rationale as getCharacters/getPets.

--- a/e2e/helpers/webview.ts
+++ b/e2e/helpers/webview.ts
@@ -16,6 +16,7 @@ export interface WebviewSettings {
   watchAllSessions?: boolean;
   hooksEnabled?: boolean;
   alwaysShowLabels?: boolean;
+  ghostHeadlessAgents?: boolean;
   debugView?: boolean;
 }
 
@@ -478,6 +479,9 @@ export async function setSettings(frame: WebviewSurface, settings: WebviewSettin
   }
   if (settings.alwaysShowLabels !== undefined) {
     await setCheckbox(settingsModal, 'Always Show Labels', settings.alwaysShowLabels);
+  }
+  if (settings.ghostHeadlessAgents !== undefined) {
+    await setCheckbox(settingsModal, 'Display Headless as Ghosts', settings.ghostHeadlessAgents);
   }
   if (settings.debugView !== undefined) {
     await setCheckbox(settingsModal, 'Debug View', settings.debugView);

--- a/e2e/tests/claude/hooks-on/basic.spec.ts
+++ b/e2e/tests/claude/hooks-on/basic.spec.ts
@@ -36,6 +36,12 @@ test.describe('Hooks ON / spawn paths', () => {
   }) => {
     const { frame, window, tmpHome, mockLogFile, narrator } = pixelAgents;
 
+    // Ghosting ships off, so turn it on before anything spawns. That makes the
+    // "not a ghost" assertion below say something — that this agent owns a
+    // terminal — rather than merely restating the default.
+    narrator.step('enabling "Display Headless as Ghosts" so the opacity cue is live');
+    await setSettings(frame, { ghostHeadlessAgents: true });
+
     // Sub-character appears on Task tool_use and despawns on tool_result.
     // Task subagent lifecycle is JSONL-driven even in hooks-on mode
     // (transcriptParser routes Task/Agent tool events through JSONL
@@ -116,9 +122,13 @@ test.describe('Hooks ON / spawn paths', () => {
   }) => {
     const { frame, tmpHome, workspaceDir, mockLogFile, narrator } = pixelAgents;
 
-    narrator.step('enabling Watch All Sessions so the hooks-only session gets adopted');
+    // Ghosting ships off, so the test turns it on — otherwise the adopted agent
+    // below is headless but drawn at full opacity, which is the correct default
+    // behaviour and would make the ghost assertion unreachable.
+    narrator.step('enabling Watch All Sessions + ghosting so the hooks-only session gets adopted');
     await setSettings(frame, {
       watchAllSessions: true,
+      ghostHeadlessAgents: true,
     });
 
     narrator.step('waiting for the hook install and hook server to be ready');

--- a/e2e/tests/claude/hooks-on/basic.spec.ts
+++ b/e2e/tests/claude/hooks-on/basic.spec.ts
@@ -17,6 +17,7 @@ import {
   waitForClaudeHookSetup,
 } from '../../../helpers/mock-claude';
 import {
+  expectCharacterGhosted,
   expectContextGauge,
   expectOverlayCount,
   expectOverlayVisible,
@@ -74,6 +75,11 @@ test.describe('Hooks ON / spawn paths', () => {
     const terminalTab = window.getByText(/Claude Code #\d+/);
     await expect(terminalTab.first()).toBeVisible({ timeout: 15_000 });
     narrator.check('a real "Claude Code #N" terminal tab is open');
+
+    // The terminal above is exactly what makes this agent NOT headless: it has
+    // one to focus, so it renders fully opaque (contrast: the adopted external
+    // session in the next test).
+    await expectCharacterGhosted(panelFrame, false);
 
     narrator.step('waiting for the t+5s Task tool_use to spawn a "Subtask" character');
     await expectOverlayCount(panelFrame, 2);
@@ -157,6 +163,10 @@ test.describe('Hooks ON / spawn paths', () => {
     await expectOverlayCount(frame, 1);
     await expectOverlayVisible(frame, 'Running: npm test');
     narrator.check('the external agent appeared — "Running: npm test"');
+
+    // Adopted from outside via Watch All Sessions: no terminal to focus, so the
+    // character is headless and renders translucent.
+    await expectCharacterGhosted(frame, true);
 
     // 2. PermissionRequest (t+4.5s) → "Needs approval"
     narrator.step('waiting for the t+4.5s PermissionRequest');

--- a/e2e/tests/claude/hooks-on/lifecycle.spec.ts
+++ b/e2e/tests/claude/hooks-on/lifecycle.spec.ts
@@ -1582,10 +1582,15 @@ test.describe('Hooks ON / lifecycle', () => {
     // assertion is about the FLIPPED state surviving a reload, not about the
     // initial default value.
     const initial = await getSettingChecked(frame, 'Always Show Labels');
-    narrator.step('flipping "Always Show Labels" in Settings');
-    await setSettings(frame, { alwaysShowLabels: !initial });
+    const initialGhost = await getSettingChecked(frame, 'Display Headless as Ghosts');
+    narrator.step('flipping "Always Show Labels" + "Display Headless as Ghosts" in Settings');
+    await setSettings(frame, {
+      alwaysShowLabels: !initial,
+      ghostHeadlessAgents: !initialGhost,
+    });
     expect(await getSettingChecked(frame, 'Always Show Labels')).toBe(!initial);
-    narrator.check('"Always Show Labels" is now flipped');
+    expect(await getSettingChecked(frame, 'Display Headless as Ghosts')).toBe(!initialGhost);
+    narrator.check('both toggles are now flipped');
 
     // Force a fresh webview by closing and reopening the panel (same
     // mechanism the restored-agents test uses for the existingAgents restore path).
@@ -1597,6 +1602,7 @@ test.describe('Hooks ON / lifecycle', () => {
     // After settingsLoaded re-hydrates, the toggle must still be in the
     // flipped state — not back to the fixture default.
     expect(await getSettingChecked(frame, 'Always Show Labels')).toBe(!initial);
+    expect(await getSettingChecked(frame, 'Display Headless as Ghosts')).toBe(!initialGhost);
     narrator.check('flipped state survives the reload — persisted through config.json');
   });
 

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -244,7 +244,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     extensionVersion: process.env.PIXEL_AGENTS_VERSION ?? '',
     watchAllSessions,
     alwaysShowLabels: adapter?.getSetting(KEY_ALWAYS_SHOW_LABELS, false) ?? false,
-    ghostHeadlessAgents: adapter?.getSetting(KEY_GHOST_HEADLESS_AGENTS, true) ?? true,
+    ghostHeadlessAgents: adapter?.getSetting(KEY_GHOST_HEADLESS_AGENTS, false) ?? false,
     hooksEnabled,
     hooksInfoShown: adapter?.getSetting(KEY_HOOKS_INFO_SHOWN, false) ?? false,
     externalAssetDirectories: cfg.externalAssetDirectories,

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -43,6 +43,7 @@ export interface ClientMessageContext {
 const KEY_SOUND_ENABLED = 'pixel-agents.soundEnabled';
 const KEY_LAST_SEEN_VERSION = 'pixel-agents.lastSeenVersion';
 const KEY_ALWAYS_SHOW_LABELS = 'pixel-agents.alwaysShowLabels';
+const KEY_GHOST_HEADLESS_AGENTS = 'pixel-agents.ghostHeadlessAgents';
 const KEY_WATCH_ALL_SESSIONS = 'pixel-agents.watchAllSessions';
 const KEY_HOOKS_ENABLED = 'pixel-agents.hooksEnabled';
 const KEY_HOOKS_INFO_SHOWN = 'pixel-agents.hooksInfoShown';
@@ -111,6 +112,10 @@ export function handleClientMessage(
 
     case 'setAlwaysShowLabels':
       adapter?.setSetting(KEY_ALWAYS_SHOW_LABELS, msg.enabled);
+      break;
+
+    case 'setGhostHeadlessAgents':
+      adapter?.setSetting(KEY_GHOST_HEADLESS_AGENTS, msg.enabled);
       break;
 
     case 'setWatchAllSessions': {
@@ -239,6 +244,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     extensionVersion: process.env.PIXEL_AGENTS_VERSION ?? '',
     watchAllSessions,
     alwaysShowLabels: adapter?.getSetting(KEY_ALWAYS_SHOW_LABELS, false) ?? false,
+    ghostHeadlessAgents: adapter?.getSetting(KEY_GHOST_HEADLESS_AGENTS, true) ?? true,
     hooksEnabled,
     hooksInfoShown: adapter?.getSetting(KEY_HOOKS_INFO_SHOWN, false) ?? false,
     externalAssetDirectories: cfg.externalAssetDirectories,

--- a/server/src/configPersistence.ts
+++ b/server/src/configPersistence.ts
@@ -8,6 +8,7 @@ export interface AdapterSettings {
   soundEnabled: boolean;
   lastSeenVersion: string;
   alwaysShowLabels: boolean;
+  ghostHeadlessAgents: boolean;
   watchAllSessions: boolean;
   hooksEnabled: boolean;
   hooksInfoShown: boolean;
@@ -20,6 +21,7 @@ export const ADAPTER_SETTING_KEYS = [
   'soundEnabled',
   'lastSeenVersion',
   'alwaysShowLabels',
+  'ghostHeadlessAgents',
   'watchAllSessions',
   'hooksEnabled',
   'hooksInfoShown',
@@ -42,6 +44,7 @@ const DEFAULT_ADAPTER_SETTINGS: AdapterSettings = {
   soundEnabled: true,
   lastSeenVersion: '',
   alwaysShowLabels: false,
+  ghostHeadlessAgents: true,
   watchAllSessions: false,
   hooksEnabled: true,
   hooksInfoShown: false,
@@ -93,6 +96,10 @@ function parseAdapterSettings(raw: unknown): AdapterSettings {
       typeof obj.alwaysShowLabels === 'boolean'
         ? obj.alwaysShowLabels
         : DEFAULT_ADAPTER_SETTINGS.alwaysShowLabels,
+    ghostHeadlessAgents:
+      typeof obj.ghostHeadlessAgents === 'boolean'
+        ? obj.ghostHeadlessAgents
+        : DEFAULT_ADAPTER_SETTINGS.ghostHeadlessAgents,
     watchAllSessions:
       typeof obj.watchAllSessions === 'boolean'
         ? obj.watchAllSessions

--- a/server/src/configPersistence.ts
+++ b/server/src/configPersistence.ts
@@ -44,7 +44,7 @@ const DEFAULT_ADAPTER_SETTINGS: AdapterSettings = {
   soundEnabled: true,
   lastSeenVersion: '',
   alwaysShowLabels: false,
-  ghostHeadlessAgents: true,
+  ghostHeadlessAgents: false,
   watchAllSessions: false,
   hooksEnabled: true,
   hooksInfoShown: false,

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -82,6 +82,8 @@ function App() {
     watchAllSessions,
     setWatchAllSessions,
     alwaysShowLabels,
+    ghostHeadlessAgents,
+    setGhostHeadlessAgents,
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,
@@ -126,6 +128,14 @@ function App() {
       return newVal;
     });
   }, []);
+
+  // Toggle "Display headless as ghosts". setGhostHeadlessAgents also updates the
+  // renderer's module copy, so the office redraws on the next frame.
+  const handleToggleGhostHeadlessAgents = useCallback(() => {
+    const next = !ghostHeadlessAgents;
+    setGhostHeadlessAgents(next);
+    transport.send({ type: 'setGhostHeadlessAgents', enabled: next });
+  }, [ghostHeadlessAgents, setGhostHeadlessAgents]);
 
   const handleSelectAgent = useCallback((id: number) => {
     transport.send({ type: 'focusAgent', id });
@@ -509,6 +519,8 @@ function App() {
         onToggleDebugMode={handleToggleDebugMode}
         alwaysShowOverlay={alwaysShowOverlay}
         onToggleAlwaysShowOverlay={handleToggleAlwaysShowOverlay}
+        ghostHeadlessAgents={ghostHeadlessAgents}
+        onToggleGhostHeadlessAgents={handleToggleGhostHeadlessAgents}
         externalAssetDirectories={externalAssetDirectories}
         watchAllSessions={watchAllSessions}
         onToggleWatchAllSessions={() => {

--- a/webview-ui/src/components/SettingsModal.tsx
+++ b/webview-ui/src/components/SettingsModal.tsx
@@ -15,6 +15,9 @@ interface SettingsModalProps {
   onToggleDebugMode: () => void;
   alwaysShowOverlay: boolean;
   onToggleAlwaysShowOverlay: () => void;
+  /** Whether headless agents (adopted, no terminal to focus) render translucent. */
+  ghostHeadlessAgents: boolean;
+  onToggleGhostHeadlessAgents: () => void;
   externalAssetDirectories: string[];
   watchAllSessions: boolean;
   onToggleWatchAllSessions: () => void;
@@ -38,6 +41,8 @@ export function SettingsModal({
   onToggleDebugMode,
   alwaysShowOverlay,
   onToggleAlwaysShowOverlay,
+  ghostHeadlessAgents,
+  onToggleGhostHeadlessAgents,
   externalAssetDirectories,
   watchAllSessions,
   onToggleWatchAllSessions,
@@ -185,6 +190,15 @@ export function SettingsModal({
         checked={alwaysShowOverlay}
         onChange={onToggleAlwaysShowOverlay}
       />
+      {/* Headless agents are the office's only terminal-less citizens in VS Code.
+          Standalone has no terminals at all, so nothing there would ever ghost. */}
+      {!isBrowserRuntime && (
+        <Checkbox
+          label="Display Headless as Ghosts"
+          checked={ghostHeadlessAgents}
+          onChange={onToggleGhostHeadlessAgents}
+        />
+      )}
       {showAreasAvailable && (
         <Checkbox label="Show Areas" checked={showAreas} onChange={onToggleShowAreas} />
       )}

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -41,6 +41,8 @@ export const CHARACTER_Z_SORT_OFFSET = 0.5;
 export const OUTLINE_Z_SORT_OFFSET = 0.001;
 export const SELECTED_OUTLINE_ALPHA = 1.0;
 export const HOVERED_OUTLINE_ALPHA = 0.5;
+/** Headless agents (adopted, no terminal to focus) render slightly translucent. */
+export const HEADLESS_CHARACTER_ALPHA = 0.5;
 export const GHOST_PREVIEW_SPRITE_ALPHA = 0.5;
 export const GHOST_PREVIEW_TINT_ALPHA = 0.25;
 export const SELECTION_DASH_PATTERN: [number, number] = [4, 3];

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { playDoneSound, playPermissionSound, setSoundEnabled } from '../notificationSound.js';
 import type { ExistingAgentMeta, PendingAgent } from '../office/engine/existingAgents.js';
 import { reconcileExistingAgents } from '../office/engine/existingAgents.js';
 import type { OfficeState } from '../office/engine/officeState.js';
+import { setGhostHeadlessAgents as setRendererGhostHeadlessAgents } from '../office/engine/renderer.js';
 import { setFloorSprites } from '../office/floorTiles.js';
 import { buildDynamicCatalog } from '../office/layout/furnitureCatalog.js';
 import { migrateLayoutColors } from '../office/layout/layoutSerializer.js';
@@ -17,8 +18,19 @@ import {
 } from '../office/toolUtils.js';
 import type { OfficeLayout, ToolActivity } from '../office/types.js';
 import { setWallSprites } from '../office/wallTiles.js';
-import { isE2E } from '../runtime.js';
+import { isBrowserRuntime, isE2E } from '../runtime.js';
 import { transport } from '../transport/index.js';
+
+/**
+ * A Headless agent is one the office adopted from outside (`claude -p`, a session
+ * picked up by Watch All Sessions) and therefore has no terminal to focus. Its
+ * character renders translucent so it reads as untouchable at a glance.
+ *
+ * Standalone is exempt: that adapter has no terminals at all, so every agent
+ * would qualify and the cue would distinguish nothing.
+ */
+const isHeadlessAgent = (isExternal: boolean | undefined): boolean =>
+  isExternal === true && !isBrowserRuntime;
 
 export interface SubagentCharacter {
   id: number;
@@ -74,6 +86,8 @@ interface ExtensionMessageState {
   watchAllSessions: boolean;
   setWatchAllSessions: (v: boolean) => void;
   alwaysShowLabels: boolean;
+  ghostHeadlessAgents: boolean;
+  setGhostHeadlessAgents: (v: boolean) => void;
   hooksEnabled: boolean;
   setHooksEnabled: (v: boolean) => void;
   hooksInfoShown: boolean;
@@ -118,10 +132,19 @@ export function useExtensionMessages(
   const [extensionVersion, setExtensionVersion] = useState('');
   const [watchAllSessions, setWatchAllSessions] = useState(false);
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
+  const [ghostHeadlessAgents, setGhostHeadlessAgentsState] = useState(true);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
   const [areaMappings, setAreaMappings] = useState<Record<string, string[]>>({});
   const [showAreas, setShowAreas] = useState(false);
+
+  // The renderer keeps its own module-level copy (read every rAF frame), so both
+  // sources of truth move together — the persisted value on settingsLoaded and
+  // the user's click in Settings.
+  const applyGhostHeadlessAgents = useCallback((enabled: boolean) => {
+    setGhostHeadlessAgentsState(enabled);
+    setRendererGhostHeadlessAgents(enabled);
+  }, []);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)
   const layoutReadyRef = useRef(false);
@@ -194,6 +217,7 @@ export function useExtensionMessages(
         // Add buffered agents now that layout (and seats) are correct
         for (const p of pendingAgents) {
           os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+          if (p.isHeadless) os.setHeadless(p.id, true);
         }
         pendingAgents = [];
         layoutReadyRef.current = true;
@@ -243,6 +267,9 @@ export function useExtensionMessages(
         } else {
           os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
           noteFolderName(folderName);
+          if (isHeadlessAgent(msg.isExternal as boolean | undefined)) {
+            os.setHeadless(id, true);
+          }
         }
         saveAgentSeats(os);
       } else if (msg.type === 'agentClosed') {
@@ -276,8 +303,11 @@ export function useExtensionMessages(
         const incoming = msg.agents as number[];
         const meta = (msg.agentMeta || {}) as Record<number, ExistingAgentMeta>;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
+        const externalAgents = (msg.externalAgents || {}) as Record<number, boolean>;
+        const headlessAgents: Record<number, boolean> = {};
         for (const id of incoming) {
           noteFolderName(folderNames[id]);
+          if (isHeadlessAgent(externalAgents[id])) headlessAgents[id] = true;
         }
         // Order-independent restore: add agents now if the layout (and its seats)
         // is already built, otherwise buffer them for the next layoutLoaded.
@@ -291,6 +321,7 @@ export function useExtensionMessages(
             folderNames,
             layoutReadyRef.current,
             pendingAgents,
+            headlessAgents,
           )
         ) {
           saveAgentSeats(os);
@@ -604,6 +635,9 @@ export function useExtensionMessages(
         if (typeof msg.alwaysShowLabels === 'boolean') {
           setAlwaysShowLabels(msg.alwaysShowLabels as boolean);
         }
+        if (typeof msg.ghostHeadlessAgents === 'boolean') {
+          applyGhostHeadlessAgents(msg.ghostHeadlessAgents as boolean);
+        }
         if (typeof msg.hooksEnabled === 'boolean') {
           setHooksEnabled(msg.hooksEnabled as boolean);
         }
@@ -691,6 +725,8 @@ export function useExtensionMessages(
     watchAllSessions,
     setWatchAllSessions,
     alwaysShowLabels,
+    ghostHeadlessAgents,
+    setGhostHeadlessAgents: applyGhostHeadlessAgents,
     hooksEnabled,
     setHooksEnabled,
     hooksInfoShown,

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -132,7 +132,7 @@ export function useExtensionMessages(
   const [extensionVersion, setExtensionVersion] = useState('');
   const [watchAllSessions, setWatchAllSessions] = useState(false);
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
-  const [ghostHeadlessAgents, setGhostHeadlessAgentsState] = useState(true);
+  const [ghostHeadlessAgents, setGhostHeadlessAgentsState] = useState(false);
   const [hooksEnabled, setHooksEnabled] = useState(true);
   const [hooksInfoShown, setHooksInfoShown] = useState(true);
   const [areaMappings, setAreaMappings] = useState<Record<string, string[]>>({});

--- a/webview-ui/src/office/engine/existingAgents.ts
+++ b/webview-ui/src/office/engine/existingAgents.ts
@@ -25,6 +25,7 @@ export interface PendingAgent {
   hueShift?: number;
   seatId?: string;
   folderName?: string;
+  isHeadless?: boolean;
 }
 
 /** Minimal structural view of OfficeState this reconciler needs. */
@@ -38,6 +39,7 @@ export interface ExistingAgentsOffice {
     skipSpawnEffect?: boolean,
     folderName?: string,
   ) => void;
+  setHeadless: (id: number, headless: boolean) => void;
 }
 
 /**
@@ -54,6 +56,7 @@ export function reconcileExistingAgents(
   folderNames: Record<number, string>,
   layoutReady: boolean,
   pending: PendingAgent[],
+  headlessAgents: Record<number, boolean> = {},
 ): boolean {
   let addedDirectly = false;
   for (const id of incoming) {
@@ -64,10 +67,12 @@ export function reconcileExistingAgents(
       hueShift: m?.hueShift,
       seatId: m?.seatId,
       folderName: folderNames[id],
+      isHeadless: headlessAgents[id] === true,
     };
     if (layoutReady) {
       if (!os.characters.has(p.id)) {
         os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+        if (p.isHeadless) os.setHeadless(p.id, true);
         addedDirectly = true;
       }
     } else {

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -1007,12 +1007,25 @@ export class OfficeState {
     if (teamUsesTmux !== undefined) {
       ch.teamUsesTmux = teamUsesTmux;
     }
+    // A teammate is not a headless agent: clicking it focuses its lead's terminal.
+    // Adopted sessions are marked headless at creation and only later discovered
+    // to be teammates, so drop the mark once the link lands.
+    if (leadAgentId !== undefined) {
+      ch.isHeadless = false;
+    }
     // A teammate discovered only after its plain external session was adopted is
     // linked here, not at creation, so it never went through the seat-next-to-lead
     // path addAgent runs for inline teammates. Cluster it now, once, on first link.
     if (wasUnlinked && leadAgentId !== undefined && !isTeamLead) {
       this.reseatNextToLead(id, leadAgentId);
     }
+  }
+
+  /** Mark an agent as headless (adopted, no terminal to focus). */
+  setHeadless(id: number, headless: boolean): void {
+    const ch = this.characters.get(id);
+    if (!ch) return;
+    ch.isHeadless = headless;
   }
 
   setAgentContext(id: number, contextTokens: number, maxContextTokens: number): void {

--- a/webview-ui/src/office/engine/renderer.ts
+++ b/webview-ui/src/office/engine/renderer.ts
@@ -31,6 +31,7 @@ import {
   GHOST_PREVIEW_TINT_ALPHA,
   GHOST_VALID_TINT,
   GRID_LINE_COLOR,
+  HEADLESS_CHARACTER_ALPHA,
   HOVERED_OUTLINE_ALPHA,
   OUTLINE_Z_SORT_OFFSET,
   ROTATE_BUTTON_BG,
@@ -72,6 +73,25 @@ import { getWallInstances, hasWallSprites, wallColorToHex } from '../wallTiles.j
 import { getCharacterSprite } from './characters.js';
 import { renderMatrixEffect } from './matrixEffect.js';
 import { getPetSpriteData } from './petEntity.js';
+
+// ── Settings ────────────────────────────────────────────────────
+
+/**
+ * "Display headless as ghosts" — whether headless agents render translucent.
+ * Module state rather than a render param: the rAF loop reads it every frame,
+ * so a toggle takes effect on the next one without threading a 21st argument
+ * through renderFrame. Same shape as setProviderCapabilities / setSoundEnabled.
+ * Mirrors the server default (on).
+ */
+let ghostHeadlessAgents = true;
+
+export function setGhostHeadlessAgents(enabled: boolean): void {
+  ghostHeadlessAgents = enabled;
+}
+
+export function isGhostHeadlessAgentsEnabled(): boolean {
+  return ghostHeadlessAgents;
+}
 
 // ── Render functions ────────────────────────────────────────────
 
@@ -381,6 +401,10 @@ export function renderScene(
     // at lower rows (e.g. desks, bookshelves that occlude from below).
     const charZY = ch.y + TILE_SIZE / 2 + CHARACTER_Z_SORT_OFFSET;
 
+    // Headless agents (adopted, no terminal to focus) render translucent while
+    // the "Display headless as ghosts" setting is on.
+    const alpha = ch.isHeadless && ghostHeadlessAgents ? HEADLESS_CHARACTER_ALPHA : 1;
+
     // Matrix spawn/despawn effect — skip outline, use per-pixel rendering
     if (ch.matrixEffect) {
       const mDrawX = drawX;
@@ -390,7 +414,10 @@ export function renderScene(
       drawables.push({
         zY: charZY,
         draw: (c) => {
+          c.save();
+          c.globalAlpha = alpha;
           renderMatrixEffect(c, mCh, mSpriteData, mDrawX, mDrawY, zoom);
+          c.restore();
         },
       });
       continue;
@@ -419,7 +446,14 @@ export function renderScene(
     drawables.push({
       zY: charZY,
       draw: (c) => {
+        if (alpha === 1) {
+          c.drawImage(cached, drawX, drawY);
+          return;
+        }
+        c.save();
+        c.globalAlpha = alpha;
         c.drawImage(cached, drawX, drawY);
+        c.restore();
       },
     });
   }

--- a/webview-ui/src/office/engine/renderer.ts
+++ b/webview-ui/src/office/engine/renderer.ts
@@ -81,9 +81,10 @@ import { getPetSpriteData } from './petEntity.js';
  * Module state rather than a render param: the rAF loop reads it every frame,
  * so a toggle takes effect on the next one without threading a 21st argument
  * through renderFrame. Same shape as setProviderCapabilities / setSoundEnabled.
- * Mirrors the server default (on).
+ * Mirrors the server default (off) — the cue is opt-in, so an office looks the
+ * same as it did before the setting existed until someone turns it on.
  */
-let ghostHeadlessAgents = true;
+let ghostHeadlessAgents = false;
 
 export function setGhostHeadlessAgents(enabled: boolean): void {
   ghostHeadlessAgents = enabled;

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -223,6 +223,10 @@ export interface Character {
   matrixEffectSeeds: number[];
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Headless agent: adopted from outside the office, so there is no terminal to
+   *  focus. Rendered translucent. Teammates and sub-agents are never headless —
+   *  clicking them reaches their lead's / parent's terminal. */
+  isHeadless?: boolean;
 
   // -- Agent Teams --
   /** Team name this agent belongs to */

--- a/webview-ui/src/testHooks.ts
+++ b/webview-ui/src/testHooks.ts
@@ -1,5 +1,6 @@
 import type { ColorValue } from './components/ui/types.js';
 import { OfficeState } from './office/engine/officeState.js';
+import { isGhostHeadlessAgentsEnabled } from './office/engine/renderer.js';
 import { carpetJunctionCase } from './office/sprites/carpetTiles.js';
 
 declare global {
@@ -12,7 +13,10 @@ declare global {
         agentName?: string;
         bubbleType: 'permission' | 'waiting' | null;
         waitingAwaitingInput?: boolean;
+        isHeadless?: boolean;
       }>;
+      /** Effective "Display headless as ghosts" setting the renderer is using. */
+      getGhostHeadlessAgents?: () => boolean;
       // ── Carpet + Areas observability (added for carpet/areas e2e) ──
       /** Sparse list of painted carpet tiles with their grid coords. */
       getCarpetTiles?: () => Array<{
@@ -120,8 +124,13 @@ export function installTestHooks(officeStateRef: { current: OfficeState | null }
       agentName: ch.agentName,
       bubbleType: ch.bubbleType,
       waitingAwaitingInput: ch.waitingAwaitingInput,
+      isHeadless: ch.isHeadless,
     }));
   };
+
+  // The ghost setting lives in the renderer module (read every rAF frame), not
+  // in OfficeState, so e2e reads it from there to assert what is actually drawn.
+  hooks.getGhostHeadlessAgents = () => isGhostHeadlessAgentsEnabled();
 
   hooks.selectAgent = (id) => {
     const os = officeStateRef.current;

--- a/webview-ui/test/existingAgents.test.ts
+++ b/webview-ui/test/existingAgents.test.ts
@@ -38,15 +38,22 @@ interface AddAgentCall {
 
 /** A fake office that records addAgent calls, mirroring how officeCanvasCursor
  *  tests inject closures instead of constructing a real OfficeState. */
-function fakeOffice(existing: number[] = []): ExistingAgentsOffice & { calls: AddAgentCall[] } {
+function fakeOffice(
+  existing: number[] = [],
+): ExistingAgentsOffice & { calls: AddAgentCall[]; headless: number[] } {
   const ids = new Set(existing);
   const calls: AddAgentCall[] = [];
+  const headless: number[] = [];
   return {
     calls,
+    headless,
     characters: { has: (id: number) => ids.has(id) },
     addAgent: (id, palette, hueShift, seatId, skipSpawnEffect, folderName) => {
       ids.add(id);
       calls.push({ id, palette, hueShift, seatId, skipSpawnEffect, folderName });
+    },
+    setHeadless: (id, isHeadless) => {
+      if (isHeadless) headless.push(id);
     },
   };
 }
@@ -93,7 +100,7 @@ test('layout not ready: buffers restored agents for the later layoutLoaded flush
   assert.equal(addedDirectly, false);
   assert.equal(os.calls.length, 0, 'no agent should be added before the layout is ready');
   assert.deepEqual(pending, [
-    { id: 5, palette: 2, hueShift: 90, seatId: 'seat-a', folderName: 'alpha' },
+    { id: 5, palette: 2, hueShift: 90, seatId: 'seat-a', folderName: 'alpha', isHeadless: false },
   ]);
 });
 
@@ -120,6 +127,33 @@ test('layout ready: a mixed roster adds only the missing agent', () => {
   assert.deepEqual(
     os.calls.map((c) => c.id),
     [6],
+  );
+});
+
+// ── headless flag (adopted agents, no terminal to focus) ────────
+
+test('layout ready: marks restored headless agents and leaves the others alone', () => {
+  const os = fakeOffice();
+  const pending: PendingAgent[] = [];
+
+  reconcileExistingAgents(os, [5, 6], {}, {}, true, pending, { 5: true });
+
+  assert.deepEqual(os.headless, [5]);
+});
+
+test('layout not ready: the headless flag rides along on the buffered agent', () => {
+  const os = fakeOffice();
+  const pending: PendingAgent[] = [];
+
+  reconcileExistingAgents(os, [5, 6], {}, {}, false, pending, { 5: true });
+
+  assert.equal(os.headless.length, 0, 'nothing is marked before the layout flush');
+  assert.deepEqual(
+    pending.map((p) => [p.id, p.isHeadless]),
+    [
+      [5, true],
+      [6, false],
+    ],
   );
 });
 


### PR DESCRIPTION
## What

Headless agents — the ones adopted from outside the office, via `claude -p` or **Watch All Sessions** — have no terminal to focus. Nothing in the office said so: they looked exactly like an agent you could click into.

They now render translucent (50%), controlled by a new **Display Headless as Ghosts** setting. It ships **off**: the cue changes how an existing office looks, so an office reads exactly as it did before until someone turns it on.

## Why these boundaries

`isExternal` was already on the wire (`agentCreated`, and the `externalAgents` map on `existingAgents`) but unused by the UI, so carrying the *fact* needed no protocol change — only a `Character.isHeadless` flag, threaded through the restore path so the ghosting survives a panel reload.

Two things are deliberately **not** ghosted:

- **Teammates and sub-agents.** `CONTEXT.md` keeps both distinct from a Headless agent, and clicking one does reach a terminal (its lead's / parent's). An adopted session that is only *later* discovered to be a teammate drops the mark when `setTeamInfo` links it.
- **Standalone.** That adapter has no terminals at all, so every agent would qualify and the cue would distinguish nothing. The settings checkbox is hidden there too, for the same reason `+ Agent` is.

The setting lives as module state in `renderer.ts` rather than as a render parameter: the rAF loop reads it every frame, so a toggle redraws on the next one without threading a 21st argument through `renderFrame` — the same shape as `setProviderCapabilities` / `setSoundEnabled`. Its default is declared in four places (server config, both `settingsLoaded` senders, the webview's pre-hydration state, and that module copy) and all four say off, so no surface briefly disagrees during startup.

`CONTEXT.md` gains a **Ghost** entry, with **Headless agent** pointing at it.

## Protocol

New `SetGhostHeadlessAgents` client message + `ghostHeadlessAgents` on `SettingsLoaded`, in `core/asyncapi.yaml` with `core/src/messages.ts` regenerated. Persisted per namespace through `configPersistence.ts`, handled in both `clientMessageHandler.ts` and `PixelAgentsViewProvider.ts`.

## Testing

- `webview-ui/test/existingAgents.test.ts` — the headless flag on both restore paths (buffered + immediate).
- `expectCharacterGhosted` (`e2e/helpers/office.ts`) asserts the visible outcome, combining the per-character flag with the renderer setting exactly as the renderer does. Wired into both `@area:spawn` tests: internal terminal agent opaque, adopted external agent ghosted. Both turn the setting on first — the external one to see a ghost at all, the internal one so "not a ghost" still asserts that the agent owns a terminal rather than restating the default.
- "settings toggles persist across a webview reload" now flips and re-checks the new toggle as well.

Ran locally: `lint`, `check-types`, `asyncapi:validate`, `asyncapi:generate` (no drift), `e2e:inventory` (regenerated), `build`, `test:server` (353 passed), `test:webview` (52 passed).

⚠️ The **full Playwright suite was not run locally** — the new e2e assertions above are unexercised until CI runs them.

## Screenshots


https://github.com/user-attachments/assets/37b7d85d-e152-4223-99e4-cbcbd41cee2f



🤖 Generated with [Claude Code](https://claude.com/claude-code)
