### PR TITLE
refactor(server): assign palette/hueShift server-side

### DIFF
--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -115,6 +115,8 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         parentAgentId: agent.leadAgentId,
         teamName: agent.teamName,
         hooksOnly: agent.hooksOnly || undefined,
+        palette: agent.palette,
+        hueShift: agent.hueShift,
       });
     });
     this.store.on('agentRemoved', (id) => {

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -33,6 +33,7 @@ import {
   watchLayoutFile,
   writeLayoutToFile,
 } from '../../server/src/layoutPersistence.js';
+import { setPaletteCount } from '../../server/src/paletteAssigner.js';
 import { PathSet } from '../../server/src/pathKey.js';
 import { claudeProvider, copyHookScript } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
@@ -556,6 +557,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             // Load character sprites (bundled + external)
             const charSprites = await this.loadAllCharacterSprites();
             if (charSprites && this.webview) {
+              setPaletteCount(charSprites.characters.length);
               console.log(
                 `[Extension] ${charSprites.characters.length} character sprites loaded, sending to webview`,
               );
@@ -790,6 +792,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     try {
       const chars = await this.loadAllCharacterSprites();
       if (chars) {
+        setPaletteCount(chars.characters.length);
         sendCharacterSpritesToWebview(this.webview, chars);
       }
     } catch (err) {

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -33,7 +33,6 @@ import {
   watchLayoutFile,
   writeLayoutToFile,
 } from '../../server/src/layoutPersistence.js';
-import { setPaletteCount } from '../../server/src/paletteAssigner.js';
 import { PathSet } from '../../server/src/pathKey.js';
 import { claudeProvider, copyHookScript } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
@@ -557,7 +556,6 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
             // Load character sprites (bundled + external)
             const charSprites = await this.loadAllCharacterSprites();
             if (charSprites && this.webview) {
-              setPaletteCount(charSprites.characters.length);
               console.log(
                 `[Extension] ${charSprites.characters.length} character sprites loaded, sending to webview`,
               );
@@ -792,7 +790,6 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     try {
       const chars = await this.loadAllCharacterSprites();
       if (chars) {
-        setPaletteCount(chars.characters.length);
         sendCharacterSpritesToWebview(this.webview, chars);
       }
     } catch (err) {

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -13,6 +13,7 @@ import {
   startFileWatching,
 } from '../../server/src/fileWatcher.js';
 import { loadLayout } from '../../server/src/layoutPersistence.js';
+import { assignPaletteIfNeeded } from '../../server/src/paletteAssigner.js';
 import { CLAUDE_TERMINAL_NAME_PREFIX } from '../../server/src/providers/hook/claude/constants.js';
 import { claudeProvider } from '../../server/src/providers/index.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from '../../server/src/timerManager.js';
@@ -119,6 +120,7 @@ export async function launchNewTerminal(
     maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
   };
 
+  assignPaletteIfNeeded(agent, agents);
   agents.set(id, agent);
   activeAgentIdRef.current = id;
   persistAgents();
@@ -388,8 +390,11 @@ export function restoreAgents(
       isTeamLead: p.agentName ? undefined : p.isTeamLead,
       leadAgentId: p.leadAgentId,
       teamUsesTmux: p.teamUsesTmux,
+      palette: p.palette,
+      hueShift: p.hueShift,
     };
 
+    assignPaletteIfNeeded(agent, store);
     store.set(p.id, agent);
     knownJsonlFiles.add(p.jsonlFile);
     if (isExternal) {

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -180,6 +180,12 @@ components:
           type: string
         isExternal:
           type: boolean
+        palette:
+          type: integer
+          description: Server-assigned character palette index.
+        hueShift:
+          type: integer
+          description: Server-assigned hue shift in degrees (0-360).
 
     AgentClosed:
       description: An agent has been removed from the office.

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -71,6 +71,8 @@ export interface AgentCreated {
   id: number;
   folderName?: string;
   isExternal?: boolean;
+  palette?: number;
+  hueShift?: number;
 }
 
 export interface AgentClosed {

--- a/core/src/paletteUtils.ts
+++ b/core/src/paletteUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Palette diversity utilities for agent character assignment.
+ *
+ * Pure functions with no DOM/sprite dependencies — safe for use in both
+ * browser (webview) and Node.js (server) environments.
+ */
+
+export interface PalettePick {
+  palette: number;
+  hueShift: number;
+}
+
+export const HUE_SHIFT_MIN_DEG = 45;
+export const HUE_SHIFT_RANGE_DEG = 271;
+
+/**
+ * Pick a diverse palette based on current palette distribution.
+ * First N agents each get a unique skin (where N = paletteCount).
+ * Beyond N, skins repeat in balanced rounds with a random hue shift (≥45°).
+ *
+ * @param paletteCount - Total number of available palettes (e.g., 6)
+ * @param paletteCounts - Array of counts per palette (length must equal paletteCount)
+ * @returns Selected palette index and hue shift in degrees
+ */
+export function pickDiversePalette(paletteCount: number, paletteCounts: number[]): PalettePick {
+  if (paletteCounts.length !== paletteCount) {
+    throw new Error(
+      `paletteCounts length (${paletteCounts.length}) must equal paletteCount (${paletteCount})`,
+    );
+  }
+
+  const minCount = Math.min(...paletteCounts);
+  const available: number[] = [];
+  for (let i = 0; i < paletteCount; i++) {
+    if (paletteCounts[i] === minCount) available.push(i);
+  }
+  const palette = available[Math.floor(Math.random() * available.length)];
+
+  // First round (minCount === 0): no hue shift. Subsequent rounds: random ≥45°.
+  let hueShift = 0;
+  if (minCount > 0) {
+    hueShift = HUE_SHIFT_MIN_DEG + Math.floor(Math.random() * HUE_SHIFT_RANGE_DEG);
+  }
+
+  return { palette, hueShift };
+}

--- a/core/src/paletteUtils.ts
+++ b/core/src/paletteUtils.ts
@@ -10,8 +10,8 @@ export interface PalettePick {
   hueShift: number;
 }
 
-export const HUE_SHIFT_MIN_DEG = 45;
-export const HUE_SHIFT_RANGE_DEG = 271;
+const HUE_SHIFT_MIN_DEG = 45;
+const HUE_SHIFT_RANGE_DEG = 271;
 
 /**
  * Pick a diverse palette based on current palette distribution.

--- a/core/src/schemas.ts
+++ b/core/src/schemas.ts
@@ -29,6 +29,11 @@ export interface PersistedAgent {
    *  transcripts are re-adopted after a reload; the spawned children
    *  themselves are derived state and never persisted. */
   backgroundAgentToolIds?: string[];
+  /** Preferred character palette (0-5). Persisted so colors stay stable
+   *  across server restarts; assignPaletteIfNeeded is a no-op on restore. */
+  palette?: number;
+  /** Hue shift in degrees (0-360). Persisted alongside palette. */
+  hueShift?: number;
 }
 
 /** Agent seat assignment with visual identity

--- a/server/__tests__/agentRuntime.restorePalette.test.ts
+++ b/server/__tests__/agentRuntime.restorePalette.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AgentRuntime } from '../src/agentRuntime.js';
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { FileStateAdapter } from '../src/fileStateAdapter.js';
+import { claudeProvider } from '../src/providers/hook/claude/claude.js';
+import type { AgentState, PersistedAgent } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: 'sess-1',
+    terminalRef: undefined,
+    isExternal: true,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    contextTokens: 0,
+    maxContextTokens: 200_000,
+    ...overrides,
+  } as AgentState;
+}
+
+/**
+ * Restored agents must keep their palette/hueShift across server restarts.
+ * PersistedAgent carries the values; restoreExternalAgents copies them onto
+ * the fresh AgentState and assignPaletteIfNeeded is a no-op (palette is
+ * already set), so existingAgents sends the persisted values instead of
+ * re-rolling. Persistence + restore round-trip is tested end-to-end through
+ * a real FileStateAdapter on disk (temp HOME), not a mock, so the on-disk
+ * shape is exercised too.
+ */
+describe('AgentRuntime -- restore preserves palette/hueShift', () => {
+  let tempHome: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let tempJsonl: string;
+  let store: AgentStateStore;
+  let runtime: AgentRuntime | undefined;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-restore-pal-'));
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    // os.homedir() consults HOME on POSIX and USERPROFILE on Windows — set
+    // both so FileStateAdapter's stateFilePath lands inside tempHome on
+    // every platform (without this, Windows tests write to the real
+    // ~/.pixel-agents/ and leak state across suites).
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    // restoreExternalAgents skips agents whose jsonlFile doesn't exist.
+    tempJsonl = path.join(tempHome, 'session.jsonl');
+    fs.writeFileSync(tempJsonl, '');
+
+    store = new AgentStateStore();
+    store.setAdapter(new FileStateAdapter({ namespace: 'standalone' }));
+  });
+
+  afterEach(() => {
+    // NOTE: dispose the runtime FIRST. AgentRuntime.dispose() calls
+    // removeAgent() for every tracked agent, which calls store.persist() --
+    // so disposing after the store has already been cleared (or after a
+    // fresh store was built) can clobber the on-disk state file. Disposing
+    // here while the original store still holds its agents is safe.
+    runtime?.dispose();
+    store?.dispose();
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('restoreExternalAgents keeps palette/hueShift from the persisted record', () => {
+    const persisted: PersistedAgent[] = [
+      {
+        id: 7,
+        sessionId: 'sess-restore',
+        terminalName: '',
+        isExternal: true,
+        jsonlFile: tempJsonl,
+        projectDir: tempHome,
+        palette: 3,
+        hueShift: 90,
+      },
+    ];
+    store.getAdapter()!.saveAgents(persisted);
+
+    runtime = new AgentRuntime(store, claudeProvider);
+    runtime.restoreExternalAgents();
+
+    const agent = store.get(7);
+    expect(agent).toBeDefined();
+    expect(agent?.palette).toBe(3);
+    expect(agent?.hueShift).toBe(90);
+  });
+
+  it('persist() then restoreExternalAgents round-trips palette/hueShift unchanged', () => {
+    // persist via one runtime, then build a fresh store + runtime from disk
+    // (simulating a restart). The old runtime is left for afterEach to
+    // dispose — disposing it mid-test would clobber the on-disk file (see
+    // the afterEach note above).
+    runtime = new AgentRuntime(store, claudeProvider);
+    const agent = createTestAgent({
+      id: 42,
+      sessionId: 'sess-rt',
+      jsonlFile: tempJsonl,
+      projectDir: tempHome,
+      palette: 5,
+      hueShift: 270,
+    });
+    store.set(42, agent);
+    store.persist();
+
+    // New store + runtime fresh from disk.
+    const freshStore = new AgentStateStore();
+    freshStore.setAdapter(new FileStateAdapter({ namespace: 'standalone' }));
+    const freshRuntime = new AgentRuntime(freshStore, claudeProvider);
+    freshRuntime.restoreExternalAgents();
+
+    const restored = freshStore.get(42);
+    expect(restored).toBeDefined();
+    expect(restored?.palette).toBe(5);
+    expect(restored?.hueShift).toBe(270);
+
+    // Dispose the fresh runtime so its removeAgent→persist doesn't leak.
+    freshRuntime.dispose();
+  });
+
+  it('assigns a fresh palette when the persisted record has no palette', () => {
+    const persisted: PersistedAgent[] = [
+      {
+        id: 9,
+        sessionId: 'sess-fresh',
+        terminalName: '',
+        isExternal: true,
+        jsonlFile: tempJsonl,
+        projectDir: tempHome,
+        // palette/hueShift intentionally omitted
+      },
+    ];
+    store.getAdapter()!.saveAgents(persisted);
+
+    runtime = new AgentRuntime(store, claudeProvider);
+    runtime.restoreExternalAgents();
+
+    const agent = store.get(9);
+    expect(agent).toBeDefined();
+    // assignPaletteIfNeeded fills in [0, PALETTE_COUNT) with hueShift 0 on
+    // an empty store (first round). We assert it's been set to something
+    // valid rather than re-deriving the exact algorithm here.
+    expect(agent?.palette).toBeGreaterThanOrEqual(0);
+    expect(agent?.palette).toBeLessThan(6);
+    expect(agent?.hueShift).toBe(0);
+  });
+});

--- a/server/__tests__/agentRuntime.restorePalette.test.ts
+++ b/server/__tests__/agentRuntime.restorePalette.test.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { StateAdapter } from '../../core/src/adapter.js';
 import { AgentRuntime } from '../src/agentRuntime.js';
 import { AgentStateStore } from '../src/agentStateStore.js';
-import { FileStateAdapter } from '../src/fileStateAdapter.js';
 import { claudeProvider } from '../src/providers/hook/claude/claude.js';
 import type { AgentState, PersistedAgent } from '../src/types.js';
 
@@ -38,60 +38,52 @@ function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
   } as AgentState;
 }
 
+function createMockAdapter(initial: PersistedAgent[] = []): StateAdapter & {
+  saved: PersistedAgent[][];
+} {
+  let current = initial;
+  const saved: PersistedAgent[][] = [];
+  return {
+    saved,
+    loadAgents: () => current,
+    saveAgents: (agents) => {
+      current = agents;
+      saved.push(agents);
+    },
+    loadSeats: () => ({}),
+    saveSeats: () => {},
+    getSetting: <T>(_key: string, defaultValue: T): T => defaultValue,
+    setSetting: vi.fn<(key: string, value: unknown) => void>(),
+  };
+}
+
 /**
  * Restored agents must keep their palette/hueShift across server restarts.
- * PersistedAgent carries the values; restoreExternalAgents copies them onto
- * the fresh AgentState and assignPaletteIfNeeded is a no-op (palette is
- * already set), so existingAgents sends the persisted values instead of
- * re-rolling. Persistence + restore round-trip is tested end-to-end through
- * a real FileStateAdapter on disk (temp HOME), not a mock, so the on-disk
- * shape is exercised too.
+ *
+ * These tests use a mock adapter (mirror of backgroundAgents.test.ts's
+ * fakeAdapter) for the in-memory PersistedAgent[] the adapter hands back.
+ * Disk is touched only for the existence gate: restoreExternalAgents skips
+ * agents whose jsonlFile doesn't exist, so each test creates one empty file.
+ * No FileStateAdapter, no HOME/USERPROFILE override, no state-file I/O.
  */
 describe('AgentRuntime -- restore preserves palette/hueShift', () => {
-  let tempHome: string;
-  let originalHome: string | undefined;
-  let originalUserProfile: string | undefined;
-  let tempJsonl: string;
-  let store: AgentStateStore;
+  let tmpDir: string;
+  let jsonlPath: string;
   let runtime: AgentRuntime | undefined;
 
   beforeEach(() => {
-    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-restore-pal-'));
-    originalHome = process.env.HOME;
-    originalUserProfile = process.env.USERPROFILE;
-    // os.homedir() consults HOME on POSIX and USERPROFILE on Windows — set
-    // both so FileStateAdapter's stateFilePath lands inside tempHome on
-    // every platform (without this, Windows tests write to the real
-    // ~/.pixel-agents/ and leak state across suites).
-    process.env.HOME = tempHome;
-    process.env.USERPROFILE = tempHome;
-    // restoreExternalAgents skips agents whose jsonlFile doesn't exist.
-    tempJsonl = path.join(tempHome, 'session.jsonl');
-    fs.writeFileSync(tempJsonl, '');
-
-    store = new AgentStateStore();
-    store.setAdapter(new FileStateAdapter({ namespace: 'standalone' }));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-restore-pal-'));
+    jsonlPath = path.join(tmpDir, 'session.jsonl');
+    fs.writeFileSync(jsonlPath, '');
   });
 
   afterEach(() => {
-    // NOTE: dispose the runtime FIRST. AgentRuntime.dispose() calls
-    // removeAgent() for every tracked agent, which calls store.persist() --
-    // so disposing after the store has already been cleared (or after a
-    // fresh store was built) can clobber the on-disk state file. Disposing
-    // here while the original store still holds its agents is safe.
+    // Dispose BEFORE cleaning the tmp dir: AgentRuntime.dispose() calls
+    // removeAgent() for every tracked agent, which calls store.persist();
+    // if the runtime is disposed mid-test (between a persist and a fresh
+    // adapter's load) it can clobber in-memory state.
     runtime?.dispose();
-    store?.dispose();
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-    if (originalUserProfile === undefined) {
-      delete process.env.USERPROFILE;
-    } else {
-      process.env.USERPROFILE = originalUserProfile;
-    }
-    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('restoreExternalAgents keeps palette/hueShift from the persisted record', () => {
@@ -101,15 +93,16 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
         sessionId: 'sess-restore',
         terminalName: '',
         isExternal: true,
-        jsonlFile: tempJsonl,
-        projectDir: tempHome,
+        jsonlFile: jsonlPath,
+        projectDir: tmpDir,
         palette: 3,
         hueShift: 90,
       },
     ];
-    store.getAdapter()!.saveAgents(persisted);
-
+    const store = new AgentStateStore();
+    store.setAdapter(createMockAdapter(persisted));
     runtime = new AgentRuntime(store, claudeProvider);
+
     runtime.restoreExternalAgents();
 
     const agent = store.get(7);
@@ -118,36 +111,49 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
     expect(agent?.hueShift).toBe(90);
   });
 
-  it('persist() then restoreExternalAgents round-trips palette/hueShift unchanged', () => {
-    // persist via one runtime, then build a fresh store + runtime from disk
-    // (simulating a restart). The old runtime is left for afterEach to
-    // dispose — disposing it mid-test would clobber the on-disk file (see
-    // the afterEach note above).
-    runtime = new AgentRuntime(store, claudeProvider);
-    const agent = createTestAgent({
-      id: 42,
-      sessionId: 'sess-rt',
-      jsonlFile: tempJsonl,
-      projectDir: tempHome,
-      palette: 5,
-      hueShift: 270,
-    });
-    store.set(42, agent);
-    store.persist();
+  it('persist() writes palette/hueShift onto the record that restoreExternalAgents copies back', () => {
+    // Phase 1: persist an agent with palette/hueShift and capture the
+    // record the adapter received.
+    const storeA = new AgentStateStore();
+    const adapterA = createMockAdapter();
+    storeA.setAdapter(adapterA);
+    runtime = new AgentRuntime(storeA, claudeProvider);
+    storeA.set(
+      42,
+      createTestAgent({
+        id: 42,
+        sessionId: 'sess-rt',
+        jsonlFile: jsonlPath,
+        projectDir: tmpDir,
+        palette: 5,
+        hueShift: 270,
+      }),
+    );
+    storeA.persist();
 
-    // New store + runtime fresh from disk.
-    const freshStore = new AgentStateStore();
-    freshStore.setAdapter(new FileStateAdapter({ namespace: 'standalone' }));
-    const freshRuntime = new AgentRuntime(freshStore, claudeProvider);
-    freshRuntime.restoreExternalAgents();
+    // Capture the record our explicit persist() wrote BEFORE disposing
+    // the runtime: dispose() walks the store and persists removals, which
+    // would otherwise clobber the captured record or push an empty entry
+    // onto `saved`.
+    expect(adapterA.saved.length).toBeGreaterThanOrEqual(1);
+    const persisted = adapterA.saved[0];
+    expect(persisted[0].palette).toBe(5);
+    expect(persisted[0].hueShift).toBe(270);
 
-    const restored = freshStore.get(42);
+    runtime.dispose();
+    runtime = undefined;
+
+    // Phase 2: a fresh store + runtime restore from the record phase 1
+    // wrote. The new adapter hands back exactly what phase 1 persisted.
+    const storeB = new AgentStateStore();
+    storeB.setAdapter(createMockAdapter(persisted));
+    runtime = new AgentRuntime(storeB, claudeProvider);
+    runtime.restoreExternalAgents();
+
+    const restored = storeB.get(42);
     expect(restored).toBeDefined();
     expect(restored?.palette).toBe(5);
     expect(restored?.hueShift).toBe(270);
-
-    // Dispose the fresh runtime so its removeAgent→persist doesn't leak.
-    freshRuntime.dispose();
   });
 
   it('assigns a fresh palette when the persisted record has no palette', () => {
@@ -157,21 +163,22 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
         sessionId: 'sess-fresh',
         terminalName: '',
         isExternal: true,
-        jsonlFile: tempJsonl,
-        projectDir: tempHome,
+        jsonlFile: jsonlPath,
+        projectDir: tmpDir,
         // palette/hueShift intentionally omitted
       },
     ];
-    store.getAdapter()!.saveAgents(persisted);
-
+    const store = new AgentStateStore();
+    store.setAdapter(createMockAdapter(persisted));
     runtime = new AgentRuntime(store, claudeProvider);
+
     runtime.restoreExternalAgents();
 
     const agent = store.get(9);
     expect(agent).toBeDefined();
-    // assignPaletteIfNeeded fills in [0, PALETTE_COUNT) with hueShift 0 on
-    // an empty store (first round). We assert it's been set to something
-    // valid rather than re-deriving the exact algorithm here.
+    // assignPaletteIfNeeded fills in [0, 6) with hueShift 0 on an empty
+    // store (first round). Assert "set to a valid value" rather than
+    // re-deriving the exact algorithm.
     expect(agent?.palette).toBeGreaterThanOrEqual(0);
     expect(agent?.palette).toBeLessThan(6);
     expect(agent?.hueShift).toBe(0);

--- a/server/__tests__/clientMessageHandler.test.ts
+++ b/server/__tests__/clientMessageHandler.test.ts
@@ -381,4 +381,52 @@ describe('clientMessageHandler: saveAgentSeats palette sync', () => {
 
     expect(store.get(999)).toBeUndefined();
   });
+
+  it('accepts palette 7 when the cache has 8 character sprites', () => {
+    // The guard reads ctx.cache?.characters?.characters.length instead
+    // of hardcoding PALETTE_COUNT. With 8 sprites, palette 7 is valid.
+    const cache: AssetCache = {
+      characters: {
+        characters: [
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+          { down: [[[]]], up: [[[]]], right: [[[]]] },
+        ],
+      },
+      pets: null,
+      floorTiles: null,
+      wallTiles: null,
+      carpetTiles: null,
+      furniture: null,
+      defaultLayout: null,
+    };
+    ctx = freshCtx(cache);
+    store.set(1, createTestAgent({ id: 1 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 7, hueShift: 90, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(1)?.palette).toBe(7);
+    // palette 8 is still out of range for 8 sprites → dropped.
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 8, hueShift: 90, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+    expect(store.get(1)?.palette).toBe(7);
+  });
 });

--- a/server/__tests__/clientMessageHandler.test.ts
+++ b/server/__tests__/clientMessageHandler.test.ts
@@ -248,3 +248,137 @@ describe('clientMessageHandler: areas + carpet wire ordering', () => {
     });
   });
 });
+
+describe('clientMessageHandler: saveAgentSeats palette sync', () => {
+  let tempHome: string;
+  let originalHome: string | undefined;
+  let store: AgentStateStore;
+  let sent: Array<Record<string, unknown>>;
+  let ctx: ClientMessageContext;
+
+  function freshCtx(cache: AssetCache | null = null): ClientMessageContext {
+    return { store, cache };
+  }
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-cmh-seats-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    store = new AgentStateStore();
+    store.setAdapter(new FileStateAdapter({ namespace: 'standalone' }));
+    sent = [];
+    ctx = freshCtx();
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    store.dispose();
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('syncs in-range palette/hueShift onto the matching AgentState', () => {
+    store.set(1, createTestAgent({ id: 1 }));
+    store.set(2, createTestAgent({ id: 2, palette: 0, hueShift: 0 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: {
+          '1': { palette: 4, hueShift: 120, seatId: 'seat-a' },
+          '2': { palette: 2, hueShift: 60, seatId: 'seat-b' },
+        },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(1)?.palette).toBe(4);
+    expect(store.get(1)?.hueShift).toBe(120);
+    expect(store.get(2)?.palette).toBe(2);
+    expect(store.get(2)?.hueShift).toBe(60);
+  });
+
+  it('drops an out-of-range palette and keeps the existing value', () => {
+    store.set(1, createTestAgent({ id: 1, palette: 1, hueShift: 10 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 99, hueShift: 50, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(1)?.palette).toBe(1);
+    // hueShift 50 is in range → still synced.
+    expect(store.get(1)?.hueShift).toBe(50);
+  });
+
+  it('drops a negative hue shift and keeps the existing value', () => {
+    store.set(1, createTestAgent({ id: 1, palette: 0, hueShift: 30 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 2, hueShift: -5, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    // palette 2 is in range → synced.
+    expect(store.get(1)?.palette).toBe(2);
+    expect(store.get(1)?.hueShift).toBe(30);
+  });
+
+  it('drops a non-integer palette and keeps the existing value', () => {
+    store.set(1, createTestAgent({ id: 1, palette: 5, hueShift: 0 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 2.5, hueShift: 90, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(1)?.palette).toBe(5);
+    expect(store.get(1)?.hueShift).toBe(90);
+  });
+
+  it('accepts the upper hue boundary (360) and lower palette boundary (0)', () => {
+    store.set(1, createTestAgent({ id: 1 }));
+
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '1': { palette: 0, hueShift: 360, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(1)?.palette).toBe(0);
+    expect(store.get(1)?.hueShift).toBe(360);
+  });
+
+  it('silently skips seat entries for unknown agent ids', () => {
+    handleClientMessage(
+      {
+        type: 'saveAgentSeats',
+        seats: { '999': { palette: 3, hueShift: 100, seatId: null } },
+      },
+      (m) => sent.push(m),
+      ctx,
+    );
+
+    expect(store.get(999)).toBeUndefined();
+  });
+});

--- a/server/__tests__/paletteAssigner.test.ts
+++ b/server/__tests__/paletteAssigner.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { assignPaletteIfNeeded, HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from '../src/paletteAssigner.js';
+import type { AgentState } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: 'sess-1',
+    terminalRef: undefined,
+    isExternal: false,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    contextTokens: 0,
+    maxContextTokens: 200_000,
+    ...overrides,
+  } as AgentState;
+}
+
+describe('paletteAssigner', () => {
+  let store: AgentStateStore;
+
+  beforeEach(() => {
+    store = new AgentStateStore();
+  });
+
+  describe('assignPaletteIfNeeded', () => {
+    it('is a no-op when palette is already set', () => {
+      const agent = createTestAgent({ id: 1, palette: 3, hueShift: 10 });
+      assignPaletteIfNeeded(agent, store);
+      expect(agent.palette).toBe(3);
+      expect(agent.hueShift).toBe(10);
+    });
+
+    it('assigns a palette in [0, PALETTE_COUNT) with no hue shift on an empty store (first round)', () => {
+      const agent = createTestAgent({ id: 1 });
+      assignPaletteIfNeeded(agent, store);
+      expect(agent.palette).toBeGreaterThanOrEqual(0);
+      expect(agent.palette).toBeLessThan(PALETTE_COUNT);
+      expect(agent.hueShift).toBe(0);
+    });
+
+    it('picks a least-used palette (one of the palettes at the minimum count)', () => {
+      // Seed counts: 0->3, 1->2, 2->1, 3->1, 4->1, 5->1. minCount=1,
+      // available = [2, 3, 4, 5].
+      const palettes = [0, 0, 0, 1, 1, 2, 3, 4, 5];
+      for (let i = 0; i < palettes.length; i++) {
+        store.set(100 + i, createTestAgent({ id: 100 + i, palette: palettes[i], hueShift: 0 }));
+      }
+      const agent = createTestAgent({ id: 1 });
+      assignPaletteIfNeeded(agent, store);
+      expect([2, 3, 4, 5]).toContain(agent.palette);
+      // minCount > 0 → hue shift in [45, 315].
+      expect(agent.hueShift).toBeGreaterThanOrEqual(45);
+      expect(agent.hueShift).toBeLessThanOrEqual(HUE_SHIFT_MAX_DEG);
+    });
+
+    it('counts only agents with a defined in-range palette', () => {
+      // Two agents with undefined palette and one out-of-range must not move
+      // the minCount, so the first real assignment stays in the first round
+      // (hueShift === 0) and can pick any of [0..5].
+      store.set(10, createTestAgent({ id: 10 })); // palette undefined
+      store.set(11, createTestAgent({ id: 11, palette: 99 })); // out of range
+      const agent = createTestAgent({ id: 1 });
+      assignPaletteIfNeeded(agent, store);
+      expect(agent.palette).toBeGreaterThanOrEqual(0);
+      expect(agent.palette).toBeLessThan(PALETTE_COUNT);
+      expect(agent.hueShift).toBe(0);
+    });
+
+    it('does not mutate the store', () => {
+      store.set(1, createTestAgent({ id: 1, palette: 2, hueShift: 0 }));
+      const before = new Map<number, AgentState>();
+      for (const [id, a] of store) before.set(id, { ...a });
+
+      const agent = createTestAgent({ id: 2 });
+      assignPaletteIfNeeded(agent, store);
+
+      for (const [id, a] of store) {
+        const prev = before.get(id);
+        expect(prev).toBeDefined();
+        expect(a.palette).toBe(prev?.palette);
+        expect(a.hueShift).toBe(prev?.hueShift);
+      }
+    });
+  });
+});

--- a/server/__tests__/paletteAssigner.test.ts
+++ b/server/__tests__/paletteAssigner.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { AgentStateStore } from '../src/agentStateStore.js';
-import { assignPaletteIfNeeded, HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from '../src/paletteAssigner.js';
+import { HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from '../src/constants.js';
+import { assignPaletteIfNeeded } from '../src/paletteAssigner.js';
 import type { AgentState } from '../src/types.js';
 
 function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {

--- a/server/__tests__/paletteAssigner.test.ts
+++ b/server/__tests__/paletteAssigner.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { AgentStateStore } from '../src/agentStateStore.js';
 import { HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from '../src/constants.js';
-import { assignPaletteIfNeeded } from '../src/paletteAssigner.js';
+import { assignPaletteIfNeeded, setPaletteCount } from '../src/paletteAssigner.js';
 import type { AgentState } from '../src/types.js';
 
 function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
@@ -39,6 +39,11 @@ describe('paletteAssigner', () => {
 
   beforeEach(() => {
     store = new AgentStateStore();
+  });
+
+  afterEach(() => {
+    // Reset module-level count so tests don't leak into each other.
+    setPaletteCount(PALETTE_COUNT);
   });
 
   describe('assignPaletteIfNeeded', () => {
@@ -99,6 +104,24 @@ describe('paletteAssigner', () => {
         expect(a.palette).toBe(prev?.palette);
         expect(a.hueShift).toBe(prev?.hueShift);
       }
+    });
+  });
+
+  describe('setPaletteCount', () => {
+    it('picks from [0, N) when set above the default 6', () => {
+      setPaletteCount(8);
+      // Six agents get 0..5; the seventh must pick from [0, 8) -- if the
+      // count were still 6, it would re-pick 0..5 and never 6 or 7.
+      for (let i = 0; i < 6; i++) {
+        store.set(100 + i, createTestAgent({ id: 100 + i, palette: i, hueShift: 0 }));
+      }
+      // minCount across 0..5 is 1, and palettes 6,7 are at count 0 -- the
+      // least-used set is {6, 7}, so the pick must be 6 or 7.
+      const agent = createTestAgent({ id: 999 });
+      assignPaletteIfNeeded(agent, store);
+      expect(agent.palette).toBeGreaterThanOrEqual(6);
+      expect(agent.palette).toBeLessThan(8);
+      expect(agent.hueShift).toBe(0); // minCount === 0 for 6 and 7
     });
   });
 });

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -36,6 +36,7 @@ import {
 } from './fileWatcher.js';
 import type { HookEvent } from './hookEventHandler.js';
 import { HookEventHandler } from './hookEventHandler.js';
+import { assignPaletteIfNeeded } from './paletteAssigner.js';
 import { PathSet, pathsMatch } from './pathKey.js';
 import { SessionRouter } from './sessionRouter.js';
 import { SubagentWatch } from './subagentWatch.js';
@@ -515,6 +516,8 @@ export class AgentRuntime {
         leadAgentId: p.leadAgentId,
         teamUsesTmux: p.teamUsesTmux,
       };
+
+      assignPaletteIfNeeded(agent, this.store);
 
       this.store.set(p.id, agent);
       this.knownJsonlFiles.add(p.jsonlFile);

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -515,6 +515,8 @@ export class AgentRuntime {
         isTeamLead: p.isTeamLead,
         leadAgentId: p.leadAgentId,
         teamUsesTmux: p.teamUsesTmux,
+        palette: p.palette,
+        hueShift: p.hueShift,
       };
 
       assignPaletteIfNeeded(agent, this.store);

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -518,7 +518,6 @@ export class AgentRuntime {
       };
 
       assignPaletteIfNeeded(agent, this.store);
-
       this.store.set(p.id, agent);
       this.knownJsonlFiles.add(p.jsonlFile);
 

--- a/server/src/agentStateStore.ts
+++ b/server/src/agentStateStore.ts
@@ -171,6 +171,8 @@ export class AgentStateStore {
         teamUsesTmux: agent.teamUsesTmux,
         backgroundAgentToolIds:
           agent.backgroundAgentToolIds.size > 0 ? [...agent.backgroundAgentToolIds] : undefined,
+        palette: agent.palette,
+        hueShift: agent.hueShift,
       });
     }
     this.adapter.saveAgents(persisted);

--- a/server/src/assetReload.ts
+++ b/server/src/assetReload.ts
@@ -14,6 +14,7 @@ import {
   mergePetSprites,
 } from './assetLoader.js';
 import type { AssetCache } from './clientMessageHandler.js';
+import { setPaletteCount } from './paletteAssigner.js';
 
 /**
  * Shared asset-loading helpers used by BOTH the VS Code adapter and the
@@ -51,6 +52,12 @@ export async function loadAllCharacters(
       chars = chars ? mergeCharacterSprites(chars, extra) : extra;
     }
   }
+  // Sync the server-side palette count so assignPaletteIfNeeded and the
+  // saveAgentSeats guard use the dynamic ceiling (external dirs can add
+  // char_N.png past the bundled 6). Centralizing here means every entry
+  // point -- standalone startup, standalone reload, VS Code startup,
+  // VS Code reload -- sees the same count without four scattered calls.
+  if (chars) setPaletteCount(chars.characters.length);
   return chars;
 }
 

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -22,7 +22,6 @@ import type { AssetCache, ReloadAssetsSideEffect } from './clientMessageHandler.
 import { readConfig } from './configPersistence.js';
 import { MAX_PORT, MIN_PORT } from './constants.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { setPaletteCount } from './paletteAssigner.js';
 import { claudeProvider, copyHookScript } from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
 
@@ -100,7 +99,6 @@ async function main(): Promise<void> {
     readConfig().externalAssetDirectories,
   );
   const charCount = assetCache.characters?.characters.length ?? 0;
-  if (charCount > 0) setPaletteCount(charCount);
   const petCount = assetCache.pets?.pets.length ?? 0;
   const furnitureCount = assetCache.furniture?.catalog.length ?? 0;
   console.log(
@@ -164,7 +162,6 @@ async function main(): Promise<void> {
       assetCache.pets = pets;
       assetCache.furniture = furniture;
       if (characters) {
-        setPaletteCount(characters.characters.length);
         send({ type: 'characterSpritesLoaded', characters: characters.characters });
       }
       if (pets) {

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -22,6 +22,7 @@ import type { AssetCache, ReloadAssetsSideEffect } from './clientMessageHandler.
 import { readConfig } from './configPersistence.js';
 import { MAX_PORT, MIN_PORT } from './constants.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
+import { setPaletteCount } from './paletteAssigner.js';
 import { claudeProvider, copyHookScript } from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
 
@@ -99,6 +100,7 @@ async function main(): Promise<void> {
     readConfig().externalAssetDirectories,
   );
   const charCount = assetCache.characters?.characters.length ?? 0;
+  if (charCount > 0) setPaletteCount(charCount);
   const petCount = assetCache.pets?.pets.length ?? 0;
   const furnitureCount = assetCache.furniture?.catalog.length ?? 0;
   console.log(
@@ -162,6 +164,7 @@ async function main(): Promise<void> {
       assetCache.pets = pets;
       assetCache.furniture = furniture;
       if (characters) {
+        setPaletteCount(characters.characters.length);
         send({ type: 'characterSpritesLoaded', characters: characters.characters });
       }
       if (pets) {

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -4,6 +4,7 @@ import type { AgentStateStore } from './agentStateStore.js';
 import type { LoadedAssets, LoadedCharacterSprites, LoadedPetSprites } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
 import { readLayoutFromFile, writeLayoutToFile } from './layoutPersistence.js';
+import { HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from './paletteAssigner.js';
 import { claudeProvider } from './providers/index.js';
 
 type WsSend = (message: Record<string, unknown>) => void;
@@ -95,9 +96,37 @@ export function handleClientMessage(
 
     case 'saveAgentSeats':
       if (msg.seats) {
-        adapter?.saveSeats(
-          msg.seats as Record<string, { palette?: number; hueShift?: number; seatId?: string }>,
-        );
+        const seats = msg.seats as Record<
+          string,
+          { palette?: number; hueShift?: number; seatId?: string }
+        >;
+        // Sync palette/hueShift back to AgentState so existingAgents stays
+        // consistent across reconnects. Validate ranges to keep a remote
+        // client (or a hand-edited payload) from poisoning the gauge with
+        // out-of-range values that would render as a glitch.
+        for (const [idStr, meta] of Object.entries(seats)) {
+          const id = Number(idStr);
+          const agent = store.get(id);
+          if (agent) {
+            if (
+              meta.palette !== undefined &&
+              Number.isInteger(meta.palette) &&
+              meta.palette >= 0 &&
+              meta.palette < PALETTE_COUNT
+            ) {
+              agent.palette = meta.palette;
+            }
+            if (
+              meta.hueShift !== undefined &&
+              Number.isInteger(meta.hueShift) &&
+              meta.hueShift >= 0 &&
+              meta.hueShift <= HUE_SHIFT_MAX_DEG
+            ) {
+              agent.hueShift = meta.hueShift;
+            }
+          }
+        }
+        adapter?.saveSeats(seats);
       }
       break;
 
@@ -266,6 +295,8 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   const agentIds: number[] = [];
   const folderNames: Record<number, string> = {};
   const externalAgents: Record<number, boolean> = {};
+  const persistedSeats = adapter?.loadSeats() ?? {};
+  const agentMeta: Record<number, { palette?: number; hueShift?: number; seatId?: string }> = {};
   for (const [id, agent] of store) {
     agentIds.push(id);
     if (agent.folderName) {
@@ -274,12 +305,17 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
     if (agent.isExternal) {
       externalAgents[id] = true;
     }
+    const persisted = persistedSeats[String(id)];
+    agentMeta[id] = {
+      palette: agent.palette,
+      hueShift: agent.hueShift,
+      seatId: persisted?.seatId,
+    };
   }
-  const seats = adapter?.loadSeats() ?? {};
   send({
     type: 'existingAgents',
     agents: agentIds,
-    agentMeta: seats,
+    agentMeta,
     folderNames,
     externalAgents,
   });

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -102,8 +102,8 @@ export function handleClientMessage(
         >;
         // Sync palette/hueShift back to AgentState so existingAgents stays
         // consistent across reconnects. Validate ranges to keep a remote
-        // client (or a hand-edited payload) from poisoning the gauge with
-        // out-of-range values that would render as a glitch.
+        // client (or a hand-edited payload) from corrupting the stored
+        // values with out-of-range inputs that would render as a glitch.
         for (const [idStr, meta] of Object.entries(seats)) {
           const id = Number(idStr);
           const agent = store.get(id);

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -61,7 +61,7 @@ export function handleClientMessage(
   send: WsSend,
   ctx: ClientMessageContext,
 ): void {
-  const { store, runtime } = ctx;
+  const { store, runtime, cache } = ctx;
   const adapter = store.getAdapter();
 
   switch (msg.type) {
@@ -104,6 +104,10 @@ export function handleClientMessage(
         // consistent across reconnects. Validate ranges to keep a remote
         // client (or a hand-edited payload) from corrupting the stored
         // values with out-of-range inputs that would render as a glitch.
+        // Palette ceiling is dynamic: external asset directories can add
+        // char_N.png beyond the bundled 6, so read the count from the asset
+        // cache instead of hardcoding PALETTE_COUNT.
+        const paletteCount = cache?.characters?.characters.length ?? PALETTE_COUNT;
         for (const [idStr, meta] of Object.entries(seats)) {
           const id = Number(idStr);
           const agent = store.get(id);
@@ -112,7 +116,7 @@ export function handleClientMessage(
               meta.palette !== undefined &&
               Number.isInteger(meta.palette) &&
               meta.palette >= 0 &&
-              meta.palette < PALETTE_COUNT
+              meta.palette < paletteCount
             ) {
               agent.palette = meta.palette;
             }

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -3,8 +3,8 @@ import type { AgentRuntime } from './agentRuntime.js';
 import type { AgentStateStore } from './agentStateStore.js';
 import type { LoadedAssets, LoadedCharacterSprites, LoadedPetSprites } from './assetLoader.js';
 import { readConfig, writeConfig } from './configPersistence.js';
+import { HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from './constants.js';
 import { readLayoutFromFile, writeLayoutToFile } from './layoutPersistence.js';
-import { HUE_SHIFT_MAX_DEG, PALETTE_COUNT } from './paletteAssigner.js';
 import { claudeProvider } from './providers/index.js';
 
 type WsSend = (message: Record<string, unknown>) => void;

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -97,5 +97,5 @@ export const CONFIG_FILE_NAME = 'config.json';
 export const PALETTE_COUNT = 6;
 /** Inclusive upper bound for a valid agent hue shift, in degrees. Used by
  *  clientMessageHandler to guard saveAgentSeats payloads from a remote or
- *  hand-edited source poisoning the gauge with out-of-range values. */
+ *  hand-edited source corrupting the stored values with out-of-range values. */
 export const HUE_SHIFT_MAX_DEG = 360;

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -88,3 +88,14 @@ export const LAYOUT_FILE_NAME = 'layout.json';
 export const LAYOUT_FILE_POLL_INTERVAL_MS = 2000;
 export const LAYOUT_REVISION_KEY = 'layoutRevision';
 export const CONFIG_FILE_NAME = 'config.json';
+
+// ── Avatar Customization ────────────────────────────────────
+/** Number of pre-colored bundled character palettes (char_0.png–char_5.png).
+ *  Mirrors `PALETTE_COUNT` in webview-ui/src/constants.ts; kept separate
+ *  because the server has no DOM/sprite access and cannot import the webview
+ *  constant. The two values must stay in sync. */
+export const PALETTE_COUNT = 6;
+/** Inclusive upper bound for a valid agent hue shift, in degrees. Used by
+ *  clientMessageHandler to guard saveAgentSeats payloads from a remote or
+ *  hand-edited source poisoning the gauge with out-of-range values. */
+export const HUE_SHIFT_MAX_DEG = 360;

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -44,6 +44,7 @@ import {
 } from './constants.js';
 import { seedContextUsage } from './contextUsage.js';
 import type { DismissalTracker } from './dismissalTracker.js';
+import { assignPaletteIfNeeded } from './paletteAssigner.js';
 import { pathsMatch } from './pathKey.js';
 import type { SubagentWatch } from './subagentWatch.js';
 import { cancelPermissionTimer, cancelWaitingTimer, clearAgentActivity } from './timerManager.js';
@@ -530,6 +531,8 @@ function adoptTerminalForFile(
     maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
   };
 
+  assignPaletteIfNeeded(agent, agents);
+
   agents.set(id, agent);
   activeAgentIdRef.current = id;
   persistAgents();
@@ -748,6 +751,8 @@ export function scanForTeammateFiles(
       teamUsesTmux: parentAgent?.teamUsesTmux,
     };
 
+    assignPaletteIfNeeded(agent, agents);
+
     agents.set(id, agent);
     persistAgents();
 
@@ -898,6 +903,7 @@ export function scanForBackgroundAgentFiles(
       spawnToolUseId: entry.toolUseId,
     };
 
+    assignPaletteIfNeeded(agent, agents);
     agents.set(id, agent);
 
     // Derived team: spawning a named agent makes the spawner a Lead, whether
@@ -1129,6 +1135,7 @@ export function adoptExternalSessionFromHook(
       contextTokens: 0,
       maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
     };
+    assignPaletteIfNeeded(agent, agents);
     agents.set(id, agent);
     persistAgents();
     if (debug) {
@@ -1209,6 +1216,8 @@ function adoptExternalSession(
     contextTokens: 0,
     maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
   };
+
+  assignPaletteIfNeeded(agent, agents);
 
   agents.set(id, agent);
   persistAgents();

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -750,7 +750,12 @@ export function scanForTeammateFiles(
       teamUsesTmux: parentAgent?.teamUsesTmux,
     };
 
-    assignPaletteIfNeeded(agent, agents);
+    if (parentAgent?.palette !== undefined) {
+      agent.palette = parentAgent.palette;
+      agent.hueShift = parentAgent.hueShift ?? 0;
+    } else {
+      assignPaletteIfNeeded(agent, agents);
+    }
     agents.set(id, agent);
     persistAgents();
 
@@ -901,7 +906,12 @@ export function scanForBackgroundAgentFiles(
       spawnToolUseId: entry.toolUseId,
     };
 
-    assignPaletteIfNeeded(agent, agents);
+    if (lead.palette !== undefined) {
+      agent.palette = lead.palette;
+      agent.hueShift = lead.hueShift ?? 0;
+    } else {
+      assignPaletteIfNeeded(agent, agents);
+    }
     agents.set(id, agent);
 
     // Derived team: spawning a named agent makes the spawner a Lead, whether

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -532,7 +532,6 @@ function adoptTerminalForFile(
   };
 
   assignPaletteIfNeeded(agent, agents);
-
   agents.set(id, agent);
   activeAgentIdRef.current = id;
   persistAgents();
@@ -752,7 +751,6 @@ export function scanForTeammateFiles(
     };
 
     assignPaletteIfNeeded(agent, agents);
-
     agents.set(id, agent);
     persistAgents();
 
@@ -1218,7 +1216,6 @@ function adoptExternalSession(
   };
 
   assignPaletteIfNeeded(agent, agents);
-
   agents.set(id, agent);
   persistAgents();
 

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -167,6 +167,8 @@ function registerWebSocketRoute(app: FastifyInstance, options: HttpServerOptions
         parentAgentId: agent.leadAgentId,
         teamName: agent.teamName,
         hooksOnly: agent.hooksOnly || undefined,
+        palette: agent.palette,
+        hueShift: agent.hueShift,
       });
     };
 

--- a/server/src/paletteAssigner.ts
+++ b/server/src/paletteAssigner.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-side palette assignment helper.
+ *
+ * Assigns palette and hueShift to agents when they're created, ensuring
+ * consistent character appearance across all connected clients.
+ */
+
+import { pickDiversePalette } from '../../core/src/paletteUtils.js';
+import type { AgentStateStore } from './agentStateStore.js';
+import type { AgentState } from './types.js';
+
+export const PALETTE_COUNT = 6;
+/** Inclusive upper bound for a valid hue shift in degrees. */
+export const HUE_SHIFT_MAX_DEG = 360;
+
+/**
+ * Assign palette and hueShift to an agent if not already set.
+ * Uses the diversity algorithm to pick a palette that's least used among
+ * existing agents.
+ *
+ * @param agent - The agent to assign a palette to (mutated in place)
+ * @param store - The agent state store (used to count existing palettes)
+ */
+export function assignPaletteIfNeeded(agent: AgentState, store: AgentStateStore): void {
+  if (agent.palette !== undefined) return;
+
+  const paletteCounts = new Array(PALETTE_COUNT).fill(0);
+  for (const existing of store.values()) {
+    if (existing.palette !== undefined && existing.palette < PALETTE_COUNT) {
+      paletteCounts[existing.palette]++;
+    }
+  }
+
+  const pick = pickDiversePalette(PALETTE_COUNT, paletteCounts);
+  agent.palette = pick.palette;
+  agent.hueShift = pick.hueShift;
+}

--- a/server/src/paletteAssigner.ts
+++ b/server/src/paletteAssigner.ts
@@ -11,6 +11,20 @@ import { PALETTE_COUNT } from './constants.js';
 import type { AgentState } from './types.js';
 
 /**
+ * Runtime palette count. External asset directories can add char_N.png
+ * beyond the bundled 6 (loadExternalCharacterSprites accepts any N), so the
+ * count is dynamic. Defaults to PALETTE_COUNT until setPaletteCount is
+ * called after assets load. Mirrors the setHookProvider / setTeamSwitch
+ * module-level setter pattern in transcriptParser.ts.
+ */
+let currentPaletteCount = PALETTE_COUNT;
+
+/** Set the palette count after asset loading (standalone + VS Code). */
+export function setPaletteCount(count: number): void {
+  currentPaletteCount = Math.max(1, Math.floor(count));
+}
+
+/**
  * Assign palette and hueShift to an agent if not already set.
  * Uses the diversity algorithm to pick a palette that's least used among
  * existing agents.
@@ -21,14 +35,15 @@ import type { AgentState } from './types.js';
 export function assignPaletteIfNeeded(agent: AgentState, store: AgentStateStore): void {
   if (agent.palette !== undefined) return;
 
-  const paletteCounts = new Array(PALETTE_COUNT).fill(0);
+  const count = currentPaletteCount;
+  const paletteCounts = new Array(count).fill(0);
   for (const existing of store.values()) {
-    if (existing.palette !== undefined && existing.palette < PALETTE_COUNT) {
+    if (existing.palette !== undefined && existing.palette < count) {
       paletteCounts[existing.palette]++;
     }
   }
 
-  const pick = pickDiversePalette(PALETTE_COUNT, paletteCounts);
+  const pick = pickDiversePalette(count, paletteCounts);
   agent.palette = pick.palette;
   agent.hueShift = pick.hueShift;
 }

--- a/server/src/paletteAssigner.ts
+++ b/server/src/paletteAssigner.ts
@@ -7,11 +7,8 @@
 
 import { pickDiversePalette } from '../../core/src/paletteUtils.js';
 import type { AgentStateStore } from './agentStateStore.js';
+import { PALETTE_COUNT } from './constants.js';
 import type { AgentState } from './types.js';
-
-export const PALETTE_COUNT = 6;
-/** Inclusive upper bound for a valid hue shift in degrees. */
-export const HUE_SHIFT_MAX_DEG = 360;
 
 /**
  * Assign palette and hueShift to an agent if not already set.

--- a/server/src/subagentWatch.ts
+++ b/server/src/subagentWatch.ts
@@ -22,6 +22,7 @@ import type * as fs from 'fs';
 import { AgentStateStore } from './agentStateStore.js';
 import { DEFAULT_MAX_CONTEXT_TOKENS } from './constants.js';
 import { readNewLines, startFileWatching } from './fileWatcher.js';
+import { assignPaletteIfNeeded } from './paletteAssigner.js';
 import { pathsMatch } from './pathKey.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
 import type { AgentState } from './types.js';
@@ -98,6 +99,7 @@ export class SubagentWatch {
       spawnToolUseId: entry.toolUseId,
     };
 
+    assignPaletteIfNeeded(agent, this.store);
     this.subKeys.set(id, { leadId, spawnToolUseId: entry.toolUseId });
     this.store.set(id, agent);
 

--- a/server/src/subagentWatch.ts
+++ b/server/src/subagentWatch.ts
@@ -22,7 +22,6 @@ import type * as fs from 'fs';
 import { AgentStateStore } from './agentStateStore.js';
 import { DEFAULT_MAX_CONTEXT_TOKENS } from './constants.js';
 import { readNewLines, startFileWatching } from './fileWatcher.js';
-import { assignPaletteIfNeeded } from './paletteAssigner.js';
 import { pathsMatch } from './pathKey.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
 import type { AgentState } from './types.js';
@@ -99,7 +98,6 @@ export class SubagentWatch {
       spawnToolUseId: entry.toolUseId,
     };
 
-    assignPaletteIfNeeded(agent, this.store);
     this.subKeys.set(id, { leadId, spawnToolUseId: entry.toolUseId });
     this.store.set(id, agent);
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -109,4 +109,9 @@ export interface PersistedAgent {
    *  transcripts are re-adopted after a reload; the spawned children
    *  themselves are derived state and never persisted. */
   backgroundAgentToolIds?: string[];
+  /** Preferred character palette (0-5). Persisted so colors stay stable
+   *  across server restarts; assignPaletteIfNeeded is a no-op on restore. */
+  palette?: number;
+  /** Hue shift in degrees (0-360). Persisted alongside palette. */
+  hueShift?: number;
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -79,6 +79,12 @@ export interface AgentState {
    *  the webview never creates a Subtask ghost for them. Transient, lazily
    *  created, never persisted. */
   teammateSpawnToolIds?: Set<string>;
+
+  // -- Avatar customization --
+  /** Preferred character palette (0-5). If undefined, auto-assigned for diversity. */
+  palette?: number;
+  /** Hue shift in degrees (0-360). Rotates the base palette colors. */
+  hueShift?: number;
 }
 
 export interface PersistedAgent {

--- a/webview-ui/src/constants.ts
+++ b/webview-ui/src/constants.ts
@@ -198,8 +198,6 @@ export const INACTIVE_SEAT_TIMER_MIN_SEC = 3.0;
 export const INACTIVE_SEAT_TIMER_RANGE_SEC = 2.0;
 /** Default/fallback palette count (bundled characters). Actual count comes from getLoadedCharacterCount(). */
 export const PALETTE_COUNT = 6;
-export const HUE_SHIFT_MIN_DEG = 45;
-export const HUE_SHIFT_RANGE_DEG = 271;
 export const AUTO_ON_FACING_DEPTH = 3;
 export const AUTO_ON_SIDE_DEPTH = 2;
 export const CHARACTER_HIT_HALF_WIDTH = 8;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -241,7 +241,9 @@ export function useExtensionMessages(
             ch.agentName = teammateName;
           }
         } else {
-          os.addAgent(id, undefined, undefined, undefined, undefined, folderName);
+          const palette = msg.palette as number | undefined;
+          const hueShift = msg.hueShift as number | undefined;
+          os.addAgent(id, palette, hueShift, undefined, undefined, folderName);
           noteFolderName(folderName);
         }
         saveAgentSeats(os);

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -1,3 +1,4 @@
+import { pickDiversePalette } from '../../../../core/src/paletteUtils.js';
 import {
   AUTO_ON_FACING_DEPTH,
   AUTO_ON_SIDE_DEPTH,
@@ -6,8 +7,6 @@ import {
   CHARACTER_SITTING_OFFSET_PX,
   DISMISS_BUBBLE_FAST_FADE_SEC,
   FURNITURE_ANIM_INTERVAL_SEC,
-  HUE_SHIFT_MIN_DEG,
-  HUE_SHIFT_RANGE_DEG,
   INACTIVE_SEAT_TIMER_MIN_SEC,
   INACTIVE_SEAT_TIMER_RANGE_SEC,
   MAX_PET_ID_LENGTH,
@@ -402,19 +401,7 @@ export class OfficeState {
       if (ch.isSubagent) continue;
       if (ch.palette < paletteCount) counts[ch.palette]++;
     }
-    const minCount = Math.min(...counts);
-    // Available = palettes at the minimum count (least used)
-    const available: number[] = [];
-    for (let i = 0; i < paletteCount; i++) {
-      if (counts[i] === minCount) available.push(i);
-    }
-    const palette = available[Math.floor(Math.random() * available.length)];
-    // First round (minCount === 0): no hue shift. Subsequent rounds: random ≥45°.
-    let hueShift = 0;
-    if (minCount > 0) {
-      hueShift = HUE_SHIFT_MIN_DEG + Math.floor(Math.random() * HUE_SHIFT_RANGE_DEG);
-    }
-    return { palette, hueShift };
+    return pickDiversePalette(paletteCount, counts);
   }
 
   addAgent(


### PR DESCRIPTION
## Description

Agents created with palette and hue set to undefined would have their palette and hue assigned by the first webview to connect.  This PR moves that code to the server so that the server will pick the palette and hue at agent creation.  This works especially well for servers that allow read-only webviews to connect.  In the existing setup a read-only webview would be unable to assign the hue and palette for the agents, resulting in them being random every time a webview connected.  This PR addresses that issue by ensuring a consistent palette and hue.

Note:  This PR does not address seat selection, which suffers the same issue.  If this PR is accepted then I am happy to also submit a fix for seat selection (which is a bit more complicated due to the layout requirements).

In all, this commit accomplished:

- Extract pickDiversePalette() to core/src/paletteUtils.ts (shared pure function, no DOM/sprite deps - safe for both browser and Node)
- New server/src/paletteAssigner.ts with assignPaletteIfNeeded() helper, called from every AgentState creation path (file watcher adoption, hook-driven external sessions, restore)
- Add palette/hueShift to AgentState (in-memory only; the wire shape comes from the AgentSeatMeta schema, unchanged)
- existingAgents sends palette/hueShift from AgentState instead of the persisted seat file, so reconnecting clients render what the server sees
- saveAgentSeats syncs palette/hueShift back to AgentState for local client modifications and validates ranges (palette in [0,6), hueShift in [0,360]) to keep a remote or hand-edited payload from setting out-of-range values
- Add tests for paletteAsssigner and extend tests for clientMessageHandler to handle the new functionality

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ...

## Screenshots / GIFs

Two agents created that have undefined palette and hue:

<img width="649" height="398" alt="image" src="https://github.com/user-attachments/assets/a998a034-17ac-4841-8d3e-fd853317033b" />

After reload these same agents exist and have persisted palette and hue (even though the webview in this case is read-only).  Note, their seat changed because of the read-only webview and the scope of this PR is limited to hue and palette:

<img width="649" height="398" alt="image" src="https://github.com/user-attachments/assets/2951e0e4-5f82-48a1-a500-476e3991cf41" />

## Test plan

The simplest way to test this is to disable palette/hueShift assigning in the webview.  You can do this by removing the palette/hueShift entries from the saveAgentSeats payload (OfficeCanvas.tsx:778-779) and removing the call to pickDiversePalette in officeState.ts:424.  If this PR code is working then you will see agents still get a diverse palette pick when they are created, and that their palette persists across reconnection to the server.

Additional testing would be to launch a single server and multiple webviews.  Ensure each webview sees the same palette/hueShift for each corresponding agent.

## E2E coverage

The change is server side with no UI changes to the webview.  The new guard logic is covered by the added tests.  I don't think additional e2e is required (and if it were then we would likely need a multi-client setup).