### PR TITLE
fix: sync agent state on standalone webview connect

### DIFF
--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import type { StateAdapter } from '../../core/src/adapter.js';
+import { resendAgentActivity } from '../../server/src/agentActivityResend.js';
 import { AgentStateStore } from '../../server/src/agentStateStore.js';
 import { DEFAULT_MAX_CONTEXT_TOKENS, JSONL_POLL_INTERVAL_MS } from '../../server/src/constants.js';
 import {
@@ -562,49 +563,7 @@ export function sendCurrentAgentStatuses(
   webview: vscode.Webview | undefined,
 ): void {
   if (!webview) return;
-  for (const [agentId, agent] of agents) {
-    // Re-send active tools
-    for (const [toolId, status] of agent.activeToolStatuses) {
-      const toolName = agent.activeToolNames.get(toolId) ?? '';
-      webview.postMessage({
-        type: 'agentToolStart',
-        id: agentId,
-        toolId,
-        status,
-        toolName,
-      });
-    }
-    // Re-send waiting status
-    if (agent.isWaiting) {
-      webview.postMessage({
-        type: 'agentStatus',
-        id: agentId,
-        status: 'waiting',
-      });
-    }
-    // Re-send team metadata. Derived teams (named background spawns) have a
-    // name and a lead link but NO teamName, so gate on any team field.
-    if (agent.teamName || agent.agentName || agent.isTeamLead) {
-      webview.postMessage({
-        type: 'agentTeamInfo',
-        id: agentId,
-        teamName: agent.teamName,
-        agentName: agent.agentName,
-        isTeamLead: agent.isTeamLead,
-        leadAgentId: agent.leadAgentId,
-        teamUsesTmux: agent.teamUsesTmux,
-      });
-    }
-    // Re-send context usage
-    if (agent.contextTokens > 0) {
-      webview.postMessage({
-        type: 'agentContextUsage',
-        id: agentId,
-        contextTokens: agent.contextTokens,
-        maxContextTokens: agent.maxContextTokens,
-      });
-    }
-  }
+  resendAgentActivity((msg) => webview.postMessage(msg), agents);
 }
 
 export function sendLayout(

--- a/server/__tests__/agentActivityResend.test.ts
+++ b/server/__tests__/agentActivityResend.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { resendAgentActivity } from '../src/agentActivityResend.js';
+import { AgentStateStore } from '../src/agentStateStore.js';
+import type { AgentState } from '../src/types.js';
+
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 0,
+    sessionId: 'test-session',
+    isExternal: false,
+    projectDir: '/test',
+    jsonlFile: '/test/session.jsonl',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    contextTokens: 0,
+    maxContextTokens: 200_000,
+    ...overrides,
+  } as AgentState;
+}
+
+describe('resendAgentActivity', () => {
+  it('sends messages in order: team info, tools, waiting, context', () => {
+    const store = new AgentStateStore();
+    store.set(
+      1,
+      createTestAgent({
+        id: 1,
+        teamName: 'test-team',
+        activeToolStatuses: new Map([['tool-1', 'Running']]),
+        activeToolNames: new Map([['tool-1', 'Bash']]),
+        isWaiting: true,
+        contextTokens: 50_000,
+      }),
+    );
+    const sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+
+    expect(sent.map((m) => m.type)).toEqual([
+      'agentTeamInfo',
+      'agentToolStart',
+      'agentStatus',
+      'agentContextUsage',
+    ]);
+  });
+
+  it('includes basic fields for regular tools', () => {
+    const store = new AgentStateStore();
+    store.set(
+      1,
+      createTestAgent({
+        id: 1,
+        activeToolStatuses: new Map([['tool-1', 'Running']]),
+        activeToolNames: new Map([['tool-1', 'Bash']]),
+      }),
+    );
+    const sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: 'agentToolStart',
+      id: 1,
+      toolId: 'tool-1',
+      status: 'Running',
+      toolName: 'Bash',
+    });
+  });
+
+  it('handles background tools with flags and promoted skip logic', () => {
+    const store = new AgentStateStore();
+    // Lead with three background tools: unnamed, named spawn, and promoted
+    store.set(
+      1,
+      createTestAgent({
+        id: 1,
+        activeToolStatuses: new Map([
+          ['bg-unnamed', 'Subtask: Unnamed'],
+          ['bg-named', 'Subtask: Named'],
+          ['bg-promoted', 'Subtask: Promoted'],
+        ]),
+        activeToolNames: new Map([
+          ['bg-unnamed', 'Agent'],
+          ['bg-named', 'Agent'],
+          ['bg-promoted', 'Agent'],
+        ]),
+        backgroundAgentToolIds: new Set(['bg-unnamed', 'bg-named', 'bg-promoted']),
+        teammateSpawnToolIds: new Set(['bg-named']),
+      }),
+    );
+    // Promoted teammate (should cause bg-promoted to be skipped)
+    store.set(
+      2,
+      createTestAgent({
+        id: 2,
+        leadAgentId: 1,
+        spawnToolUseId: 'bg-promoted',
+        agentName: 'promoted-agent',
+      }),
+    );
+    const sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+
+    const toolStarts = sent.filter((m) => m.type === 'agentToolStart');
+    expect(toolStarts).toHaveLength(2); // unnamed + named, NOT promoted
+
+    // Unnamed: runInBackground=true, no isTeammateSpawn
+    const unnamed = toolStarts.find((t) => t.toolId === 'bg-unnamed');
+    expect(unnamed).toMatchObject({ runInBackground: true });
+    expect(unnamed?.isTeammateSpawn).toBeUndefined();
+
+    // Named: runInBackground=true, isTeammateSpawn=true
+    const named = toolStarts.find((t) => t.toolId === 'bg-named');
+    expect(named).toMatchObject({ runInBackground: true, isTeammateSpawn: true });
+  });
+
+  it('sends team info for any team field trigger, omits when none present', () => {
+    // teamName trigger
+    let store = new AgentStateStore();
+    store.set(1, createTestAgent({ id: 1, teamName: 'my-team' }));
+    let sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: 'agentTeamInfo', id: 1, teamName: 'my-team' });
+
+    // agentName trigger (derived team)
+    store = new AgentStateStore();
+    store.set(2, createTestAgent({ id: 2, agentName: 'worker-1', leadAgentId: 1 }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: 'agentTeamInfo', id: 2, agentName: 'worker-1' });
+
+    // isTeamLead trigger
+    store = new AgentStateStore();
+    store.set(3, createTestAgent({ id: 3, isTeamLead: true }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ type: 'agentTeamInfo', id: 3, isTeamLead: true });
+
+    // No team fields: no message
+    store = new AgentStateStore();
+    store.set(4, createTestAgent({ id: 4 }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent.filter((m) => m.type === 'agentTeamInfo')).toHaveLength(0);
+  });
+
+  it('sends waiting status only when agent is waiting', () => {
+    let store = new AgentStateStore();
+    store.set(1, createTestAgent({ id: 1, isWaiting: true }));
+    let sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toEqual([{ type: 'agentStatus', id: 1, status: 'waiting' }]);
+
+    store = new AgentStateStore();
+    store.set(2, createTestAgent({ id: 2, isWaiting: false }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('sends context usage only when agent has tokens', () => {
+    let store = new AgentStateStore();
+    store.set(1, createTestAgent({ id: 1, contextTokens: 50_000, maxContextTokens: 200_000 }));
+    let sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toEqual([
+      { type: 'agentContextUsage', id: 1, contextTokens: 50_000, maxContextTokens: 200_000 },
+    ]);
+
+    store = new AgentStateStore();
+    store.set(2, createTestAgent({ id: 2, contextTokens: 0, maxContextTokens: 200_000 }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('handles edge cases: empty store and multiple agents', () => {
+    // Empty store
+    let store = new AgentStateStore();
+    let sent: Array<Record<string, unknown>> = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(0);
+
+    // Multiple agents with different activity
+    store = new AgentStateStore();
+    store.set(
+      1,
+      createTestAgent({
+        id: 1,
+        activeToolStatuses: new Map([['tool-1', 'Running']]),
+        activeToolNames: new Map([['tool-1', 'Bash']]),
+      }),
+    );
+    store.set(2, createTestAgent({ id: 2, isWaiting: true }));
+    sent = [];
+    resendAgentActivity((msg) => sent.push(msg), store);
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toMatchObject({ type: 'agentToolStart', id: 1 });
+    expect(sent[1]).toMatchObject({ type: 'agentStatus', id: 2, status: 'waiting' });
+  });
+});

--- a/server/__tests__/agentActivityResend.test.ts
+++ b/server/__tests__/agentActivityResend.test.ts
@@ -87,6 +87,10 @@ describe('resendAgentActivity', () => {
       1,
       createTestAgent({
         id: 1,
+        // A teamed lead: the webview routes agentToolStart by the parent's
+        // teamName, so the team message has to land before the tool replays or
+        // a background spawn is routed as if the lead had no team.
+        teamName: 'test-team',
         activeToolStatuses: new Map([
           ['bg-unnamed', 'Subtask: Unnamed'],
           ['bg-named', 'Subtask: Named'],
@@ -117,14 +121,27 @@ describe('resendAgentActivity', () => {
     const toolStarts = sent.filter((m) => m.type === 'agentToolStart');
     expect(toolStarts).toHaveLength(2); // unnamed + named, NOT promoted
 
-    // Unnamed: runInBackground=true, no isTeammateSpawn
+    // Team info first: the webview reads the parent's teamName to decide whether
+    // a background agentToolStart becomes a Subtask sub-character, so a replay
+    // that arrives before it is routed against stale team state.
+    const teamIdx = sent.findIndex((m) => m.type === 'agentTeamInfo' && m.id === 1);
+    const firstBgToolIdx = sent.findIndex((m) => m.type === 'agentToolStart' && m.id === 1);
+    expect(teamIdx).toBeGreaterThanOrEqual(0);
+    expect(teamIdx).toBeLessThan(firstBgToolIdx);
+
+    // Unnamed: runInBackground=true, no isTeammateSpawn. toolName is required —
+    // without it the webview cannot recreate the Subtask after agentToolsClear.
     const unnamed = toolStarts.find((t) => t.toolId === 'bg-unnamed');
-    expect(unnamed).toMatchObject({ runInBackground: true });
+    expect(unnamed).toMatchObject({ runInBackground: true, toolName: 'Agent' });
     expect(unnamed?.isTeammateSpawn).toBeUndefined();
 
-    // Named: runInBackground=true, isTeammateSpawn=true
+    // Named: runInBackground=true, isTeammateSpawn=true, toolName present.
     const named = toolStarts.find((t) => t.toolId === 'bg-named');
-    expect(named).toMatchObject({ runInBackground: true, isTeammateSpawn: true });
+    expect(named).toMatchObject({
+      runInBackground: true,
+      isTeammateSpawn: true,
+      toolName: 'Agent',
+    });
   });
 
   it('sends team info for any team field trigger, omits when none present', () => {

--- a/server/__tests__/clientMessageHandler.test.ts
+++ b/server/__tests__/clientMessageHandler.test.ts
@@ -194,6 +194,27 @@ describe('clientMessageHandler: areas + carpet wire ordering', () => {
       expect(existing.agents).toEqual([1]);
     });
 
+    it('replays agent activity after layoutLoaded so it lands on real characters', () => {
+      // Two things at once, both invisible to the helper's own unit tests:
+      // that handleWebviewReady calls the replay at all, and that it runs AFTER
+      // layoutLoaded. The characters the replay targets only exist once the
+      // layout flush creates them, so an earlier replay is silently dropped and
+      // a reconnecting client shows a working agent as Idle.
+      store.set(1, createTestAgent({ id: 1, isWaiting: true }));
+
+      handleClientMessage({ type: 'webviewReady' }, (m) => sent.push(m), ctx);
+
+      const types = sent.map((m) => m.type);
+      const iLayout = types.indexOf('layoutLoaded');
+      const iStatus = types.indexOf('agentStatus');
+
+      expect(iLayout).toBeGreaterThanOrEqual(0);
+      expect(iStatus).toBeGreaterThanOrEqual(0);
+      expect(iLayout).toBeLessThan(iStatus);
+
+      expect(sent[iStatus]).toMatchObject({ type: 'agentStatus', id: 1, status: 'waiting' });
+    });
+
     it('emits carpetTilesLoaded after wallTilesLoaded when both are present in the cache', () => {
       // Hex placeholders are test fixtures, not UI tokens — disable the
       // centralized-color rule just for this cache literal.

--- a/server/src/agentActivityResend.ts
+++ b/server/src/agentActivityResend.ts
@@ -1,0 +1,92 @@
+import type { AgentStateStore } from './agentStateStore.js';
+import { hasPromotedBackgroundAgent } from './teamUtils.js';
+
+/**
+ * Replay an agent's active state to a connecting client.
+ *
+ * Extracted to prevent drift between the VS Code adapter (sendCurrentAgentStatuses)
+ * and the standalone handler (handleWebviewReady). Both paths must send messages in
+ * the same order with the same flags to avoid ghost Subtask characters on reconnect.
+ *
+ * Order matters:
+ * 1. Team info first — webview needs team context before tool messages
+ * 2. Regular tools
+ * 3. Background tools with runInBackground + isTeammateSpawn flags, skipping promoted spawns
+ * 4. Waiting status
+ * 5. Context usage
+ */
+export function resendAgentActivity(
+  send: (message: Record<string, unknown>) => void,
+  store: AgentStateStore,
+): void {
+  for (const [id, agent] of store) {
+    // 1. Team metadata first — webview uses this to route tool messages correctly.
+    // Derived teams (named background spawns) have a name and a lead link but NO
+    // teamName, so gate on any team field.
+    if (agent.teamName || agent.agentName || agent.isTeamLead) {
+      send({
+        type: 'agentTeamInfo',
+        id,
+        teamName: agent.teamName,
+        agentName: agent.agentName,
+        isTeamLead: agent.isTeamLead,
+        leadAgentId: agent.leadAgentId,
+        teamUsesTmux: agent.teamUsesTmux,
+      });
+    }
+
+    // 2. Regular (non-background) tools
+    for (const [toolId, status] of agent.activeToolStatuses) {
+      // Skip background tools here — they're sent separately below with proper flags
+      if (agent.backgroundAgentToolIds.has(toolId)) continue;
+
+      const toolName = agent.activeToolNames.get(toolId) ?? '';
+      send({
+        type: 'agentToolStart',
+        id,
+        toolId,
+        status,
+        toolName,
+      });
+    }
+
+    // 3. Background tools with runInBackground flag. Skip promoted spawns to prevent
+    // ghost Subtask characters alongside the real teammate character.
+    for (const toolId of agent.backgroundAgentToolIds) {
+      if (hasPromotedBackgroundAgent(id, toolId, store)) continue;
+
+      const status = agent.activeToolStatuses.get(toolId);
+      if (!status) continue;
+
+      const toolName = agent.activeToolNames.get(toolId);
+      send({
+        type: 'agentToolStart',
+        id,
+        toolId,
+        status,
+        toolName,
+        runInBackground: true,
+        isTeammateSpawn: agent.teammateSpawnToolIds?.has(toolId) || undefined,
+      });
+    }
+
+    // 4. Waiting status
+    if (agent.isWaiting) {
+      send({
+        type: 'agentStatus',
+        id,
+        status: 'waiting',
+      });
+    }
+
+    // 5. Context usage
+    if (agent.contextTokens > 0) {
+      send({
+        type: 'agentContextUsage',
+        id,
+        contextTokens: agent.contextTokens,
+        maxContextTokens: agent.maxContextTokens,
+      });
+    }
+  }
+}

--- a/server/src/agentActivityResend.ts
+++ b/server/src/agentActivityResend.ts
@@ -4,10 +4,6 @@ import { hasPromotedBackgroundAgent } from './teamUtils.js';
 /**
  * Replay an agent's active state to a connecting client.
  *
- * Extracted to prevent drift between the VS Code adapter (sendCurrentAgentStatuses)
- * and the standalone handler (handleWebviewReady). Both paths must send messages in
- * the same order with the same flags to avoid ghost Subtask characters on reconnect.
- *
  * Order matters:
  * 1. Team info first — webview needs team context before tool messages
  * 2. Regular tools

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -295,10 +295,43 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   const savedLayout = readLayoutFromFile();
   send({ type: 'layoutLoaded', layout: savedLayout ?? cache?.defaultLayout ?? null });
 
-  // 8. Context gauges, AFTER layoutLoaded -- the characters they target only
+  // 8. Agent state, AFTER layoutLoaded -- the characters they target only
   // exist once the layout flush creates them. Without this a reconnecting
   // client shows bare characters until each agent takes another turn.
   for (const [id, agent] of store) {
+    // Re-send active tools
+    for (const [toolId, status] of agent.activeToolStatuses) {
+      const toolName = agent.activeToolNames.get(toolId) ?? '';
+      send({
+        type: 'agentToolStart',
+        id,
+        toolId,
+        status,
+        toolName,
+      });
+    }
+    // Re-send waiting status
+    if (agent.isWaiting) {
+      send({
+        type: 'agentStatus',
+        id,
+        status: 'waiting',
+      });
+    }
+    // Re-send team metadata. Derived teams (named background spawns) have a
+    // name and a lead link but NO teamName, so gate on any team field.
+    if (agent.teamName || agent.agentName || agent.isTeamLead) {
+      send({
+        type: 'agentTeamInfo',
+        id,
+        teamName: agent.teamName,
+        agentName: agent.agentName,
+        isTeamLead: agent.isTeamLead,
+        leadAgentId: agent.leadAgentId,
+        teamUsesTmux: agent.teamUsesTmux,
+      });
+    }
+    // Re-send context usage
     if (agent.contextTokens > 0) {
       send({
         type: 'agentContextUsage',

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -1,3 +1,4 @@
+import { resendAgentActivity } from './agentActivityResend.js';
 import { buildAgentDiagnostics } from './agentDiagnostics.js';
 import type { AgentRuntime } from './agentRuntime.js';
 import type { AgentStateStore } from './agentStateStore.js';
@@ -298,47 +299,5 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   // 8. Agent state, AFTER layoutLoaded -- the characters they target only
   // exist once the layout flush creates them. Without this a reconnecting
   // client shows bare characters until each agent takes another turn.
-  for (const [id, agent] of store) {
-    // Re-send active tools
-    for (const [toolId, status] of agent.activeToolStatuses) {
-      const toolName = agent.activeToolNames.get(toolId) ?? '';
-      send({
-        type: 'agentToolStart',
-        id,
-        toolId,
-        status,
-        toolName,
-      });
-    }
-    // Re-send waiting status
-    if (agent.isWaiting) {
-      send({
-        type: 'agentStatus',
-        id,
-        status: 'waiting',
-      });
-    }
-    // Re-send team metadata. Derived teams (named background spawns) have a
-    // name and a lead link but NO teamName, so gate on any team field.
-    if (agent.teamName || agent.agentName || agent.isTeamLead) {
-      send({
-        type: 'agentTeamInfo',
-        id,
-        teamName: agent.teamName,
-        agentName: agent.agentName,
-        isTeamLead: agent.isTeamLead,
-        leadAgentId: agent.leadAgentId,
-        teamUsesTmux: agent.teamUsesTmux,
-      });
-    }
-    // Re-send context usage
-    if (agent.contextTokens > 0) {
-      send({
-        type: 'agentContextUsage',
-        id,
-        contextTokens: agent.contextTokens,
-        maxContextTokens: agent.maxContextTokens,
-      });
-    }
-  }
+  resendAgentActivity(send, store);
 }


### PR DESCRIPTION
## Description

When a webview connects via WebSocket (standalone mode), the server now sends active tool statuses, waiting status, and team metadata in addition to context usage. This matches the VS Code adapter behavior and prevents agents from appearing idle until their next update.

Fixes the issue where all agents show 'Idle' on initial connection even when they're actively working.

See reference implementation in adapters/vscode/agentManager.ts `sendCurrentAgentStatuses`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / build
- [ ] Other: ...

## Test plan

Run the stand-alone server prior to this PR, create an agent, and have it perform a task.  While the agent is performing the task, refresh your webview.  Notice the agent is now marked as "Idle", despite performing a task.

After applying this patch perform the same task but notice the agent now correctly indicates their task.